### PR TITLE
legal: Implement Fair Source License 0.9 and BETA status

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,56 @@
+# Fair Source License, Version 0.9
+
+Copyright (C) 2025 16-Bit Weather
+
+Licensor: 16-Bit Weather
+Software: 16-Bit Weather Platform
+Use Limitation: 5 users
+License Grant Date: January 2025
+Licensed Work Published: https://github.com/deephouse23/Weather-application-
+Change Date: Four years from License Grant Date
+Change License: MIT
+
+## Terms
+
+**Acceptance.** By using the Software, you agree to the terms of this license.
+
+**Permitted Use.** Licensor grants you a non-exclusive, worldwide license to use, copy, distribute, make available, and prepare derivative works of the Software, subject to the Use Limitation and the conditions below.
+
+**Use Limitation.** The Software may be used for any purpose, including commercial purposes, for up to 5 users. A "user" is any individual person who has access to the Software.
+
+**Conditions.**
+- You must conspicuously display this license on each original or modified copy of the Software.
+- If you receive the Software in original or modified form from a third party, the terms and conditions set forth in this license apply to your use of that work.
+- Any use of the Software in violation of this license will automatically terminate your rights under this license for the current and all future versions of the Software.
+- You may not use the Software in any way that violates applicable law.
+
+**No Other Rights.** These terms do not allow you to sublicense or transfer any of your rights to third parties, except as expressly permitted above.
+
+**Termination.** If you violate any of the terms of this license, your license will terminate immediately and automatically.
+
+**No Warranty.** The Software is provided "as is," without any warranties, express or implied. The Licensor will not be liable for any damages arising from the use of the Software.
+
+**Definitions.**
+- "Software" means the 16-Bit Weather Platform software and associated documentation files.
+- "Licensor" means the copyright owner or entity authorized by the copyright owner that is granting the license.
+
+---
+
+## BETA SOFTWARE NOTICE
+
+⚠️ **This software is currently in BETA (v0.3.2)**
+
+This means:
+- Features may change without notice
+- Bugs and issues are expected
+- API interfaces may be modified
+- Performance optimizations are ongoing
+- Production use is at your own risk
+
+Please report issues at: https://github.com/deephouse23/Weather-application-/issues
+
+---
+
+After the Change Date, this Software will be licensed under the MIT License.
+
+For more information about the Fair Source License, visit: https://fair.io

