### PR TITLE
Design: Nord dashboard surface polish and typography

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -16,7 +16,7 @@
   }
   body {
     @apply bg-background text-foreground;
-    font-family: var(--theme-font, 'Inconsolata'), monospace;
+    font-family: var(--font-body, var(--font-ui), ui-sans-serif, system-ui, sans-serif);
     font-weight: 400;
   }
 }
@@ -430,6 +430,15 @@ body {
     background: var(--card-bg-hover);
   }
 
+  /* Weather dashboard: lifted panels (inset highlight + soft ambient shadow + accent hairline) */
+  .dashboard-surface {
+    border: 1px solid var(--border-invisible);
+    box-shadow:
+      0 1px 0 rgba(255, 255, 255, 0.055) inset,
+      0 14px 44px -22px rgba(0, 0, 0, 0.72),
+      0 0 0 1px rgba(var(--theme-accent-rgb), 0.1);
+  }
+
   /* Interactive card styles with accessibility */
   .card-interactive {
     transition: all 0.2s ease;
@@ -510,7 +519,7 @@ button {
 @media (max-width: 640px) {
   body {
     font-size: 14px;
-    line-height: 1.4;
+    line-height: 1.5;
   }
 
   .space-y-6> :not([hidden])~ :not([hidden]) {

--- a/app/globals.css
+++ b/app/globals.css
@@ -16,6 +16,7 @@
   }
   body {
     @apply bg-background text-foreground;
+
     font-family: var(--font-body, var(--font-ui), ui-sans-serif, system-ui, sans-serif);
     font-weight: 400;
   }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,7 +15,7 @@
 import type React from "react"
 import "./globals.css"
 import type { Metadata } from "next"
-import { Inconsolata, VT323 } from "next/font/google"
+import { IBM_Plex_Sans, Inconsolata, VT323 } from "next/font/google"
 // PERFORMANCE: Analytics lazy loaded via client component wrapper
 import AnalyticsWrapper from "@/components/analytics-wrapper"
 import AppThemeProvider from "@/app/providers/ThemeProvider"
@@ -27,6 +27,13 @@ import AuthDebug from "@/components/auth/auth-debug"
 
 // PERFORMANCE: Use next/font for non-blocking font loading
 // Include all weights used in codebase (400, 500, 600, 700, 800)
+const ibmPlexSans = IBM_Plex_Sans({
+  subsets: ["latin"],
+  display: "swap",
+  variable: "--font-ui",
+  weight: ["400", "500", "600", "700"],
+})
+
 const inconsolata = Inconsolata({
   subsets: ["latin"],
   display: 'swap',
@@ -158,7 +165,7 @@ export default function RootLayout({
         <link rel="dns-prefetch" href="https://pollen.googleapis.com" />
         <link rel="dns-prefetch" href="https://www.google.com" />
       </head>
-      <body className={`${inconsolata.variable} ${vt323.variable} min-h-screen font-sans`} style={{ backgroundColor: 'var(--bg)', color: 'var(--text)' }}>
+      <body className={`${ibmPlexSans.variable} ${inconsolata.variable} ${vt323.variable} min-h-screen font-sans antialiased`} style={{ backgroundColor: 'var(--bg)', color: 'var(--text)' }}>
         <ErrorBoundaryWrapper>
           <AuthProvider>
             <AppThemeProvider>

--- a/app/theme.css
+++ b/app/theme.css
@@ -62,6 +62,8 @@
 
     /* Feature toggles / UI logic */
     --theme-font: var(--font-inconsolata), 'Inconsolata', monospace;
+    /* Nord: clean UI sans; use font-mono / Inconsolata for numeric “terminal” blocks */
+    --font-body: var(--font-ui), ui-sans-serif, system-ui, sans-serif;
   }
 
   /* 
@@ -113,6 +115,7 @@
     --card-bg-hover: rgba(var(--theme-accent-rgb), 0.08);
 
     --theme-font: var(--font-vt323), 'VT323', monospace;
+    --font-body: var(--theme-font), ui-monospace, monospace;
   }
 
   /* 
@@ -164,6 +167,7 @@
     --card-bg-hover: rgba(var(--theme-accent-rgb), 0.08);
 
     --theme-font: var(--font-inconsolata), 'Inconsolata', monospace;
+    --font-body: var(--theme-font), ui-monospace, monospace;
   }
 
   /* 
@@ -215,6 +219,7 @@
     --card-bg-hover: rgba(var(--theme-accent-rgb), 0.08);
 
     --theme-font: var(--font-inconsolata), 'Inconsolata', monospace;
+    --font-body: var(--theme-font), ui-monospace, monospace;
   }
 
   /* 
@@ -266,5 +271,6 @@
     --card-bg-hover: rgba(var(--theme-accent-rgb), 0.08);
 
     --theme-font: var(--font-vt323), 'VT323', monospace;
+    --font-body: var(--theme-font), ui-monospace, monospace;
   }
 }

--- a/components/air-quality-display.tsx
+++ b/components/air-quality-display.tsx
@@ -45,7 +45,7 @@ export function AirQualityDisplay({ aqi, theme, className, minimal = false }: Ai
         border: 'border-white/20'
       }
     : {
-        container: 'bg-card border-primary glow-subtle',
+        container: 'bg-card/80 dashboard-surface rounded-xl glow-subtle',
         header: 'text-primary',
         text: 'text-foreground',
         border: 'border-primary/40'
@@ -96,7 +96,7 @@ export function AirQualityDisplay({ aqi, theme, className, minimal = false }: Ai
 
         {/* AQI Scale Labels */}
         {!minimal && (
-          <div className="flex justify-between text-xs text-gray-400 mt-1 px-1">
+          <div className="flex justify-between text-xs text-muted-foreground/90 mt-1 px-1">
             {AQI_SCALE_LABELS.map((label, index) => (
               <span key={index}>{label}</span>
             ))}

--- a/components/auth/auth-button.tsx
+++ b/components/auth/auth-button.tsx
@@ -48,7 +48,7 @@ export default function AuthButton() {
         href="/auth/login"
         className={cn(
           buttonVariants({ variant: "default", size: "default" }),
-          "min-w-[80px] font-bold shadow-md bg-emerald-600 hover:bg-emerald-500 text-white border-2 border-white/20"
+          "min-w-[80px] font-bold shadow-md shadow-glow-subtle border border-primary/25"
         )}
       >
         <LogIn className="w-3 h-3 mr-1" />

--- a/components/forecast.tsx
+++ b/components/forecast.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useMemo, type KeyboardEvent } from "react"
+import { useEffect, useState, type KeyboardEvent } from "react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { cn } from "@/lib/utils"
 // removed ThemeType import as manual mapping is gone, but we might accept the prop for compat
@@ -60,15 +60,16 @@ function ForecastCard({ day, index, onDayClick, isSelected }: {
   const isUSALocation = day.country === 'US' || day.country === 'USA';
   const tempUnit = isUSALocation ? '°F' : '°C';
 
-  // Generate date in M.DD.YY format - memoized to avoid hydration mismatch
-  const formattedDate = useMemo(() => {
+  // M.DD.YY from local calendar; computed on client only to avoid SSR/client date skew
+  const [formattedDate, setFormattedDate] = useState('');
+  useEffect(() => {
     const today = new Date();
     const targetDate = new Date(today);
     targetDate.setDate(today.getDate() + index);
     const month = targetDate.getMonth() + 1;
     const date = targetDate.getDate();
     const year = targetDate.getFullYear().toString().slice(-2);
-    return `${month}.${date.toString().padStart(2, '0')}.${year}`;
+    setFormattedDate(`${month}.${date.toString().padStart(2, '0')}.${year}`);
   }, [index]);
 
   const handleClick = () => {

--- a/components/forecast.tsx
+++ b/components/forecast.tsx
@@ -28,7 +28,7 @@ export default function Forecast({ forecast, onDayClick, selectedDay }: Forecast
     : "grid-cols-2 sm:grid-cols-3 lg:grid-cols-5";
 
   return (
-    <Card className="p-3 sm:p-4 lg:p-6 border-0 shadow-md hover:shadow-lg transition-all duration-300 animate-slide-in">
+    <Card className="p-3 sm:p-4 lg:p-6 border-0 rounded-xl dashboard-surface bg-card/55 backdrop-blur-md transition-shadow duration-300 animate-slide-in">
       <CardHeader className="p-0 mb-3 sm:mb-4">
         <CardTitle className="text-center text-base sm:text-lg lg:text-xl font-extrabold uppercase tracking-wider text-primary glow">
           {title}
@@ -87,10 +87,11 @@ function ForecastCard({ day, index, onDayClick, isSelected }: {
   return (
     <Card
       className={cn(
-        "cursor-pointer transition-all duration-300 hover:scale-105 hover:-translate-y-1 hover:shadow-lg hover:border-primary/50 card-interactive",
+        "cursor-pointer transition-all duration-200 hover:-translate-y-0.5 card-interactive",
         "flex flex-col justify-between min-h-[120px] sm:min-h-[140px] lg:min-h-[160px]",
-        "backdrop-blur-sm bg-card/80",
-        isSelected && "ring-2 ring-primary ring-opacity-80 scale-105 shadow-[0_0_15px_rgba(var(--primary),0.3)]"
+        "backdrop-blur-sm bg-card/70 border border-[var(--border-invisible)] shadow-[0_10px_28px_-14px_rgba(0,0,0,0.55)]",
+        "hover:border-[var(--border-subtle)] hover:shadow-[0_14px_36px_-14px_rgba(0,0,0,0.55)]",
+        isSelected && "ring-2 ring-primary ring-offset-2 ring-offset-background shadow-[0_0_22px_rgba(var(--theme-accent-rgb),0.32)]"
       )}
       onClick={handleClick}
       onKeyDown={handleKeyDown}
@@ -104,7 +105,7 @@ function ForecastCard({ day, index, onDayClick, isSelected }: {
         <div className="text-xs sm:text-sm font-bold text-primary mb-1 uppercase tracking-wider glow text-center">
           <span className="sm:hidden">{day.day.substring(0, 3)}</span>
           <span className="hidden sm:inline">{day.day}</span>
-          <div className="text-[10px] text-muted-foreground mt-1">
+          <div className="text-xs text-muted-foreground/90 mt-1 tabular-nums">
             {formattedDate}
           </div>
         </div>
@@ -120,16 +121,19 @@ function ForecastCard({ day, index, onDayClick, isSelected }: {
 
         {/* Temp */}
         <div className="space-y-1 text-center">
-          <div className="text-sm sm:text-base lg:text-lg font-bold text-foreground pixel-glow">
+          <div className="text-sm sm:text-base lg:text-lg font-bold text-foreground tabular-nums font-mono tracking-tight">
             {Math.round(day.highTemp)}{tempUnit}
           </div>
-          <div className="text-xs sm:text-sm text-muted-foreground font-medium">
+          <div className="text-xs sm:text-sm text-muted-foreground/90 font-medium tabular-nums font-mono">
             {Math.round(day.lowTemp)}{tempUnit}
           </div>
         </div>
 
         {/* Description - Mobile responsive */}
-        <div className="text-[10px] text-primary/80 capitalize mt-2 text-center w-full truncate leading-tight">
+        <div
+          className="text-xs text-primary/85 capitalize mt-2 text-center w-full line-clamp-2 leading-snug min-h-[2.25rem]"
+          title={day.description}
+        >
           <span className="sm:hidden">
             {day.description.length > 12 ? `${day.description.substring(0, 10)}...` : day.description}
           </span>

--- a/components/hourly-forecast.tsx
+++ b/components/hourly-forecast.tsx
@@ -15,10 +15,10 @@
  */
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { useEffect, useRef } from "react"
+import { useEffect, useRef, useState } from "react"
 import { cn } from "@/lib/utils"
 import { Droplets } from "lucide-react"
-import { ThemeType } from "@/lib/theme-config" // Ensure using shared type or just remove if not needed for logic
+import type { ThemeType } from "@/lib/theme-config"
 import WeatherIconModern from "./weather-icon-modern"
 
 export interface HourlyForecastData {
@@ -47,16 +47,21 @@ export default function HourlyForecast({
   tempUnit = '°F'
 }: HourlyForecastProps) {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  /** Client-only clock so server and client agree on first paint (no hydration mismatch for "NOW"). */
+  const [now, setNow] = useState<number | null>(null);
 
-  // Auto-scroll to current hour on mount
   useEffect(() => {
-    if (scrollContainerRef.current) {
-      const currentHourCard = scrollContainerRef.current.querySelector('.current-hour');
-      if (currentHourCard) {
-        currentHourCard.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'start' });
-      }
-    }
+    setNow(Date.now());
   }, []);
+
+  // Auto-scroll to current hour once client time is known
+  useEffect(() => {
+    if (now === null || !scrollContainerRef.current) return;
+    const currentHourCard = scrollContainerRef.current.querySelector('.current-hour');
+    if (currentHourCard) {
+      currentHourCard.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'start' });
+    }
+  }, [now]);
 
   if (!hourly || hourly.length === 0) {
     return null;
@@ -64,7 +69,6 @@ export default function HourlyForecast({
 
   // Take first 24 hours for a cleaner view (user can scroll)
   const displayHours = hourly.slice(0, 24);
-  const now = Date.now();
 
   return (
     <Card className="p-3 sm:p-4 lg:p-6 border-0 rounded-xl dashboard-surface backdrop-blur-md bg-card/55 animate-slide-in">
@@ -86,7 +90,8 @@ export default function HourlyForecast({
           <div className="flex gap-3 sm:gap-4 pb-2 w-max mx-auto sm:mx-0">
             {displayHours.map((hour) => {
               const hourTime = new Date(hour.dt * 1000);
-              const isCurrentHour = Math.abs(hourTime.getTime() - now) < 1800000; // Within 30 min
+              const isCurrentHour =
+                now !== null && Math.abs(hourTime.getTime() - now) < 1800000; // Within 30 min
               const isMidnight = hourTime.getHours() === 0;
 
               return (

--- a/components/hourly-forecast.tsx
+++ b/components/hourly-forecast.tsx
@@ -67,7 +67,7 @@ export default function HourlyForecast({
   const now = Date.now();
 
   return (
-    <Card className="p-3 sm:p-4 lg:p-6 border-0 shadow-xl backdrop-blur-md bg-card/40 animate-slide-in">
+    <Card className="p-3 sm:p-4 lg:p-6 border-0 rounded-xl dashboard-surface backdrop-blur-md bg-card/55 animate-slide-in">
       <CardHeader className="p-0 mb-3 sm:mb-4">
         <CardTitle className="text-center text-base sm:text-lg lg:text-xl font-bold uppercase tracking-wider text-primary glow">
           HOURLY FORECAST
@@ -77,7 +77,7 @@ export default function HourlyForecast({
       <CardContent className="p-0">
         <div
           ref={scrollContainerRef}
-          className="overflow-x-auto overflow-y-hidden py-4 px-2 scrollbar-hide"
+          className="overflow-x-auto overflow-y-hidden py-4 px-2 scrollbar-hide scroll-smooth snap-x snap-mandatory"
           style={{
             scrollbarWidth: 'thin',
             scrollbarColor: 'hsl(var(--primary)) transparent'
@@ -103,7 +103,7 @@ export default function HourlyForecast({
         </div>
 
         {/* Scroll hint for mobile */}
-        <div className="text-center mt-2 text-xs opacity-70 text-muted-foreground">
+        <div className="text-center mt-2 text-xs text-muted-foreground/90">
           ← Scroll for more hours →
         </div>
       </CardContent>
@@ -125,13 +125,14 @@ function HourlyCard({
   return (
     <Card
       className={cn(
-        "flex-shrink-0 flex flex-col items-center justify-between",
+        "flex-shrink-0 flex flex-col items-center justify-between snap-start",
         "rounded-xl p-3 sm:p-4 min-w-[100px] sm:min-w-[110px]",
-        "transition-all duration-300 hover:scale-105 hover:-translate-y-1",
-        "backdrop-blur-md",
+        "transition-all duration-200 hover:-translate-y-0.5",
+        "backdrop-blur-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+        "shadow-[0_10px_28px_-14px_rgba(0,0,0,0.55)]",
         isCurrentHour
-          ? "bg-primary/10 border-0 shadow-[0_0_15px_rgba(var(--primary),0.3)] current-hour"
-          : "bg-card/50 hover:bg-card/80 border-0",
+          ? "bg-primary/12 border border-primary/25 shadow-[0_0_20px_rgba(var(--theme-accent-rgb),0.28)] current-hour"
+          : "bg-card/55 hover:bg-card/75 border border-[var(--border-invisible)] hover:border-[var(--border-subtle)] hover:shadow-[0_12px_32px_-14px_rgba(0,0,0,0.5)]",
         isMidnight && "border-l-0"
       )}
     >
@@ -145,7 +146,7 @@ function HourlyCard({
 
       {/* Day marker for midnight */}
       {isMidnight && !isCurrentHour && (
-        <div className="text-[10px] mb-1 font-bold uppercase tracking-widest opacity-80 text-primary">
+        <div className="text-xs mb-1 font-bold uppercase tracking-widest text-primary/90">
           {new Date(hour.dt * 1000).toLocaleDateString('en-US', { weekday: 'short' })}
         </div>
       )}
@@ -162,14 +163,14 @@ function HourlyCard({
 
       {/* Temperature */}
       <div className={cn(
-        "text-lg sm:text-xl font-bold mb-2 pixel-glow text-primary",
-        isCurrentHour && "scale-110"
+        "text-lg sm:text-xl font-bold mb-2 tabular-nums tracking-tight text-primary font-mono",
+        isCurrentHour && "glow"
       )}>
         {Math.round(hour.temp)}{tempUnit}
       </div>
 
       {/* Stats Row */}
-      <div className="flex items-center gap-3 w-full justify-center text-[10px] sm:text-xs opacity-80 text-muted-foreground">
+      <div className="flex items-center gap-3 w-full justify-center text-xs text-muted-foreground/90">
         {/* Precip */}
         <div className={cn(
           "flex items-center gap-0.5",

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-[color,transform,box-shadow,background-color] duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 active:translate-y-px active:brightness-[0.97] disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {

--- a/components/weather-display.tsx
+++ b/components/weather-display.tsx
@@ -89,11 +89,11 @@ export function WeatherDisplay({
     : 0
 
   return (
-    <div className="space-y-4 sm:space-y-6">
+    <div className="space-y-5 sm:space-y-7">
       {/* 1. Location Header with Large Temperature */}
       <div className="text-center mb-4">
         <div className="flex items-center justify-center gap-3 mb-2">
-          <h1 className={cn("text-xl sm:text-2xl font-extrabold tracking-wider uppercase", themeClasses.headerText, themeClasses.glow)} style={{
+          <h1 className={cn("text-xl sm:text-2xl font-extrabold tracking-wider uppercase text-primary font-sans", themeClasses.glow)} style={{
             fontSize: "clamp(18px, 3.5vw, 28px)"
           }}>
             {weather.location} WEATHER
@@ -112,12 +112,12 @@ export function WeatherDisplay({
             />
           )}
         </div>
-        <p data-testid="temperature-value" className={cn("text-6xl sm:text-8xl font-bold my-2", themeClasses.text)} style={{
+        <p data-testid="temperature-value" className={cn("text-6xl sm:text-8xl font-bold my-2 tabular-nums tracking-tight font-mono", themeClasses.text)} style={{
           fontSize: "clamp(48px, 12vw, 96px)"
         }}>
           {weather?.temperature ?? 'N/A'}{weather?.temperature != null ? '°' : ''}
         </p>
-        <p className={cn("text-base sm:text-lg", themeClasses.secondaryText)}>
+        <p className="text-base sm:text-lg text-muted-foreground/90 leading-relaxed">
           {weather?.condition || 'Unknown'} - {weather?.description || 'No description available'}
         </p>
       </div>
@@ -132,7 +132,7 @@ export function WeatherDisplay({
       )}
 
       {/* 3. Two-column layout: 5-Day Forecast + AQI (left) / Radar (right) */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-5 lg:gap-6 pt-1">
         {/* LEFT: 5-Day Forecast + AQI stacked */}
         <div className="space-y-4">
           {weather?.forecast && weather.forecast.length > 0 ? (
@@ -162,19 +162,19 @@ export function WeatherDisplay({
 
         {/* RIGHT: Weather Radar only */}
         {showRadar && (
-          <div className="space-y-2">
-            <div className="flex items-center justify-between">
+          <div className="space-y-3 rounded-xl dashboard-surface bg-card/40 p-3 sm:p-4">
+            <div className="flex items-center justify-between gap-2">
               <h2 className="text-lg font-semibold text-terminal-text-primary">
                 Weather Radar
               </h2>
               <Link
                 href="/radar"
-                className="px-2 py-1 border-0 rounded-md font-mono text-xs font-bold transition-colors hover:scale-105 text-terminal-text-primary hover:text-white"
+                className="px-2 py-1 border-0 rounded-md text-xs font-semibold transition-colors hover:text-primary text-muted-foreground hover:text-foreground"
               >
                 VIEW FULL →
               </Link>
             </div>
-            <div className="h-[400px] rounded-lg overflow-visible">
+            <div className="h-[400px] rounded-lg overflow-visible ring-1 ring-[var(--border-invisible)]">
               <LazyWeatherMap
                 latitude={weather?.coordinates?.lat}
                 longitude={weather?.coordinates?.lon}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -151,9 +151,9 @@ const config: Config = {
 				'slide-in': 'slideIn 0.5s ease-out forwards'
 			},
 			fontFamily: {
-				sans: ['Inconsolata', 'monospace'],
-				mono: ['Inconsolata', 'monospace'],
-				display: ['VT323', 'monospace'],
+				sans: ['var(--font-body)', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+				mono: ['var(--font-inconsolata)', 'ui-monospace', 'monospace'],
+				display: ['var(--font-vt323)', 'VT323', 'monospace'],
 			},
 			fontWeight: {
 				light: '300',


### PR DESCRIPTION
## Summary
Visual polish for the weather dashboard on Nord (and shared primitives).

## Changes
- IBM Plex Sans as UI body font on Nord via `--font-ui` / `--font-body`; premium themes keep VT323/Inconsolata as full UI font
- New `.dashboard-surface` utility: inset highlight + soft shadow + accent hairline on hourly, 5-day, radar, and AQI panels
- Hourly/forecast tiles: corrected shadows (theme RGB), focus rings, scroll snap, less aggressive hover scale
- Weather hero: sans location line, mono tabular temperature, improved condition line contrast
- Login CTA uses primary + subtle glow; shared Button active press feedback
- Mobile body line-height 1.5

## Verification
- `npm run test:ci` (78 passed)
- `next build` (Node 20)
- Playwright Chromium: 28/28 against dev server with `PLAYWRIGHT_TEST_BASE_URL` + Playwright test mode
- Lighthouse collect + assert (Node 20, existing prod server on :3000)

## Notes
Local default Node 18 cannot run `next build` or default `lhci`; use Node 20+ or `npx node@20` for build/Lighthouse as above.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable "dashboard surface" style for elevated panels across the app.

* **Style**
  * Rolled out a refreshed typography system with a new UI/body font stack for improved readability.
  * Polished card visuals: rounded corners, subtle layered shadows, translucent surfaces.
  * Improved interactive feedback: tighter hover/active transitions and clearer focus states.
  * Adjusted spacing and mobile line-height for better legibility on small screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->