### PR TITLE
fix: Update Sentry DSN configuration to resolve 403 errors

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,18 @@
+# Copy this file to .env.local and add your actual values
+
+# OpenWeatherMap API Key (Required)
+NEXT_PUBLIC_OPENWEATHER_API_KEY=your_openweather_api_key_here
+
+# Google APIs (Optional)
+NEXT_PUBLIC_GOOGLE_POLLEN_API_KEY=your_google_pollen_api_key_here
+NEXT_PUBLIC_GOOGLE_AIR_QUALITY_API_KEY=your_google_air_quality_key_here
+
+# Sentry Error Monitoring (Optional)
+# Get your DSN from: https://16bitweather.sentry.io/settings/projects/javascript-nextjs/keys/
+NEXT_PUBLIC_SENTRY_DSN=https://91a13cb4875d11f08eaeb65aedfd09e2@o4508684533522432.ingest.us.sentry.io/4508684595814400
+SENTRY_DSN=https://91a13cb4875d11f08eaeb65aedfd09e2@o4508684533522432.ingest.us.sentry.io/4508684595814400
+SENTRY_AUTH_TOKEN=sntrys_your_auth_token_here
+
+# For Vercel deployment, also set:
+# SENTRY_ORG=16bitweather
+# SENTRY_PROJECT=javascript-nextjs

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -1,7 +1,7 @@
 import * as Sentry from "@sentry/nextjs";
 
 Sentry.init({
-  dsn: "https://6fde5a2b0af444c1a62a31fa17b94b5a@o4508684533522432.ingest.us.sentry.io/4508684595814400",
+  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN || "https://91a13cb4875d11f08eaeb65aedfd09e2@o4508684533522432.ingest.us.sentry.io/4508684595814400",
   
   // Set tracesSampleRate to 1.0 to capture 100%
   // of the transactions for testing.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -102,6 +102,9 @@ export default withSentryConfig(nextConfig, {
 
   org: "16bitweather",
   project: "javascript-nextjs",
+  
+  // Auth token for uploading source maps
+  authToken: process.env.SENTRY_AUTH_TOKEN,
 
   // Only print logs for uploading source maps in CI
   silent: !process.env.CI,

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -1,7 +1,7 @@
 import * as Sentry from "@sentry/nextjs";
 
 Sentry.init({
-  dsn: "https://6fde5a2b0af444c1a62a31fa17b94b5a@o4508684533522432.ingest.us.sentry.io/4508684595814400",
+  dsn: process.env.SENTRY_DSN || "https://91a13cb4875d11f08eaeb65aedfd09e2@o4508684533522432.ingest.us.sentry.io/4508684595814400",
 
   // Set tracesSampleRate to 1.0 to capture 100%
   // of the transactions for testing.

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -1,7 +1,7 @@
 import * as Sentry from "@sentry/nextjs";
 
 Sentry.init({
-  dsn: "https://6fde5a2b0af444c1a62a31fa17b94b5a@o4508684533522432.ingest.us.sentry.io/4508684595814400",
+  dsn: process.env.SENTRY_DSN || "https://91a13cb4875d11f08eaeb65aedfd09e2@o4508684533522432.ingest.us.sentry.io/4508684595814400",
 
   // Set tracesSampleRate to 1.0 to capture 100%
   // of the transactions for testing.


### PR DESCRIPTION
- Use correct DSN token 
- Add environment variable support for DSN configuration
- Include auth token in Next.js config for source map uploads
- Add .env.local.example with proper Sentry setup

This fixes the 403 Forbidden errors in production by using the correct project DSN instead of placeholder values.