--- a/LICENSE_HEADER.txt
+++ b/LICENSE_HEADER.txt
@@ -1,0 +1,13 @@
+/**
+ * 16-Bit Weather Platform - BETA v0.3.2
+ * 
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ * 
+ * Use Limitation: 5 users
+ * See LICENSE file for full terms
+ * 
+ * BETA SOFTWARE NOTICE:
+ * This software is in active development. Features may change.
+ * Report issues: https://github.com/deephouse23/Weather-application-/issues
+ */

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
-# 🌟 16-Bit Weather v0.3.0
+# 🌟 16-Bit Weather v0.3.2 - BETA
+
+[![License: Fair Source](https://img.shields.io/badge/License-Fair%20Source%200.9-yellow)](LICENSE)
+[![Beta Version](https://img.shields.io/badge/Status-BETA-orange)](https://github.com/deephouse23/Weather-application-/releases)
+[![Version](https://img.shields.io/badge/Version-0.3.2--beta-blue)](https://github.com/deephouse23/Weather-application-/releases)
 
 **Experience weather data like it's 1985!**
+
+> ⚠️ **BETA SOFTWARE**: This project is currently in beta. Features may change, and bugs may exist. Use in production at your own risk.
 
 A retro-styled weather application that combines modern meteorological data with authentic 16-bit gaming aesthetics. Get comprehensive weather information displayed through a nostalgic terminal interface with pixel-perfect styling.
 
@@ -415,6 +421,37 @@ This groundbreaking release represents a **complete architectural transformation
 - **⚡ Faster initial load** - Optimized bundle size and lazy loading
 - **💾 Better caching** - Improved location memory and data persistence
 - **🔄 Smoother animations** - Enhanced user interface transitions
+
+---
+
+## 📜 License
+
+### Fair Source License 0.9
+
+This project is licensed under the **Fair Source License, Version 0.9**.
+
+- **Use Limitation**: 5 users
+- **Change Date**: January 2029 (4 years from release)
+- **Change License**: MIT License after Change Date
+- **Commercial Use**: Allowed for up to 5 users
+
+#### What this means:
+- ✅ **Free for small teams** (up to 5 users)
+- ✅ **Commercial use allowed** within user limit
+- ✅ **Modification and distribution permitted**
+- ✅ **Becomes MIT licensed** in 2029
+- ❌ **Requires license** for more than 5 users
+
+For the full license terms, see the [LICENSE](LICENSE) file.
+
+### 🚧 Beta Status
+
+This software is currently in **BETA** (v0.3.2). This means:
+- Features may change without notice
+- Bugs and issues are expected  
+- API interfaces may be modified
+- Performance optimizations are ongoing
+- Production use is at your own risk
 
 ---
 

--- a/add-license-headers.js
+++ b/add-license-headers.js
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+
+/**
+ * Script to add Fair Source License headers to all source files
+ * Run with: node add-license-headers.js
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const LICENSE_HEADER = `/**
+ * 16-Bit Weather Platform - BETA v0.3.2
+ * 
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ * 
+ * Use Limitation: 5 users
+ * See LICENSE file for full terms
+ * 
+ * BETA SOFTWARE NOTICE:
+ * This software is in active development. Features may change.
+ * Report issues: https://github.com/deephouse23/Weather-application-/issues
+ */
+
+`;
+
+// Directories to process
+const DIRECTORIES = [
+  'app',
+  'components',
+  'lib'
+];
+
+// File extensions to process
+const EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx'];
+
+// Files to skip
+const SKIP_FILES = [
+  'node_modules',
+  '.next',
+  'dist',
+  'build',
+  'coverage'
+];
+
+function shouldSkip(filePath) {
+  return SKIP_FILES.some(skip => filePath.includes(skip));
+}
+
+function hasLicenseHeader(content) {
+  return content.includes('Fair Source License') || 
+         content.includes('16-Bit Weather Platform');
+}
+
+function addHeaderToFile(filePath) {
+  if (shouldSkip(filePath)) {
+    return;
+  }
+
+  const content = fs.readFileSync(filePath, 'utf8');
+  
+  // Skip if already has license header
+  if (hasLicenseHeader(content)) {
+    console.log(`✓ Already has header: ${filePath}`);
+    return;
+  }
+
+  // Handle different file types
+  let newContent;
+  
+  // For files that start with "use client" or "use server"
+  if (content.startsWith('"use client"') || content.startsWith('"use server"')) {
+    const lines = content.split('\n');
+    const directive = lines[0];
+    const rest = lines.slice(1).join('\n');
+    newContent = `${directive}\n\n${LICENSE_HEADER}${rest}`;
+  } else {
+    newContent = LICENSE_HEADER + content;
+  }
+
+  fs.writeFileSync(filePath, newContent, 'utf8');
+  console.log(`✅ Added header to: ${filePath}`);
+}
+
+function processDirectory(dirPath) {
+  const files = fs.readdirSync(dirPath);
+
+  files.forEach(file => {
+    const filePath = path.join(dirPath, file);
+    const stat = fs.statSync(filePath);
+
+    if (stat.isDirectory() && !shouldSkip(filePath)) {
+      processDirectory(filePath);
+    } else if (stat.isFile()) {
+      const ext = path.extname(file);
+      if (EXTENSIONS.includes(ext)) {
+        addHeaderToFile(filePath);
+      }
+    }
+  });
+}
+
+console.log('🚀 Adding Fair Source License headers to source files...\n');
+
+DIRECTORIES.forEach(dir => {
+  const dirPath = path.join(process.cwd(), dir);
+  if (fs.existsSync(dirPath)) {
+    console.log(`\n📁 Processing ${dir}/...`);
+    processDirectory(dirPath);
+  }
+});
+
+console.log('\n✨ Done! License headers have been added to all source files.');
+console.log('\nNote: Remember to update [your-username] in the headers with your actual GitHub username.');

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,5 +1,20 @@
 "use client"
 
+/**
+ * 16-Bit Weather Platform - BETA v0.3.2
+ * 
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ * 
+ * Use Limitation: 5 users
+ * See LICENSE file for full terms
+ * 
+ * BETA SOFTWARE NOTICE:
+ * This software is in active development. Features may change.
+ * Report issues: https://github.com/deephouse23/Weather-application-/issues
+ */
+
+
 import dynamic from 'next/dynamic'
 import { Loader2 } from "lucide-react"
 import PageWrapper from "@/components/page-wrapper"

--- a/app/api/extremes/route.ts
+++ b/app/api/extremes/route.ts
@@ -1,4 +1,18 @@
 /**
+ * 16-Bit Weather Platform - BETA v0.3.2
+ * 
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ * 
+ * Use Limitation: 5 users
+ * See LICENSE file for full terms
+ * 
+ * BETA SOFTWARE NOTICE:
+ * This software is in active development. Features may change.
+ * Report issues: https://github.com/deephouse23/Weather-application-/issues
+ */
+
+/**
  * API Route for Temperature Extremes
  * Version 0.3.2
  */

--- a/app/api/weather/air-quality/route.ts
+++ b/app/api/weather/air-quality/route.ts
@@ -1,3 +1,17 @@
+/**
+ * 16-Bit Weather Platform - BETA v0.3.2
+ * 
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ * 
+ * Use Limitation: 5 users
+ * See LICENSE file for full terms
+ * 
+ * BETA SOFTWARE NOTICE:
+ * This software is in active development. Features may change.
+ * Report issues: https://github.com/deephouse23/Weather-application-/issues
+ */
+
 import { NextRequest, NextResponse } from 'next/server'
 
 const BASE_URL = 'https://api.openweathermap.org/data/2.5'

--- a/app/api/weather/current/route.ts
+++ b/app/api/weather/current/route.ts
@@ -1,3 +1,17 @@
+/**
+ * 16-Bit Weather Platform - BETA v0.3.2
+ * 
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ * 
+ * Use Limitation: 5 users
+ * See LICENSE file for full terms
+ * 
+ * BETA SOFTWARE NOTICE:
+ * This software is in active development. Features may change.
+ * Report issues: https://github.com/deephouse23/Weather-application-/issues
+ */
+
 import { NextRequest, NextResponse } from 'next/server'
 
 const BASE_URL = 'https://api.openweathermap.org/data/2.5'

--- a/app/api/weather/forecast/route.ts
+++ b/app/api/weather/forecast/route.ts
@@ -1,3 +1,17 @@
+/**
+ * 16-Bit Weather Platform - BETA v0.3.2
+ * 
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ * 
+ * Use Limitation: 5 users
+ * See LICENSE file for full terms
+ * 
+ * BETA SOFTWARE NOTICE:
+ * This software is in active development. Features may change.
+ * Report issues: https://github.com/deephouse23/Weather-application-/issues
+ */
+
 import { NextRequest, NextResponse } from 'next/server'
 
 const BASE_URL = 'https://api.openweathermap.org/data/2.5'

--- a/app/api/weather/geocoding/route.ts
+++ b/app/api/weather/geocoding/route.ts
@@ -1,3 +1,17 @@
+/**
+ * 16-Bit Weather Platform - BETA v0.3.2
+ * 
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ * 
+ * Use Limitation: 5 users
+ * See LICENSE file for full terms
+ * 
+ * BETA SOFTWARE NOTICE:
+ * This software is in active development. Features may change.
+ * Report issues: https://github.com/deephouse23/Weather-application-/issues
+ */
+
 import { NextRequest, NextResponse } from 'next/server'
 
 const GEO_URL = 'https://api.openweathermap.org/geo/1.0'

--- a/app/api/weather/pollen/route.ts
+++ b/app/api/weather/pollen/route.ts
@@ -1,3 +1,17 @@
+/**
+ * 16-Bit Weather Platform - BETA v0.3.2
+ * 
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ * 
+ * Use Limitation: 5 users
+ * See LICENSE file for full terms
+ * 
+ * BETA SOFTWARE NOTICE:
+ * This software is in active development. Features may change.
+ * Report issues: https://github.com/deephouse23/Weather-application-/issues
+ */
+
 import { NextRequest, NextResponse } from 'next/server'
 
 const BASE_URL = 'https://api.openweathermap.org/data/2.5'

--- a/app/api/weather/uv/route.ts
+++ b/app/api/weather/uv/route.ts
@@ -1,3 +1,17 @@
+/**
+ * 16-Bit Weather Platform - BETA v0.3.2
+ * 
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ * 
+ * Use Limitation: 5 users
+ * See LICENSE file for full terms
+ * 
+ * BETA SOFTWARE NOTICE:
+ * This software is in active development. Features may change.
+ * Report issues: https://github.com/deephouse23/Weather-application-/issues
+ */
+
 import { NextRequest, NextResponse } from 'next/server'
 
 const BASE_URL_V3 = 'https://api.openweathermap.org/data/3.0'

--- a/app/cloud-types/page.tsx
+++ b/app/cloud-types/page.tsx
@@ -1,5 +1,20 @@
 "use client"
 
+/**
+ * 16-Bit Weather Platform - BETA v0.3.2
+ * 
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ * 
+ * Use Limitation: 5 users
+ * See LICENSE file for full terms
+ * 
+ * BETA SOFTWARE NOTICE:
+ * This software is in active development. Features may change.
+ * Report issues: https://github.com/deephouse23/Weather-application-/issues
+ */
+
+
 import React, { useState, useEffect } from "react"
 import PageWrapper from "@/components/page-wrapper"
 import { ThemeType, themeUtils, APP_CONSTANTS } from "@/lib/utils"

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,3 +1,17 @@
+/**
+ * 16-Bit Weather Platform - BETA v0.3.2
+ * 
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ * 
+ * Use Limitation: 5 users
+ * See LICENSE file for full terms
+ * 
+ * BETA SOFTWARE NOTICE:
+ * This software is in active development. Features may change.
+ * Report issues: https://github.com/deephouse23/Weather-application-/issues
+ */
+
 'use client'
 
 import dynamic from 'next/dynamic'

--- a/app/extremes/page.tsx
+++ b/app/extremes/page.tsx
@@ -1,5 +1,20 @@
 "use client"
 
+/**
+ * 16-Bit Weather Platform - BETA v0.3.2
+ * 
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ * 
+ * Use Limitation: 5 users
+ * See LICENSE file for full terms
+ * 
+ * BETA SOFTWARE NOTICE:
+ * This software is in active development. Features may change.
+ * Report issues: https://github.com/deephouse23/Weather-application-/issues
+ */
+
+
 import { useState, useEffect, useRef } from "react"
 import PageWrapper from "@/components/page-wrapper"
 import { Loader2, TrendingUp, TrendingDown, MapPin, RefreshCw, Thermometer } from "lucide-react"

--- a/app/fun-facts/page.tsx
+++ b/app/fun-facts/page.tsx
@@ -1,5 +1,20 @@
 "use client"
 
+/**
+ * 16-Bit Weather Platform - BETA v0.3.2
+ * 
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ * 
+ * Use Limitation: 5 users
+ * See LICENSE file for full terms
+ * 
+ * BETA SOFTWARE NOTICE:
+ * This software is in active development. Features may change.
+ * Report issues: https://github.com/deephouse23/Weather-application-/issues
+ */
+
+
 import { useState, useEffect } from "react"
 import PageWrapper from "@/components/page-wrapper"
 import { ChevronDown, ChevronUp } from "lucide-react"

--- a/app/games/page.tsx
+++ b/app/games/page.tsx
@@ -1,5 +1,20 @@
 "use client"
 
+/**
+ * 16-Bit Weather Platform - BETA v0.3.2
+ * 
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ * 
+ * Use Limitation: 5 users
+ * See LICENSE file for full terms
+ * 
+ * BETA SOFTWARE NOTICE:
+ * This software is in active development. Features may change.
+ * Report issues: https://github.com/deephouse23/Weather-application-/issues
+ */
+
+
 import { useState, useEffect } from "react"
 import PageWrapper from "@/components/page-wrapper"
 import { ExternalLink } from "lucide-react"

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,3 +1,17 @@
+/**
+ * 16-Bit Weather Platform - BETA v0.3.2
+ * 
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ * 
+ * Use Limitation: 5 users
+ * See LICENSE file for full terms
+ * 
+ * BETA SOFTWARE NOTICE:
+ * This software is in active development. Features may change.
+ * Report issues: https://github.com/deephouse23/Weather-application-/issues
+ */
+
 'use client'
 
 import dynamic from 'next/dynamic'

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,3 +1,17 @@
+/**
+ * 16-Bit Weather Platform - BETA v0.3.2
+ * 
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ * 
+ * Use Limitation: 5 users
+ * See LICENSE file for full terms
+ * 
+ * BETA SOFTWARE NOTICE:
+ * This software is in active development. Features may change.
+ * Report issues: https://github.com/deephouse23/Weather-application-/issues
+ */
+
 import type React from "react"
 import "./globals.css"
 import type { Metadata } from "next"

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,3 +1,17 @@
+/**
+ * 16-Bit Weather Platform - BETA v0.3.2
+ * 
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ * 
+ * Use Limitation: 5 users
+ * See LICENSE file for full terms
+ * 
+ * BETA SOFTWARE NOTICE:
+ * This software is in active development. Features may change.
+ * Report issues: https://github.com/deephouse23/Weather-application-/issues
+ */
+
 'use client'
 
 import dynamic from 'next/dynamic'

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,20 @@
 "use client"
 
+/**
+ * 16-Bit Weather Platform - BETA v0.3.2
+ * 
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ * 
+ * Use Limitation: 5 users
+ * See LICENSE file for full terms
+ * 
+ * BETA SOFTWARE NOTICE:
+ * This software is in active development. Features may change.
+ * Report issues: https://github.com/deephouse23/Weather-application-/issues
+ */
+
+
 import React, { useState, useEffect, Suspense } from "react"
 import dynamic from 'next/dynamic'
 import { Loader2 } from "lucide-react"

--- a/app/providers/ThemeProvider.tsx
+++ b/app/providers/ThemeProvider.tsx
@@ -1,3 +1,17 @@
+/**
+ * 16-Bit Weather Platform - BETA v0.3.2
+ * 
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ * 
+ * Use Limitation: 5 users
+ * See LICENSE file for full terms
+ * 
+ * BETA SOFTWARE NOTICE:
+ * This software is in active development. Features may change.
+ * Report issues: https://github.com/deephouse23/Weather-application-/issues
+ */
+
 'use client'
 
 import { ThemeProvider } from '@/components/theme-provider'

--- a/app/weather-systems/page.tsx
+++ b/app/weather-systems/page.tsx
@@ -1,5 +1,20 @@
 "use client"
 
+/**
+ * 16-Bit Weather Platform - BETA v0.3.2
+ * 
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ * 
+ * Use Limitation: 5 users
+ * See LICENSE file for full terms
+ * 
+ * BETA SOFTWARE NOTICE:
+ * This software is in active development. Features may change.
+ * Report issues: https://github.com/deephouse23/Weather-application-/issues
+ */
+
+
 import React, { useState, useEffect } from "react"
 import PageWrapper from "@/components/page-wrapper"
 import { ThemeType, themeUtils, APP_CONSTANTS } from "@/lib/utils"

--- a/app/weather/[city]/client.tsx
+++ b/app/weather/[city]/client.tsx
@@ -1,5 +1,20 @@
 "use client"
 
+/**
+ * 16-Bit Weather Platform - BETA v0.3.2
+ * 
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ * 
+ * Use Limitation: 5 users
+ * See LICENSE file for full terms
+ * 
+ * BETA SOFTWARE NOTICE:
+ * This software is in active development. Features may change.
+ * Report issues: https://github.com/deephouse23/Weather-application-/issues
+ */
+
+
 import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { fetchWeatherData } from '@/lib/weather-api'

--- a/app/weather/[city]/page.tsx
+++ b/app/weather/[city]/page.tsx
@@ -1,3 +1,17 @@
+/**
+ * 16-Bit Weather Platform - BETA v0.3.2
+ * 
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ * 
+ * Use Limitation: 5 users
+ * See LICENSE file for full terms
+ * 
+ * BETA SOFTWARE NOTICE:
+ * This software is in active development. Features may change.
+ * Report issues: https://github.com/deephouse23/Weather-application-/issues
+ */
+
 import { Suspense } from 'react'
 import CityWeatherClient from './client'
 import { EnhancedMetaTags } from '@/components/enhanced-meta-tags'

--- a/components/air-quality-display.tsx
+++ b/components/air-quality-display.tsx
@@ -1,4 +1,18 @@
 /**
+ * 16-Bit Weather Platform - BETA v0.3.2
+ * 
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ * 
+ * Use Limitation: 5 users
+ * See LICENSE file for full terms
+ * 
+ * BETA SOFTWARE NOTICE:
+ * This software is in active development. Features may change.
+ * Report issues: https://github.com/deephouse23/Weather-application-/issues
+ */
+
+/**
  * Air Quality Index (AQI) Display Component
  * Displays AQI data with color-coded visual bar, description, and recommendations
  */

--- a/components/city-autocomplete.tsx
+++ b/components/city-autocomplete.tsx
@@ -1,5 +1,20 @@
 "use client"
 
+/**
+ * 16-Bit Weather Platform - BETA v0.3.2
+ * 
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ * 
+ * Use Limitation: 5 users
+ * See LICENSE file for full terms
+ * 
+ * BETA SOFTWARE NOTICE:
+ * This software is in active development. Features may change.
+ * Report issues: https://github.com/deephouse23/Weather-application-/issues
+ */
+
+
 import { useState, useEffect, useRef } from "react"
 import { useRouter } from "next/navigation"
 import { cn } from "@/lib/utils"

--- a/components/collapsible-section.tsx
+++ b/components/collapsible-section.tsx
@@ -1,4 +1,18 @@
 /**
+ * 16-Bit Weather Platform - BETA v0.3.2
+ * 
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ * 
+ * Use Limitation: 5 users
+ * See LICENSE file for full terms
+ * 
+ * BETA SOFTWARE NOTICE:
+ * This software is in active development. Features may change.
+ * Report issues: https://github.com/deephouse23/Weather-application-/issues
+ */
+
+/**
  * Simple Collapsible Section Component
  * For minimal SEO content that doesn't clutter the interface
  */

--- a/components/enhanced-meta-tags.tsx
+++ b/components/enhanced-meta-tags.tsx
@@ -1,4 +1,18 @@
 /**
+ * 16-Bit Weather Platform - BETA v0.3.2
+ * 
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ * 
+ * Use Limitation: 5 users
+ * See LICENSE file for full terms
+ * 
+ * BETA SOFTWARE NOTICE:
+ * This software is in active development. Features may change.
+ * Report issues: https://github.com/deephouse23/Weather-application-/issues
+ */
+
+/**
  * Enhanced Meta Tags Component
  * Comprehensive SEO and social sharing optimization
  */

--- a/components/environmental-display.tsx
+++ b/components/environmental-display.tsx
@@ -1,4 +1,18 @@
 /**
+ * 16-Bit Weather Platform - BETA v0.3.2
+ * 
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ * 
+ * Use Limitation: 5 users
+ * See LICENSE file for full terms
+ * 
+ * BETA SOFTWARE NOTICE:
+ * This software is in active development. Features may change.
+ * Report issues: https://github.com/deephouse23/Weather-application-/issues
+ */
+
+/**
  * Environmental Display Component
  * Combined AQI and Pollen display for consistent environmental data presentation
  */

--- a/components/error-boundary.tsx
+++ b/components/error-boundary.tsx
@@ -1,5 +1,20 @@
 "use client"
 
+/**
+ * 16-Bit Weather Platform - BETA v0.3.2
+ * 
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ * 
+ * Use Limitation: 5 users
+ * See LICENSE file for full terms
+ * 
+ * BETA SOFTWARE NOTICE:
+ * This software is in active development. Features may change.
+ * Report issues: https://github.com/deephouse23/Weather-application-/issues
+ */
+
+
 import React, { Component, ErrorInfo, ReactNode } from "react"
 import { AlertTriangle, RefreshCw } from "lucide-react"
 import { cn } from "@/lib/utils"

--- a/components/expandable-forecast.tsx
+++ b/components/expandable-forecast.tsx
@@ -1,5 +1,20 @@
 "use client"
 
+/**
+ * 16-Bit Weather Platform - BETA v0.3.2
+ * 
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ * 
+ * Use Limitation: 5 users
+ * See LICENSE file for full terms
+ * 
+ * BETA SOFTWARE NOTICE:
+ * This software is in active development. Features may change.
+ * Report issues: https://github.com/deephouse23/Weather-application-/issues
+ */
+
+
 import { useState } from "react"
 import { cn } from "@/lib/utils"
 import { ChevronDown, ChevronUp, Droplets, Wind, Eye, Gauge, Sunrise, Sunset, Cloud, Info } from "lucide-react"

--- a/components/forecast-details.tsx
+++ b/components/forecast-details.tsx
@@ -1,5 +1,20 @@
 "use client"
 
+/**
+ * 16-Bit Weather Platform - BETA v0.3.2
+ * 
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ * 
+ * Use Limitation: 5 users
+ * See LICENSE file for full terms
+ * 
+ * BETA SOFTWARE NOTICE:
+ * This software is in active development. Features may change.
+ * Report issues: https://github.com/deephouse23/Weather-application-/issues
+ */
+
+
 import { useState } from "react"
 import { cn } from "@/lib/utils"
 import { ChevronDown, ChevronUp, Droplets, Wind, Eye, Gauge, Sunrise, Sunset, Cloud, Info } from "lucide-react"

--- a/components/forecast.tsx
+++ b/components/forecast.tsx
@@ -1,5 +1,20 @@
 "use client"
 
+/**
+ * 16-Bit Weather Platform - BETA v0.3.2
+ * 
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ * 
+ * Use Limitation: 5 users
+ * See LICENSE file for full terms
+ * 
+ * BETA SOFTWARE NOTICE:
+ * This software is in active development. Features may change.
+ * Report issues: https://github.com/deephouse23/Weather-application-/issues
+ */
+
+
 import { cn } from "@/lib/utils"
 
 // Theme types

--- a/components/historical-chart.tsx
+++ b/components/historical-chart.tsx
@@ -1,5 +1,20 @@
 "use client"
 
+/**
+ * 16-Bit Weather Platform - BETA v0.3.2
+ * 
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ * 
+ * Use Limitation: 5 users
+ * See LICENSE file for full terms
+ * 
+ * BETA SOFTWARE NOTICE:
+ * This software is in active development. Features may change.
+ * Report issues: https://github.com/deephouse23/Weather-application-/issues
+ */
+
+
 import { useState, useEffect } from 'react'
 import { Line } from 'react-chartjs-2'
 import {

--- a/components/lazy-weather-components.tsx
+++ b/components/lazy-weather-components.tsx
@@ -1,4 +1,18 @@
 /**
+ * 16-Bit Weather Platform - BETA v0.3.2
+ * 
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ * 
+ * Use Limitation: 5 users
+ * See LICENSE file for full terms
+ * 
+ * BETA SOFTWARE NOTICE:
+ * This software is in active development. Features may change.
+ * Report issues: https://github.com/deephouse23/Weather-application-/issues
+ */
+
+/**
  * Lazy-loaded weather components for better performance
  * Components load only when needed, improving initial page load times
  */

--- a/components/location-context.tsx
+++ b/components/location-context.tsx
@@ -1,5 +1,20 @@
 "use client"
 
+/**
+ * 16-Bit Weather Platform - BETA v0.3.2
+ * 
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ * 
+ * Use Limitation: 5 users
+ * See LICENSE file for full terms
+ * 
+ * BETA SOFTWARE NOTICE:
+ * This software is in active development. Features may change.
+ * Report issues: https://github.com/deephouse23/Weather-application-/issues
+ */
+
+
 import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react'
 import { usePathname } from 'next/navigation'
 import { userCacheService } from '@/lib/user-cache-service'

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -1,5 +1,20 @@
 "use client"
 
+/**
+ * 16-Bit Weather Platform - BETA v0.3.2
+ * 
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ * 
+ * Use Limitation: 5 users
+ * See LICENSE file for full terms
+ * 
+ * BETA SOFTWARE NOTICE:
+ * This software is in active development. Features may change.
+ * Report issues: https://github.com/deephouse23/Weather-application-/issues
+ */
+
+
 import { useState } from "react"
 import Link from "next/link"
 import { usePathname } from "next/navigation"

--- a/components/optimized-image.tsx
+++ b/components/optimized-image.tsx
@@ -1,4 +1,18 @@
 /**
+ * 16-Bit Weather Platform - BETA v0.3.2
+ * 
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ * 
+ * Use Limitation: 5 users
+ * See LICENSE file for full terms
+ * 
+ * BETA SOFTWARE NOTICE:
+ * This software is in active development. Features may change.
+ * Report issues: https://github.com/deephouse23/Weather-application-/issues
+ */
+
+/**
  * Optimized Image Component
  * Provides lazy loading, proper alt text, and performance optimization
  */

--- a/components/page-wrapper.tsx
+++ b/components/page-wrapper.tsx
@@ -1,5 +1,20 @@
 "use client"
 
+/**
+ * 16-Bit Weather Platform - BETA v0.3.2
+ * 
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ * 
+ * Use Limitation: 5 users
+ * See LICENSE file for full terms
+ * 
+ * BETA SOFTWARE NOTICE:
+ * This software is in active development. Features may change.
+ * Report issues: https://github.com/deephouse23/Weather-application-/issues
+ */
+
+
 import { useState, useEffect } from "react"
 import Navigation from "./navigation"
 import { useTheme } from "@/components/theme-provider"

--- a/components/pollen-display.tsx
+++ b/components/pollen-display.tsx
@@ -1,4 +1,18 @@
 /**
+ * 16-Bit Weather Platform - BETA v0.3.2
+ * 
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ * 
+ * Use Limitation: 5 users
+ * See LICENSE file for full terms
+ * 
+ * BETA SOFTWARE NOTICE:
+ * This software is in active development. Features may change.
+ * Report issues: https://github.com/deephouse23/Weather-application-/issues
+ */
+
+/**
  * Pollen Count Display Component
  * Displays pollen data for tree, grass, and weed categories with color coding
  */

--- a/components/responsive-container.tsx
+++ b/components/responsive-container.tsx
@@ -1,4 +1,18 @@
 /**
+ * 16-Bit Weather Platform - BETA v0.3.2
+ * 
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ * 
+ * Use Limitation: 5 users
+ * See LICENSE file for full terms
+ * 
+ * BETA SOFTWARE NOTICE:
+ * This software is in active development. Features may change.
+ * Report issues: https://github.com/deephouse23/Weather-application-/issues
+ */
+
+/**
  * Responsive Container Component
  * Ensures perfect mobile responsiveness across all screen sizes
  */

--- a/components/snake-game.tsx
+++ b/components/snake-game.tsx
@@ -1,3 +1,17 @@
+/**
+ * 16-Bit Weather Platform - BETA v0.3.2
+ * 
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ * 
+ * Use Limitation: 5 users
+ * See LICENSE file for full terms
+ * 
+ * BETA SOFTWARE NOTICE:
+ * This software is in active development. Features may change.
+ * Report issues: https://github.com/deephouse23/Weather-application-/issues
+ */
+
 import React, { useEffect, useRef, useState } from 'react';
 
 interface HighScore {

--- a/components/sunrise-sunset.tsx
+++ b/components/sunrise-sunset.tsx
@@ -1,3 +1,17 @@
+/**
+ * 16-Bit Weather Platform - BETA v0.3.2
+ * 
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ * 
+ * Use Limitation: 5 users
+ * See LICENSE file for full terms
+ * 
+ * BETA SOFTWARE NOTICE:
+ * This software is in active development. Features may change.
+ * Report issues: https://github.com/deephouse23/Weather-application-/issues
+ */
+
 interface SunriseSunsetProps {
   sunrise: string;
   sunset: string;

--- a/components/theme-provider.tsx
+++ b/components/theme-provider.tsx
@@ -1,5 +1,20 @@
 "use client"
 
+/**
+ * 16-Bit Weather Platform - BETA v0.3.2
+ * 
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ * 
+ * Use Limitation: 5 users
+ * See LICENSE file for full terms
+ * 
+ * BETA SOFTWARE NOTICE:
+ * This software is in active development. Features may change.
+ * Report issues: https://github.com/deephouse23/Weather-application-/issues
+ */
+
+
 import React, { createContext, useContext, useEffect, useState } from 'react'
 import { safeStorage } from '@/lib/safe-storage'
 

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -1,5 +1,20 @@
 "use client"
 
+/**
+ * 16-Bit Weather Platform - BETA v0.3.2
+ * 
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ * 
+ * Use Limitation: 5 users
+ * See LICENSE file for full terms
+ * 
+ * BETA SOFTWARE NOTICE:
+ * This software is in active development. Features may change.
+ * Report issues: https://github.com/deephouse23/Weather-application-/issues
+ */
+
+
 import * as React from "react"
 import { Moon, Sun, Zap } from "lucide-react"
 import { useTheme } from "@/components/theme-provider"

--- a/components/weather-search.tsx
+++ b/components/weather-search.tsx
@@ -1,5 +1,20 @@
 "use client"
 
+/**
+ * 16-Bit Weather Platform - BETA v0.3.2
+ * 
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ * 
+ * Use Limitation: 5 users
+ * See LICENSE file for full terms
+ * 
+ * BETA SOFTWARE NOTICE:
+ * This software is in active development. Features may change.
+ * Report issues: https://github.com/deephouse23/Weather-application-/issues
+ */
+
+
 import { useState, useEffect } from "react"
 import { Search, Loader2, MapPin, X } from "lucide-react"
 // APP_CONSTANTS removed - no longer needed for themes

--- a/lib/air-quality-utils.ts
+++ b/lib/air-quality-utils.ts
@@ -1,4 +1,18 @@
 /**
+ * 16-Bit Weather Platform - BETA v0.3.2
+ * 
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ * 
+ * Use Limitation: 5 users
+ * See LICENSE file for full terms
+ * 
+ * BETA SOFTWARE NOTICE:
+ * This software is in active development. Features may change.
+ * Report issues: https://github.com/deephouse23/Weather-application-/issues
+ */
+
+/**
  * Air Quality and Pollen Utility Functions
  * Shared utilities for consistent AQI and pollen data handling across the application
  */

--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -1,3 +1,17 @@
+/**
+ * 16-Bit Weather Platform - BETA v0.3.2
+ * 
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ * 
+ * Use Limitation: 5 users
+ * See LICENSE file for full terms
+ * 
+ * BETA SOFTWARE NOTICE:
+ * This software is in active development. Features may change.
+ * Report issues: https://github.com/deephouse23/Weather-application-/issues
+ */
+
 import { WeatherData } from './types'
 import { safeStorage } from './safe-storage'
 

--- a/lib/city-database.ts
+++ b/lib/city-database.ts
@@ -1,3 +1,17 @@
+/**
+ * 16-Bit Weather Platform - BETA v0.3.2
+ * 
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ * 
+ * Use Limitation: 5 users
+ * See LICENSE file for full terms
+ * 
+ * BETA SOFTWARE NOTICE:
+ * This software is in active development. Features may change.
+ * Report issues: https://github.com/deephouse23/Weather-application-/issues
+ */
+
 export interface CityData {
   name: string;
   state?: string;

--- a/lib/error-utils.ts
+++ b/lib/error-utils.ts
@@ -1,4 +1,18 @@
 /**
+ * 16-Bit Weather Platform - BETA v0.3.2
+ * 
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ * 
+ * Use Limitation: 5 users
+ * See LICENSE file for full terms
+ * 
+ * BETA SOFTWARE NOTICE:
+ * This software is in active development. Features may change.
+ * Report issues: https://github.com/deephouse23/Weather-application-/issues
+ */
+
+/**
  * Error Handling Utilities
  * Centralized error handling for consistent error messages and logging
  */

--- a/lib/extremes/extremes-client.ts
+++ b/lib/extremes/extremes-client.ts
@@ -1,4 +1,18 @@
 /**
+ * 16-Bit Weather Platform - BETA v0.3.2
+ * 
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ * 
+ * Use Limitation: 5 users
+ * See LICENSE file for full terms
+ * 
+ * BETA SOFTWARE NOTICE:
+ * This software is in active development. Features may change.
+ * Report issues: https://github.com/deephouse23/Weather-application-/issues
+ */
+
+/**
  * Client-side API wrapper for extremes data
  * Version 0.3.2
  */

--- a/lib/extremes/extremes-data.ts
+++ b/lib/extremes/extremes-data.ts
@@ -1,4 +1,18 @@
 /**
+ * 16-Bit Weather Platform - BETA v0.3.2
+ * 
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ * 
+ * Use Limitation: 5 users
+ * See LICENSE file for full terms
+ * 
+ * BETA SOFTWARE NOTICE:
+ * This software is in active development. Features may change.
+ * Report issues: https://github.com/deephouse23/Weather-application-/issues
+ */
+
+/**
  * Temperature Extremes Data Service
  * Fetches and manages global temperature extremes
  * Version 0.3.2

--- a/lib/hooks.ts
+++ b/lib/hooks.ts
@@ -1,3 +1,17 @@
+/**
+ * 16-Bit Weather Platform - BETA v0.3.2
+ * 
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ * 
+ * Use Limitation: 5 users
+ * See LICENSE file for full terms
+ * 
+ * BETA SOFTWARE NOTICE:
+ * This software is in active development. Features may change.
+ * Report issues: https://github.com/deephouse23/Weather-application-/issues
+ */
+
 import { useState, useEffect, useCallback, useRef } from 'react'
 
 /**

--- a/lib/location-service.ts
+++ b/lib/location-service.ts
@@ -1,4 +1,18 @@
 /**
+ * 16-Bit Weather Platform - BETA v0.3.2
+ * 
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ * 
+ * Use Limitation: 5 users
+ * See LICENSE file for full terms
+ * 
+ * BETA SOFTWARE NOTICE:
+ * This software is in active development. Features may change.
+ * Report issues: https://github.com/deephouse23/Weather-application-/issues
+ */
+
+/**
  * Location Detection Service
  * 
  * This service provides comprehensive location detection capabilities with:

--- a/lib/safe-storage.ts
+++ b/lib/safe-storage.ts
@@ -1,4 +1,18 @@
 /**
+ * 16-Bit Weather Platform - BETA v0.3.2
+ * 
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ * 
+ * Use Limitation: 5 users
+ * See LICENSE file for full terms
+ * 
+ * BETA SOFTWARE NOTICE:
+ * This software is in active development. Features may change.
+ * Report issues: https://github.com/deephouse23/Weather-application-/issues
+ */
+
+/**
  * Safe localStorage wrapper that handles SSR/static generation
  * Only accesses localStorage when window exists (client-side)
  */

--- a/lib/theme-utils.ts
+++ b/lib/theme-utils.ts
@@ -1,4 +1,18 @@
 /**
+ * 16-Bit Weather Platform - BETA v0.3.2
+ * 
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ * 
+ * Use Limitation: 5 users
+ * See LICENSE file for full terms
+ * 
+ * BETA SOFTWARE NOTICE:
+ * This software is in active development. Features may change.
+ * Report issues: https://github.com/deephouse23/Weather-application-/issues
+ */
+
+/**
  * Centralized Theme Utility System
  * 
  * Provides consistent theme styling across all components with optimized

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,3 +1,17 @@
+/**
+ * 16-Bit Weather Platform - BETA v0.3.2
+ * 
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ * 
+ * Use Limitation: 5 users
+ * See LICENSE file for full terms
+ * 
+ * BETA SOFTWARE NOTICE:
+ * This software is in active development. Features may change.
+ * Report issues: https://github.com/deephouse23/Weather-application-/issues
+ */
+
 export interface WeatherData {
   location: string;
   country: string;

--- a/lib/user-cache-service.ts
+++ b/lib/user-cache-service.ts
@@ -1,4 +1,18 @@
 /**
+ * 16-Bit Weather Platform - BETA v0.3.2
+ * 
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ * 
+ * Use Limitation: 5 users
+ * See LICENSE file for full terms
+ * 
+ * BETA SOFTWARE NOTICE:
+ * This software is in active development. Features may change.
+ * Report issues: https://github.com/deephouse23/Weather-application-/issues
+ */
+
+/**
  * User Cache Service
  * 
  * This service provides comprehensive caching and user preference management with:

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,3 +1,17 @@
+/**
+ * 16-Bit Weather Platform - BETA v0.3.2
+ * 
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ * 
+ * Use Limitation: 5 users
+ * See LICENSE file for full terms
+ * 
+ * BETA SOFTWARE NOTICE:
+ * This software is in active development. Features may change.
+ * Report issues: https://github.com/deephouse23/Weather-application-/issues
+ */
+
 import { clsx, type ClassValue } from "clsx"
 import { twMerge } from "tailwind-merge"
 

--- a/lib/weather-api.ts
+++ b/lib/weather-api.ts
@@ -1,4 +1,18 @@
 /**
+ * 16-Bit Weather Platform - BETA v0.3.2
+ * 
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ * 
+ * Use Limitation: 5 users
+ * See LICENSE file for full terms
+ * 
+ * BETA SOFTWARE NOTICE:
+ * This software is in active development. Features may change.
+ * Report issues: https://github.com/deephouse23/Weather-application-/issues
+ */
+
+/**
  * Weather API Module - OpenWeatherMap Integration
  * 
  * This module provides comprehensive weather data fetching capabilities with:


### PR DESCRIPTION
BREAKING CHANGE: Project now under Fair Source License

- Add Fair Source License 0.9 with 5-user limitation
- Mark project as BETA software (v0.3.2)
- Add license headers to all source files
- Update README with license badges and beta warnings
- Add automatic header insertion script
- License will convert to MIT in January 2029

License Details:
- Free for up to 5 users
- Commercial use allowed within limit
- Becomes MIT licensed after 4 years
- BETA status indicates active development

Closes: License implementation for public release