### PR TITLE
feat: Add NOAA MRMS high-resolution radar for US locations

### DIFF
--- a/components/WMSTileLayer.tsx
+++ b/components/WMSTileLayer.tsx
@@ -1,0 +1,87 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import { useMap } from 'react-leaflet'
+import L from 'leaflet'
+
+interface WMSTileLayerProps {
+  url: string
+  layers: string
+  format?: string
+  transparent?: boolean
+  opacity?: number
+  time?: number | string
+  attribution?: string
+  zIndex?: number
+}
+
+/**
+ * Custom WMS TileLayer component for react-leaflet
+ * Supports time-enabled WMS services like NOAA MRMS
+ */
+export function WMSTileLayer({
+  url,
+  layers,
+  format = 'image/png',
+  transparent = true,
+  opacity = 0.7,
+  time,
+  attribution = '',
+  zIndex = 400
+}: WMSTileLayerProps) {
+  const map = useMap()
+  const layerRef = useRef<L.TileLayer.WMS | null>(null)
+
+  useEffect(() => {
+    if (!map) return
+
+    // Create WMS layer
+    const wmsLayer = L.tileLayer.wms(url, {
+      layers,
+      format,
+      transparent,
+      opacity,
+      attribution,
+      // @ts-ignore - time parameter may not be in types but is valid for WMS
+      time: time || undefined,
+      version: '1.3.0',
+      crs: L.CRS.EPSG3857,
+      // Performance optimizations
+      updateWhenIdle: true,
+      updateWhenZooming: false,
+      keepBuffer: 2,
+      maxNativeZoom: 10,
+      maxZoom: 18,
+      tileSize: 256,
+      zIndex
+    })
+
+    wmsLayer.addTo(map)
+    layerRef.current = wmsLayer
+
+    return () => {
+      if (layerRef.current) {
+        map.removeLayer(layerRef.current)
+        layerRef.current = null
+      }
+    }
+  }, [map, url])
+
+  // Update opacity when it changes
+  useEffect(() => {
+    if (layerRef.current) {
+      layerRef.current.setOpacity(opacity)
+    }
+  }, [opacity])
+
+  // Update time parameter when it changes
+  useEffect(() => {
+    if (layerRef.current && time !== undefined) {
+      // Force redraw with new time
+      layerRef.current.setParams({ time: time } as any, false)
+      layerRef.current.redraw()
+    }
+  }, [time])
+
+  return null // This component doesn't render anything directly
+}

--- a/lib/utils/location-utils.ts
+++ b/lib/utils/location-utils.ts
@@ -1,0 +1,78 @@
+/**
+ * Location utility functions for weather application
+ */
+
+/**
+ * Check if coordinates are within the United States
+ * Includes CONUS, Alaska, Hawaii, Puerto Rico, and US territories
+ */
+export function isUSLocation(latitude: number, longitude: number): boolean {
+  // CONUS (Continental US)
+  const isCONUS =
+    latitude >= 24.5 && latitude <= 49.5 &&
+    longitude >= -125 && longitude <= -66
+
+  // Alaska
+  const isAlaska =
+    latitude >= 51 && latitude <= 71.5 &&
+    longitude >= -180 && longitude <= -129
+
+  // Hawaii
+  const isHawaii =
+    latitude >= 18.9 && latitude <= 22.5 &&
+    longitude >= -160.5 && longitude <= -154.5
+
+  // Puerto Rico
+  const isPuertoRico =
+    latitude >= 17.9 && latitude <= 18.6 &&
+    longitude >= -67.3 && longitude <= -65.2
+
+  // US Virgin Islands
+  const isUSVI =
+    latitude >= 17.6 && latitude <= 18.5 &&
+    longitude >= -65.1 && longitude <= -64.5
+
+  // Guam
+  const isGuam =
+    latitude >= 13.2 && latitude <= 13.7 &&
+    longitude >= 144.6 && longitude <= 145
+
+  return isCONUS || isAlaska || isHawaii || isPuertoRico || isUSVI || isGuam
+}
+
+/**
+ * Get region name for US location
+ */
+export function getUSRegion(latitude: number, longitude: number): string | null {
+  if (!isUSLocation(latitude, longitude)) return null
+
+  if (latitude >= 51 && latitude <= 71.5 && longitude >= -180 && longitude <= -129) {
+    return 'Alaska'
+  }
+
+  if (latitude >= 18.9 && latitude <= 22.5 && longitude >= -160.5 && longitude <= -154.5) {
+    return 'Hawaii'
+  }
+
+  if (latitude >= 17.9 && latitude <= 18.6 && longitude >= -67.3 && longitude <= -65.2) {
+    return 'Puerto Rico'
+  }
+
+  if (latitude >= 17.6 && latitude <= 18.5 && longitude >= -65.1 && longitude <= -64.5) {
+    return 'US Virgin Islands'
+  }
+
+  if (latitude >= 13.2 && latitude <= 13.7 && longitude >= 144.6 && longitude <= 145) {
+    return 'Guam'
+  }
+
+  return 'Continental US'
+}
+
+/**
+ * Check if location is in MRMS coverage area
+ * MRMS covers CONUS, Alaska, Caribbean (PR/USVI), Guam, and Hawaii
+ */
+export function isInMRMSCoverage(latitude: number, longitude: number): boolean {
+  return isUSLocation(latitude, longitude)
+}


### PR DESCRIPTION
- Add NOAA MRMS radar toggle for US locations (FREE, real-time updates)
- Create WMSTileLayer component for WMS protocol support
- Add US location detection utilities (CONUS, Alaska, Hawaii, territories)
- Increase radar opacity from 70% to 85% for better visibility
- Integrate MRMS with existing animated time-lapse system
- Use nowCOAST GeoServer endpoint for reliable MRMS data

MRMS provides 2-minute update intervals and high-resolution composite reflectivity data for the entire US, including Alaska, Hawaii, Puerto Rico, US Virgin Islands, and Guam. The radar automatically detects US locations and shows the MRMS toggle in the Layers dropdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)