### PR TITLE
feat: add Vibe Check comfort score page and AI tool

### DIFF
--- a/__tests__/vibe-check.test.ts
+++ b/__tests__/vibe-check.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Unit tests for Vibe Check comfort scoring algorithm
+ */
+
+import {
+  calculateVibeScore,
+  getVibeCategory,
+  type VibeInput,
+} from '@/lib/services/vibe-check';
+
+describe('Vibe Check', () => {
+  describe('calculateVibeScore', () => {
+    it('should return a perfect score for ideal conditions', () => {
+      const input: VibeInput = {
+        tempF: 72,
+        humidity: 45,
+        windMph: 5,
+        precipChance: 0,
+        uvIndex: 3,
+        cloudCover: 20,
+      };
+
+      const result = calculateVibeScore(input);
+
+      expect(result.score).toBeGreaterThanOrEqual(90);
+      expect(result.score).toBeLessThanOrEqual(100);
+    });
+
+    it('should return a low score for harsh conditions', () => {
+      const input: VibeInput = {
+        tempF: 10,
+        humidity: 95,
+        windMph: 40,
+        precipChance: 100,
+        uvIndex: 0,
+        cloudCover: 100,
+      };
+
+      const result = calculateVibeScore(input);
+
+      expect(result.score).toBeLessThan(20);
+    });
+
+    it('should clamp score between 0 and 100', () => {
+      const extreme: VibeInput = {
+        tempF: -50, humidity: 100, windMph: 100,
+        precipChance: 100, uvIndex: 15, cloudCover: 100,
+      };
+
+      const result = calculateVibeScore(extreme);
+
+      expect(result.score).toBeGreaterThanOrEqual(0);
+      expect(result.score).toBeLessThanOrEqual(100);
+    });
+  });
+
+  describe('getVibeCategory', () => {
+    it('should map scores to correct categories', () => {
+      expect(getVibeCategory(95)).toBe('Immaculate');
+      expect(getVibeCategory(70)).toBe('Vibin');
+      expect(getVibeCategory(50)).toBe('Decent');
+      expect(getVibeCategory(30)).toBe('Meh');
+      expect(getVibeCategory(10)).toBe('Rough');
+    });
+  });
+});

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,167 +1,239 @@
-import { Github, Twitter, Terminal, Gamepad2, Cpu, Zap, CloudLightning } from 'lucide-react'
-import Link from 'next/link'
-import Navigation from '@/components/navigation'
+'use client';
+
+/**
+ * 16-Bit Weather Platform - About Page
+ *
+ * Platform overview, creator story, tech stack, and available modules.
+ */
+
+import React, { useState } from 'react';
+import Link from 'next/link';
+import {
+  Github, Twitter, Terminal, Cpu, Zap, CloudLightning, Map, Plane, Sun,
+  Gamepad2, Newspaper, Sparkles, Thermometer, AlertTriangle, ChevronDown,
+  Globe, Database, Shield, Gauge
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { useTheme } from '@/components/theme-provider';
+import { getComponentStyles, type ThemeType } from '@/lib/theme-utils';
+import PageWrapper from '@/components/page-wrapper';
+
+function Accordion({ title, icon: Icon, children, defaultOpen = false }: {
+  title: string;
+  icon: React.ElementType;
+  children: React.ReactNode;
+  defaultOpen?: boolean;
+}) {
+  const [isOpen, setIsOpen] = useState(defaultOpen);
+  return (
+    <div className="border border-border rounded-lg overflow-hidden">
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="w-full flex items-center justify-between p-5 bg-card/50 hover:bg-card/80 transition-colors"
+      >
+        <div className="flex items-center gap-3">
+          <Icon className="w-5 h-5 text-primary" />
+          <h2 className="text-lg font-bold font-mono tracking-wider uppercase">{title}</h2>
+        </div>
+        <ChevronDown className={cn("w-5 h-5 text-muted-foreground transition-transform", isOpen && "rotate-180")} />
+      </button>
+      {isOpen && (
+        <div className="p-6 border-t border-border animate-in slide-in-from-top-2 duration-200">
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}
+
+const modules = [
+  { href: "/radar", label: "Radar", desc: "Real-time NOAA MRMS radar with animated playback", icon: Map },
+  { href: "/situation", label: "Current Situation", desc: "Live NWS alerts dashboard with Weather Intensity Score", icon: AlertTriangle },
+  { href: "/severe", label: "Severe Weather", desc: "Active tornado, thunderstorm, and flood warnings", icon: CloudLightning },
+  { href: "/aviation", label: "Aviation", desc: "METARs, PIREPs, SIGMETs, and flight conditions", icon: Plane },
+  { href: "/space-weather", label: "Space Weather", desc: "Solar flares, Kp index, aurora forecast, and coronagraph", icon: Sun },
+  { href: "/vibe-check", label: "Vibe Check", desc: "Outdoor comfort scoring — is it a good day to go out?", icon: Thermometer },
+  { href: "/games", label: "Retro Games", desc: "Weather-themed arcade games with leaderboards", icon: Gamepad2 },
+  { href: "/news", label: "News Feed", desc: "Aggregated weather news from NOAA, NASA, and USGS", icon: Newspaper },
+  { href: "/ai", label: "AI Chat", desc: "Claude-powered weather assistant with tool calling", icon: Sparkles },
+];
 
 export default function AboutPage() {
+  const { theme } = useTheme();
+  const themeClasses = getComponentStyles((theme || 'nord') as ThemeType, 'weather');
+
   return (
-    <div className="min-h-screen bg-terminal-bg-primary text-terminal-text-primary selection:bg-terminal-accent selection:text-black overflow-x-hidden">
-      <div className="relative z-50">
-        <Navigation />
-      </div>
-
-      {/* Grid Background Effect */}
-      <div className="fixed inset-0 z-0 pointer-events-none opacity-20"
-        style={{
-          backgroundImage: 'linear-gradient(to right, var(--terminal-border) 1px, transparent 1px), linear-gradient(to bottom, var(--terminal-border) 1px, transparent 1px)',
-          backgroundSize: '40px 40px'
-        }}
-      />
-
-      <div className="container mx-auto px-4 py-16 relative z-10">
-
-        {/* HERO SECTION */}
-        <div className="max-w-4xl mx-auto text-center mb-20 space-y-6">
-          <div className="inline-block px-4 py-1 border-0 text-terminal-accent font-mono text-sm mb-4 bg-terminal-accent/10 rounded-full animate-pulse">
-            SYSTEM_STATUS: ONLINE
-          </div>
-          <h1 className="text-5xl md:text-7xl font-black tracking-tighter uppercase font-mono bg-clip-text text-transparent bg-gradient-to-r from-terminal-accent via-white to-terminal-accent-secondary drop-shadow-[0_0_10px_rgba(0,212,255,0.5)]">
-            Retro Soul.<br />
-            Modern Intelligence.
+    <PageWrapper>
+      <div className="max-w-5xl mx-auto px-4 py-8 space-y-8">
+        {/* Hero */}
+        <div className="text-center space-y-3">
+          <h1 className="text-3xl md:text-5xl font-extrabold tracking-tight font-mono uppercase">
+            Mission Status:{' '}
+            <span className="text-primary">About 16-Bit Weather</span>
           </h1>
-          <p className="text-xl md:text-2xl text-terminal-text-muted font-mono max-w-2xl mx-auto leading-relaxed">
-            Weather data doesn't have to be boring. Use the terminal. <br />Check the radar. Play the game.
+          <p className="text-sm font-mono text-muted-foreground tracking-wider">
+            // RETRO SOUL // MODERN INTELLIGENCE // WEATHER EDUCATION
           </p>
         </div>
 
-        {/* MAIN CONTENT GRID */}
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-8 max-w-6xl mx-auto mb-20">
+        {/* Accordion Sections */}
+        <div className="space-y-4">
 
-          {/* THE STORY CARD */}
-          <div className="group relative">
-            <div className="absolute -inset-1 bg-gradient-to-r from-terminal-accent-secondary to-terminal-accent opacity-75 blur group-hover:opacity-100 transition duration-1000 group-hover:duration-200"></div>
-            <div className="relative h-full bg-terminal-bg-elevated border-0 p-8 md:p-10 flex flex-col justify-between">
-              <div>
-                <div className="flex items-center space-x-3 mb-6">
-                  <Terminal className="w-8 h-8 text-terminal-accent-secondary" />
-                  <h2 className="text-2xl font-bold font-mono tracking-wider uppercase text-terminal-accent-secondary">The Source Code</h2>
-                </div>
-                <div className="space-y-4 text-terminal-text-secondary font-mono leading-relaxed">
-                  <p>
-                    I've had an interest in weather since I can remember.
-                  </p>
-                  <p>
-                    But this project isn't just about meteorology. It's about the <span className="text-terminal-text-primary font-bold">craft</span>.
-                    I find it incredibly fun to create "shitty websites" as a proxy to learn software development, explore CI/CD pipelines, and push the boundaries of what a web app can be.
-                  </p>
-                  <p>
-                    16-Bit Weather is where <span className="text-terminal-accent">Nostalgia</span> meets a <span className="text-terminal-accent-secondary">Tron-like aesthetic</span>.
-                    It's powered by modern tech agents, but feels like it belongs in an arcade cabinet from 1985.
-                  </p>
-                </div>
-              </div>
+          {/* The Source Code - Justin's Story */}
+          <Accordion title="The Source Code" icon={Terminal} defaultOpen={true}>
+            <div className="space-y-4 font-mono text-sm leading-relaxed text-muted-foreground">
+              <p>
+                I&apos;ve had an interest in weather since I can remember. Growing up watching storms
+                roll in, checking radar obsessively, and trying to understand why the atmosphere does
+                what it does — that curiosity never went away.
+              </p>
+              <p>
+                But this project isn&apos;t just about meteorology. It&apos;s about the{' '}
+                <span className="text-foreground font-bold">craft</span>. I find it incredibly fun
+                to build ambitious web apps as a way to learn software development, explore CI/CD
+                pipelines, and push the boundaries of what a weather platform can be.
+              </p>
+              <p>
+                16-Bit Weather is where{' '}
+                <span className="text-primary">nostalgia</span> meets{' '}
+                <span className="text-primary">modern intelligence</span>.
+                It&apos;s powered by AI agents, real-time government data feeds, and cutting-edge web tech
+                — but feels like it belongs in an arcade cabinet from 1985.
+              </p>
+              <p>
+                Every feature you see here was built with curiosity, late nights, and a belief that
+                weather data doesn&apos;t have to be boring. Use the terminal. Check the radar. Play the game.
+              </p>
             </div>
-          </div>
+          </Accordion>
 
-          {/* TECH STACK CARD */}
-          <div className="group relative">
-            <div className="absolute -inset-1 bg-gradient-to-r from-terminal-accent to-terminal-accent-success opacity-75 blur group-hover:opacity-100 transition duration-1000 group-hover:duration-200"></div>
-            <div className="relative h-full bg-terminal-bg-elevated border-0 p-8 md:p-10">
-              <div className="flex items-center space-x-3 mb-6">
-                <Cpu className="w-8 h-8 text-terminal-accent" />
-                <h2 className="text-2xl font-bold font-mono tracking-wider uppercase text-terminal-accent">Under the Hood</h2>
-              </div>
+          {/* System Architecture */}
+          <Accordion title="System Architecture" icon={Globe}>
+            <div className="space-y-6">
+              <p className="font-mono text-sm text-muted-foreground">
+                16-Bit Weather is a retro-styled weather education platform that combines real-time
+                weather data with pixel-influenced visuals, educational content, interactive games,
+                and tool-backed AI. It monitors weather across the United States through multiple
+                government data sources, updated in real-time.
+              </p>
 
-              <div className="space-y-6">
-                <p className="text-terminal-text-secondary font-mono">
-                  Don't let the pixels fool you. This machine is running on high-octane modern infrastructure.
+              <div className="border border-primary/30 rounded-lg p-5 bg-primary/5">
+                <h3 className="font-mono font-bold text-sm mb-2 flex items-center gap-2">
+                  <Zap className="w-4 h-4 text-primary" />
+                  REAL-TIME INTELLIGENCE
+                </h3>
+                <p className="font-mono text-sm text-muted-foreground">
+                  The platform features a{' '}
+                  <Link href="/situation" className="text-primary underline underline-offset-4 hover:text-primary/80">
+                    Weather Intensity Score (WIS)
+                  </Link>
+                  {' '}— a scoring algorithm that monitors weather severity across the United States in
+                  real-time. Updated every 5 minutes from NWS active alerts, the WIS provides immediate
+                  insight into current weather conditions nationwide.
                 </p>
+              </div>
 
-                <div className="space-y-4">
-                  <div className="flex items-center p-3 border-0 hover:border-terminal-accent transition-colors bg-terminal-bg-secondary">
-                    <Zap className="w-6 h-6 text-terminal-accent-warning mr-4" />
-                    <div>
-                      <div className="font-bold font-mono text-terminal-text-primary">THE ENGINE</div>
-                      <div className="text-sm text-terminal-text-muted font-mono">Next.js 15 (App Router)</div>
-                    </div>
-                  </div>
-
-                  <div className="flex items-center p-3 border-0 hover:border-terminal-accent-success transition-colors bg-terminal-bg-secondary">
-                    <CloudLightning className="w-6 h-6 text-terminal-accent-success mr-4" />
-                    <div>
-                      <div className="font-bold font-mono text-terminal-text-primary">LIVE DATA</div>
-                      <div className="text-sm text-terminal-text-muted font-mono">OpenWeatherMap API + Supabase</div>
-                    </div>
-                  </div>
-
-                  <div className="flex items-center p-3 border-0 hover:border-terminal-accent-secondary transition-colors bg-terminal-bg-secondary">
-                    <Gamepad2 className="w-6 h-6 text-terminal-accent-secondary mr-4" />
-                    <div>
-                      <div className="font-bold font-mono text-terminal-text-primary">THE AESTHETIC</div>
-                      <div className="text-sm text-terminal-text-muted font-mono">TailwindCSS + Framer Motion</div>
-                    </div>
-                  </div>
-                </div>
+              <div className="border border-border rounded-lg p-5 bg-card/30">
+                <h3 className="font-mono font-bold text-sm mb-2 flex items-center gap-2">
+                  <Shield className="w-4 h-4 text-muted-foreground" />
+                  ADVISORY
+                </h3>
+                <p className="font-mono text-xs text-muted-foreground">
+                  While these tools provide valuable weather insights, always follow official warnings
+                  from the National Weather Service and local authorities for safety decisions.
+                </p>
               </div>
             </div>
+          </Accordion>
+
+          {/* Under the Hood */}
+          <Accordion title="Under the Hood" icon={Cpu}>
+            <div className="space-y-4">
+              <p className="font-mono text-sm text-muted-foreground">
+                Don&apos;t let the pixels fool you. This machine is running on high-octane modern infrastructure.
+              </p>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                {[
+                  { icon: Zap, label: "THE ENGINE", value: "Next.js 16 (App Router) + React 19" },
+                  { icon: Database, label: "DATA LAYER", value: "Supabase PostgreSQL + Row-Level Security" },
+                  { icon: CloudLightning, label: "WEATHER DATA", value: "OpenWeatherMap + NOAA + NWS + USGS + NASA" },
+                  { icon: Sparkles, label: "AI ENGINE", value: "Vercel AI SDK + Claude (Anthropic)" },
+                  { icon: Globe, label: "RADAR", value: "NOAA MRMS + Iowa NEXRAD via OpenLayers" },
+                  { icon: Gauge, label: "MONITORING", value: "Sentry + Lighthouse CI (score >= 85)" },
+                  { icon: Gamepad2, label: "AESTHETIC", value: "Tailwind CSS v4 + 5 retro themes" },
+                  { icon: Shield, label: "DEPLOYMENT", value: "Vercel Edge + GitHub Actions CI/CD" },
+                ].map((item) => (
+                  <div key={item.label} className="flex items-center gap-3 p-3 border border-border rounded bg-card/30">
+                    <item.icon className="w-5 h-5 text-primary shrink-0" />
+                    <div>
+                      <div className="font-mono font-bold text-xs">{item.label}</div>
+                      <div className="font-mono text-xs text-muted-foreground">{item.value}</div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </Accordion>
+        </div>
+
+        {/* Available Modules Grid */}
+        <div className="space-y-4">
+          <h2 className="text-xl font-bold font-mono tracking-wider uppercase flex items-center gap-2">
+            <span className="w-2 h-2 rounded-full bg-primary" />
+            Available Modules
+          </h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+            {modules.map((mod) => (
+              <Link
+                key={mod.href}
+                href={mod.href}
+                className="border border-border rounded-lg p-4 bg-card/30 hover:bg-card/60 transition-colors group"
+              >
+                <div className="flex items-center gap-2 mb-2">
+                  <mod.icon className="w-4 h-4 text-primary" />
+                  <h3 className="font-mono font-bold text-sm text-primary group-hover:underline underline-offset-4">
+                    {mod.label.toUpperCase()}
+                  </h3>
+                </div>
+                <p className="font-mono text-xs text-muted-foreground">{mod.desc}</p>
+              </Link>
+            ))}
           </div>
         </div>
 
-        {/* CONNECT / PLAYER 1 SECTION */}
-        <div className="max-w-3xl mx-auto">
-          <div className="border-0 bg-terminal-bg-primary p-2">
-            <div className="border-0 p-8 text-center relative overflow-hidden">
-              {/* Scanline effect */}
-              <div className="absolute inset-0 bg-[linear-gradient(rgba(18,16,16,0)_50%,rgba(0,0,0,0.25)_50%),linear-gradient(90deg,rgba(255,0,0,0.06),rgba(0,255,0,0.02),rgba(0,0,255,0.06))] z-0 pointer-events-none bg-[length:100%_4px,3px_100%]"></div>
+        {/* Connect / Player 1 */}
+        <div className="border border-border rounded-lg p-8 text-center bg-card/30">
+          <div className="w-20 h-20 mx-auto bg-primary/20 border-2 border-primary rounded-full mb-4 flex items-center justify-center">
+            <Terminal className="w-8 h-8 text-primary" />
+          </div>
+          <h3 className="text-xl font-bold font-mono mb-1">PLAYER 1</h3>
+          <p className="text-sm font-mono text-muted-foreground tracking-widest uppercase mb-6">Justin Elrod</p>
 
-              <div className="relative z-10">
-                <div className="w-24 h-24 mx-auto bg-terminal-accent rounded-full mb-6 flex items-center justify-center p-1 cursor-pointer hover:scale-110 transition-transform">
-                  <img
-                    src="https://api.dicebear.com/9.x/avataaars/svg?seed=Felix&top=shortHairSides&accessories=prescription02"
-                    alt="Player 1"
-                    className="w-full h-full rounded-full bg-black"
-                  />
-                </div>
-
-                <h3 className="text-2xl font-bold font-mono text-terminal-text-primary mb-2">PLAYER 1</h3>
-                <p className="text-terminal-accent font-mono text-sm tracking-widest uppercase mb-8">Ready to Connect</p>
-
-                <div className="flex justify-center gap-6">
-                  <a href="https://github.com/deephouse23" target="_blank" rel="noopener noreferrer"
-                    className="group flex flex-col items-center space-y-2">
-                    <div className="w-12 h-12 bg-terminal-bg-secondary border-0 flex items-center justify-center group-hover:border-terminal-text-primary group-hover:bg-terminal-text-primary group-hover:text-terminal-bg-primary transition-all duration-300">
-                      <Github className="w-6 h-6" />
-                    </div>
-                    <span className="text-xs font-mono text-terminal-text-muted group-hover:text-terminal-text-primary">GITHUB</span>
-                  </a>
-
-                  <a href="https://x.com/Justin_Elrod" target="_blank" rel="noopener noreferrer"
-                    className="group flex flex-col items-center space-y-2">
-                    <div className="w-12 h-12 bg-terminal-bg-secondary border-0 flex items-center justify-center group-hover:border-terminal-text-primary group-hover:bg-terminal-text-primary group-hover:text-terminal-bg-primary transition-all duration-300">
-                      <Twitter className="w-6 h-6" />
-                    </div>
-                    <span className="text-xs font-mono text-terminal-text-muted group-hover:text-terminal-text-primary">X</span>
-                  </a>
-
-                  <Link href="/dashboard" className="group flex flex-col items-center space-y-2">
-                    <div className="w-12 h-12 bg-terminal-bg-secondary border-0 flex items-center justify-center group-hover:border-terminal-accent group-hover:bg-terminal-accent group-hover:text-terminal-bg-primary transition-all duration-300">
-                      <Terminal className="w-6 h-6" />
-                    </div>
-                    <span className="text-xs font-mono text-terminal-text-muted group-hover:text-terminal-accent">DASHBOARD</span>
-                  </Link>
-
-                  <Link href="/" className="group flex flex-col items-center space-y-2">
-                    <div className="w-12 h-12 bg-terminal-bg-secondary border-0 flex items-center justify-center group-hover:border-terminal-accent-secondary group-hover:bg-terminal-accent-secondary group-hover:text-terminal-bg-primary transition-all duration-300">
-                      <CloudLightning className="w-6 h-6" />
-                    </div>
-                    <span className="text-xs font-mono text-terminal-text-muted group-hover:text-terminal-accent-secondary">WEATHER</span>
-                  </Link>
-                </div>
+          <div className="flex justify-center gap-6">
+            <a href="https://github.com/deephouse23" target="_blank" rel="noopener noreferrer"
+              className="group flex flex-col items-center gap-2">
+              <div className="w-12 h-12 border border-border rounded-lg flex items-center justify-center group-hover:border-primary group-hover:bg-primary/10 transition-colors">
+                <Github className="w-5 h-5" />
               </div>
-            </div>
+              <span className="text-xs font-mono text-muted-foreground group-hover:text-primary">GITHUB</span>
+            </a>
+            <a href="https://x.com/Justin_Elrod" target="_blank" rel="noopener noreferrer"
+              className="group flex flex-col items-center gap-2">
+              <div className="w-12 h-12 border border-border rounded-lg flex items-center justify-center group-hover:border-primary group-hover:bg-primary/10 transition-colors">
+                <Twitter className="w-5 h-5" />
+              </div>
+              <span className="text-xs font-mono text-muted-foreground group-hover:text-primary">X</span>
+            </a>
+            <Link href="/dashboard" className="group flex flex-col items-center gap-2">
+              <div className="w-12 h-12 border border-border rounded-lg flex items-center justify-center group-hover:border-primary group-hover:bg-primary/10 transition-colors">
+                <Terminal className="w-5 h-5" />
+              </div>
+              <span className="text-xs font-mono text-muted-foreground group-hover:text-primary">DASHBOARD</span>
+            </Link>
           </div>
         </div>
 
       </div>
-    </div>
-  )
+    </PageWrapper>
+  );
 }

--- a/app/api/weather/vibe/route.ts
+++ b/app/api/weather/vibe/route.ts
@@ -1,0 +1,98 @@
+/**
+ * 16-Bit Weather Platform - Vibe Check API Route
+ *
+ * Returns comfort score for current conditions + 7-day forecast.
+ * Proxies through internal onecall route to reuse rate limiting.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { calculateVibeScore, type VibeInput } from '@/lib/services/vibe-check'
+
+function getBaseUrl(): string {
+  if (process.env.NEXT_PUBLIC_BASE_URL) return process.env.NEXT_PUBLIC_BASE_URL
+  if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`
+  return 'http://localhost:3000'
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const searchParams = request.nextUrl.searchParams
+    const lat = searchParams.get('lat')
+    const lon = searchParams.get('lon')
+
+    if (!lat || !lon) {
+      return NextResponse.json({ error: 'Missing required parameters: lat, lon' }, { status: 400 })
+    }
+
+    // Use internal onecall route
+    const baseUrl = getBaseUrl()
+    const url = `${baseUrl}/api/weather/onecall?lat=${lat}&lon=${lon}&units=imperial&exclude=minutely,alerts`
+    const response = await fetch(url)
+
+    if (!response.ok) {
+      console.error('[Vibe API] OneCall failed:', response.status)
+      return NextResponse.json({ error: 'Failed to fetch weather data' }, { status: 502 })
+    }
+
+    const data = await response.json()
+
+    // Current vibe
+    const currentInput: VibeInput = {
+      tempF: data.current?.temp ?? 72,
+      humidity: data.current?.humidity ?? 50,
+      windMph: data.current?.wind_speed ?? 5,
+      precipChance: (data.hourly?.[0]?.pop ?? 0) * 100,
+      uvIndex: data.current?.uvi ?? 3,
+      cloudCover: data.current?.clouds ?? 20,
+    }
+    const current = calculateVibeScore(currentInput)
+
+    // 7-day forecast vibes
+    const daily = (data.daily ?? []).slice(0, 7).map((day: {
+      dt: number
+      temp: { max: number; min: number }
+      humidity: number
+      wind_speed: number
+      pop: number
+      uvi: number
+      clouds: number
+      weather: Array<{ main: string; description: string; icon: string }>
+    }) => {
+      const avgTemp = (day.temp.max + day.temp.min) / 2
+      const input: VibeInput = {
+        tempF: avgTemp,
+        humidity: day.humidity ?? 50,
+        windMph: day.wind_speed ?? 5,
+        precipChance: (day.pop ?? 0) * 100,
+        uvIndex: day.uvi ?? 3,
+        cloudCover: day.clouds ?? 20,
+      }
+      const vibe = calculateVibeScore(input)
+      return {
+        dt: day.dt,
+        highTemp: Math.round(day.temp.max),
+        lowTemp: Math.round(day.temp.min),
+        condition: day.weather?.[0]?.main ?? 'Clear',
+        icon: day.weather?.[0]?.icon ?? '01d',
+        ...vibe,
+      }
+    })
+
+    // Find best day
+    const bestDay = daily.reduce((best: { score: number; dt: number } | null, day: { score: number; dt: number }) =>
+      !best || day.score > best.score ? day : best,
+    null)
+
+    return NextResponse.json({
+      current,
+      daily,
+      bestDay,
+      location: data.timezone ?? '',
+    }, {
+      headers: { 'Cache-Control': 'public, s-maxage=600, stale-while-revalidate=60' },
+    })
+  } catch (error) {
+    console.error('[Vibe API]', error)
+    return NextResponse.json({ error: 'Failed to compute vibe check' }, { status: 500 })
+  }
+}

--- a/app/severe/page.tsx
+++ b/app/severe/page.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+/**
+ * 16-Bit Weather Platform - Severe Weather Page
+ *
+ * Filtered view of NWS alerts for severe thunderstorm,
+ * tornado, wind, hail, and flood warnings.
+ */
+
+import React, { useEffect, useState, useCallback } from 'react';
+import { cn } from '@/lib/utils';
+import { useTheme } from '@/components/theme-provider';
+import { getComponentStyles, type ThemeType } from '@/lib/theme-utils';
+import PageWrapper from '@/components/page-wrapper';
+import type { NWSAlert } from '@/lib/services/nws-alerts-service';
+
+const SEVERE_KEYWORDS = ['tornado', 'thunderstorm', 'wind', 'hail', 'flood'];
+
+const severityBadge: Record<string, string> = {
+  Extreme: 'bg-red-500/20 text-red-400 border-red-500/50',
+  Severe: 'bg-orange-500/20 text-orange-400 border-orange-500/50',
+  Moderate: 'bg-yellow-500/20 text-yellow-400 border-yellow-500/50',
+  Minor: 'bg-blue-500/20 text-blue-400 border-blue-500/50',
+};
+
+function getTimeRemaining(expires: string): string {
+  const diff = new Date(expires).getTime() - Date.now();
+  if (diff <= 0) return 'EXPIRED';
+  const h = Math.floor(diff / 3600000);
+  const m = Math.floor((diff % 3600000) / 60000);
+  return h > 0 ? `${h}h ${m}m left` : `${m}m left`;
+}
+
+export default function SeverePage() {
+  const { theme } = useTheme();
+  getComponentStyles((theme || 'nord') as ThemeType, 'weather');
+  const [alerts, setAlerts] = useState<NWSAlert[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const fetchData = useCallback(async () => {
+    try {
+      const res = await fetch('/api/weather/alerts');
+      if (!res.ok) return;
+      const data = await res.json();
+      const filtered = (data.alerts ?? []).filter((a: NWSAlert) =>
+        SEVERE_KEYWORDS.some(kw => a.event.toLowerCase().includes(kw))
+      );
+      filtered.sort((a: NWSAlert, b: NWSAlert) => {
+        const order: Record<string, number> = { Extreme: 0, Severe: 1, Moderate: 2, Minor: 3 };
+        return (order[a.severity] ?? 4) - (order[b.severity] ?? 4);
+      });
+      setAlerts(filtered);
+    } catch (e) { console.error('[Severe]', e); }
+    finally { setIsLoading(false); }
+  }, []);
+
+  useEffect(() => { fetchData(); const i = setInterval(fetchData, 300000); return () => clearInterval(i); }, [fetchData]);
+
+  return (
+    <PageWrapper>
+      <div className="max-w-7xl mx-auto px-4 py-8 space-y-8">
+        <div className="text-center space-y-2">
+          <h1 className="text-3xl md:text-4xl font-extrabold tracking-tight font-mono uppercase">Severe Weather</h1>
+          <p className="text-sm font-mono text-muted-foreground tracking-wider">// ACTIVE TORNADO, THUNDERSTORM, WIND, HAIL &amp; FLOOD WARNINGS</p>
+        </div>
+
+        {isLoading && <p className="text-center text-lg font-mono text-muted-foreground animate-pulse py-12">SCANNING FOR SEVERE WEATHER...</p>}
+
+        {!isLoading && alerts.length === 0 && (
+          <div className="text-center py-12 border border-border rounded-lg bg-card/30">
+            <p className="text-lg font-mono text-green-400 font-bold">ALL CLEAR</p>
+            <p className="text-sm font-mono text-muted-foreground mt-2">No active severe weather alerts</p>
+          </div>
+        )}
+
+        {!isLoading && alerts.length > 0 && (
+          <div className="space-y-4">
+            <div className="flex items-center justify-between">
+              <h2 className="text-xl font-bold font-mono tracking-wider uppercase">Active Severe Alerts</h2>
+              <span className="text-xs font-mono text-muted-foreground">{alerts.length} active</span>
+            </div>
+            <div className="grid gap-3">
+              {alerts.map((alert, i) => (
+                <div key={alert.id || i} className="border border-border rounded-lg p-4 bg-card/50 hover:bg-card/80 transition-colors">
+                  <div className="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-4">
+                    <div className="flex items-center gap-2 shrink-0">
+                      <span className="text-xs font-mono text-muted-foreground w-8">#{String(i + 1).padStart(2, '0')}</span>
+                      <span className={cn('px-2 py-0.5 rounded text-xs font-mono font-bold border', severityBadge[alert.severity])}>{alert.severity.toUpperCase()}</span>
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <p className="font-mono font-bold text-sm truncate">{alert.event}</p>
+                      <p className="text-xs font-mono text-muted-foreground truncate">{alert.areaDesc}</p>
+                    </div>
+                    {alert.expires && <span className="text-xs font-mono text-muted-foreground shrink-0">{getTimeRemaining(alert.expires)}</span>}
+                  </div>
+                  {alert.headline && <p className="mt-2 text-xs font-mono text-muted-foreground line-clamp-2">{alert.headline}</p>}
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </PageWrapper>
+  );
+}

--- a/app/travel/page.tsx
+++ b/app/travel/page.tsx
@@ -1,0 +1,196 @@
+'use client';
+
+/**
+ * 16-Bit Weather Platform - Travel Weather Page
+ *
+ * Compare weather conditions between two locations for trip planning.
+ */
+
+import React, { useState } from 'react';
+import { cn } from '@/lib/utils';
+import { useTheme } from '@/components/theme-provider';
+import { getComponentStyles, type ThemeType } from '@/lib/theme-utils';
+import PageWrapper from '@/components/page-wrapper';
+import { ArrowRight, MapPin } from 'lucide-react';
+
+interface LocationWeather {
+  name: string;
+  temp: number;
+  feelsLike: number;
+  humidity: number;
+  wind: number;
+  condition: string;
+  description: string;
+}
+
+export default function TravelPage() {
+  const { theme } = useTheme();
+  getComponentStyles((theme || 'nord') as ThemeType, 'weather');
+  const [origin, setOrigin] = useState('');
+  const [destination, setDestination] = useState('');
+  const [originWeather, setOriginWeather] = useState<LocationWeather | null>(null);
+  const [destWeather, setDestWeather] = useState<LocationWeather | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  async function fetchWeatherForLocation(query: string): Promise<LocationWeather | null> {
+    try {
+      const geoRes = await fetch(`/api/weather/geocoding?q=${encodeURIComponent(query)}`);
+      if (!geoRes.ok) return null;
+      const geoData = await geoRes.json();
+      const loc = geoData[0] || geoData;
+      if (!loc?.lat && !loc?.latitude) return null;
+
+      const lat = loc.lat ?? loc.latitude;
+      const lon = loc.lon ?? loc.longitude;
+      const name = loc.name ?? query;
+
+      const wxRes = await fetch(`/api/weather/current?lat=${lat}&lon=${lon}&units=imperial`);
+      if (!wxRes.ok) return null;
+      const wx = await wxRes.json();
+
+      return {
+        name,
+        temp: Math.round(wx.main?.temp ?? 0),
+        feelsLike: Math.round(wx.main?.feels_like ?? 0),
+        humidity: wx.main?.humidity ?? 0,
+        wind: Math.round(wx.wind?.speed ?? 0),
+        condition: wx.weather?.[0]?.main ?? 'Unknown',
+        description: wx.weather?.[0]?.description ?? '',
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  async function handleCompare() {
+    if (!origin.trim() || !destination.trim()) return;
+    setIsLoading(true);
+    setError('');
+    setOriginWeather(null);
+    setDestWeather(null);
+
+    const [o, d] = await Promise.all([
+      fetchWeatherForLocation(origin),
+      fetchWeatherForLocation(destination),
+    ]);
+
+    if (!o || !d) {
+      setError('Could not find weather for one or both locations. Try "City, State" format.');
+    } else {
+      setOriginWeather(o);
+      setDestWeather(d);
+    }
+    setIsLoading(false);
+  }
+
+  function WeatherCard({ data, label }: { data: LocationWeather; label: string }) {
+    return (
+      <div className="border border-border rounded-lg p-6 bg-card/30 flex-1">
+        <p className="text-xs font-mono text-muted-foreground tracking-wider mb-1">{label}</p>
+        <h3 className="text-lg font-bold font-mono flex items-center gap-2 mb-4">
+          <MapPin className="w-4 h-4 text-primary" />
+          {data.name}
+        </h3>
+        <div className="space-y-3">
+          <div className="text-center">
+            <span className="text-5xl font-extrabold font-mono">{data.temp}</span>
+            <span className="text-lg font-mono text-muted-foreground">°F</span>
+            <p className="text-sm font-mono text-muted-foreground capitalize mt-1">{data.description}</p>
+          </div>
+          <div className="grid grid-cols-3 gap-2 pt-3 border-t border-border">
+            <div className="text-center">
+              <p className="text-xs font-mono text-muted-foreground">FEELS LIKE</p>
+              <p className="font-mono font-bold">{data.feelsLike}°</p>
+            </div>
+            <div className="text-center">
+              <p className="text-xs font-mono text-muted-foreground">HUMIDITY</p>
+              <p className="font-mono font-bold">{data.humidity}%</p>
+            </div>
+            <div className="text-center">
+              <p className="text-xs font-mono text-muted-foreground">WIND</p>
+              <p className="font-mono font-bold">{data.wind} mph</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <PageWrapper>
+      <div className="max-w-5xl mx-auto px-4 py-8 space-y-8">
+        <div className="text-center space-y-2">
+          <h1 className="text-3xl md:text-4xl font-extrabold tracking-tight font-mono uppercase">Travel Weather</h1>
+          <p className="text-sm font-mono text-muted-foreground tracking-wider">// COMPARE CONDITIONS // PLAN YOUR TRIP</p>
+        </div>
+
+        {/* Search Form */}
+        <div className="flex flex-col md:flex-row items-center gap-3 max-w-3xl mx-auto">
+          <input
+            type="text"
+            placeholder="Origin (e.g. New York, NY)"
+            value={origin}
+            onChange={(e) => setOrigin(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && handleCompare()}
+            className="flex-1 w-full px-4 py-3 bg-card/50 border border-border rounded-lg font-mono text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+          />
+          <ArrowRight className="w-5 h-5 text-muted-foreground shrink-0 hidden md:block" />
+          <input
+            type="text"
+            placeholder="Destination (e.g. Miami, FL)"
+            value={destination}
+            onChange={(e) => setDestination(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && handleCompare()}
+            className="flex-1 w-full px-4 py-3 bg-card/50 border border-border rounded-lg font-mono text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+          />
+          <button
+            onClick={handleCompare}
+            disabled={isLoading || !origin.trim() || !destination.trim()}
+            className={cn(
+              "px-6 py-3 rounded-lg font-mono font-bold text-sm transition-colors shrink-0",
+              "bg-primary text-primary-foreground hover:bg-primary/90",
+              "disabled:opacity-50 disabled:cursor-not-allowed"
+            )}
+          >
+            {isLoading ? 'LOADING...' : 'COMPARE'}
+          </button>
+        </div>
+
+        {error && <p className="text-center text-sm font-mono text-orange-400">{error}</p>}
+
+        {isLoading && <p className="text-center text-lg font-mono text-muted-foreground animate-pulse py-12">COMPUTING TRAVEL CONDITIONS...</p>}
+
+        {/* Results */}
+        {originWeather && destWeather && (
+          <div className="space-y-6">
+            <div className="flex flex-col md:flex-row gap-6">
+              <WeatherCard data={originWeather} label="ORIGIN" />
+              <WeatherCard data={destWeather} label="DESTINATION" />
+            </div>
+
+            {/* Comparison Summary */}
+            <div className="border border-border rounded-lg p-5 bg-card/30 text-center">
+              <p className="font-mono text-sm text-muted-foreground mb-2">TRAVEL ADVISORY</p>
+              <p className="font-mono font-bold">
+                {destWeather.temp > originWeather.temp
+                  ? `${destWeather.name} is ${destWeather.temp - originWeather.temp}° warmer than ${originWeather.name}`
+                  : destWeather.temp < originWeather.temp
+                    ? `${destWeather.name} is ${originWeather.temp - destWeather.temp}° cooler than ${originWeather.name}`
+                    : `Both locations are the same temperature`
+                }
+              </p>
+            </div>
+          </div>
+        )}
+
+        {/* Empty State */}
+        {!isLoading && !originWeather && !destWeather && !error && (
+          <div className="text-center py-12 border border-border rounded-lg bg-card/30">
+            <p className="text-lg font-mono text-muted-foreground">Enter two locations to compare weather conditions</p>
+          </div>
+        )}
+      </div>
+    </PageWrapper>
+  );
+}

--- a/app/tropical/page.tsx
+++ b/app/tropical/page.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+/**
+ * 16-Bit Weather Platform - Tropical Tracker Page
+ *
+ * NHC tropical outlooks, satellite imagery, and hurricane season info.
+ */
+
+import React from 'react';
+import { cn } from '@/lib/utils';
+import { useTheme } from '@/components/theme-provider';
+import { getComponentStyles, type ThemeType } from '@/lib/theme-utils';
+import PageWrapper from '@/components/page-wrapper';
+import { ExternalLink } from 'lucide-react';
+
+const NHC_BASE = 'https://www.nhc.noaa.gov';
+
+const graphics = [
+  {
+    title: '2-DAY TROPICAL OUTLOOK',
+    desc: '48-hour tropical weather formation potential for the Atlantic Basin',
+    src: `${NHC_BASE}/xgtwo/two_atl_2d0.png`,
+    link: `${NHC_BASE}/gtwo.php`,
+  },
+  {
+    title: '7-DAY TROPICAL OUTLOOK',
+    desc: 'Extended tropical weather formation potential for the Atlantic Basin',
+    src: `${NHC_BASE}/xgtwo/two_atl_5d0.png`,
+    link: `${NHC_BASE}/gtwo.php`,
+  },
+  {
+    title: 'ATLANTIC SATELLITE',
+    desc: 'Real-time visible satellite loop of the Atlantic hurricane basin',
+    src: `${NHC_BASE}/satellite/satellite_atl_loop-vis.gif`,
+    link: `${NHC_BASE}/satellite.php`,
+  },
+  {
+    title: 'SEA SURFACE TEMPERATURE',
+    desc: 'Pacific sea surface temperature analysis — fuel for tropical development',
+    src: `${NHC_BASE}/tafb/pac_sst.gif`,
+    link: `${NHC_BASE}/tafb_latest.php`,
+  },
+];
+
+export default function TropicalPage() {
+  const { theme } = useTheme();
+  getComponentStyles((theme || 'nord') as ThemeType, 'weather');
+
+  return (
+    <PageWrapper>
+      <div className="max-w-7xl mx-auto px-4 py-8 space-y-8">
+        <div className="text-center space-y-2">
+          <h1 className="text-3xl md:text-4xl font-extrabold tracking-tight font-mono uppercase">Tropical Tracker</h1>
+          <p className="text-sm font-mono text-muted-foreground tracking-wider">// NHC OUTLOOKS // ATLANTIC BASIN // SATELLITE IMAGERY</p>
+        </div>
+
+        {/* NHC Graphics Grid */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          {graphics.map((g) => (
+            <div key={g.title} className="border border-border rounded-lg overflow-hidden bg-card/30">
+              <div className="p-4 border-b border-border">
+                <h3 className="font-mono font-bold text-sm">{g.title}</h3>
+                <p className="font-mono text-xs text-muted-foreground mt-1">{g.desc}</p>
+              </div>
+              <div className="relative aspect-[4/3] bg-black">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={g.src}
+                  alt={g.title}
+                  className="w-full h-full object-contain"
+                  loading="lazy"
+                />
+              </div>
+              <a
+                href={g.link}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-2 p-3 text-xs font-mono text-primary hover:bg-card/60 transition-colors border-t border-border"
+              >
+                <ExternalLink className="w-3 h-3" />
+                VIEW ON NHC
+              </a>
+            </div>
+          ))}
+        </div>
+
+        {/* Info */}
+        <div className="border border-border rounded-lg p-6 bg-card/30 text-center">
+          <p className="font-mono text-sm text-muted-foreground">
+            Data sourced from the{' '}
+            <a href={NHC_BASE} target="_blank" rel="noopener noreferrer" className="text-primary underline underline-offset-4">
+              NOAA National Hurricane Center
+            </a>
+            . Atlantic hurricane season runs <span className="text-foreground font-bold">June 1 - November 30</span>.
+            Eastern Pacific season runs <span className="text-foreground font-bold">May 15 - November 30</span>.
+          </p>
+        </div>
+      </div>
+    </PageWrapper>
+  );
+}

--- a/app/vibe-check/page.tsx
+++ b/app/vibe-check/page.tsx
@@ -1,0 +1,220 @@
+'use client';
+
+/**
+ * 16-Bit Weather Platform - Vibe Check Page
+ *
+ * "What's the vibe today?" — Comfort scoring for your location.
+ * Categories: Rough → Meh → Decent → Vibin → Immaculate
+ */
+
+import React, { useEffect, useState, useCallback } from 'react';
+import { cn } from '@/lib/utils';
+import { useTheme } from '@/components/theme-provider';
+import { getComponentStyles, type ThemeType } from '@/lib/theme-utils';
+import PageWrapper from '@/components/page-wrapper';
+import type { VibeResult } from '@/lib/services/vibe-check';
+
+interface DailyVibe extends VibeResult {
+  dt: number;
+  highTemp: number;
+  lowTemp: number;
+  condition: string;
+  icon: string;
+}
+
+interface VibeData {
+  current: VibeResult | null;
+  daily: DailyVibe[];
+  bestDay: { dt: number; score: number } | null;
+  location: string;
+}
+
+const categoryColors: Record<string, string> = {
+  Immaculate: 'text-emerald-400 border-emerald-500/40 bg-emerald-500/10',
+  Vibin: 'text-green-400 border-green-500/40 bg-green-500/10',
+  Decent: 'text-yellow-400 border-yellow-500/40 bg-yellow-500/10',
+  Meh: 'text-orange-400 border-orange-500/40 bg-orange-500/10',
+  Rough: 'text-red-400 border-red-500/40 bg-red-500/10',
+};
+
+const categoryEmoji: Record<string, string> = {
+  Immaculate: '✨',
+  Vibin: '😎',
+  Decent: '👍',
+  Meh: '😐',
+  Rough: '💀',
+};
+
+function getDayName(dt: number, index: number): string {
+  if (index === 0) return 'Today';
+  if (index === 1) return 'Tomorrow';
+  return new Date(dt * 1000).toLocaleDateString('en-US', { weekday: 'short' });
+}
+
+function getDayDate(dt: number): string {
+  return new Date(dt * 1000).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
+const breakdownLabels: Record<string, { label: string; icon: string }> = {
+  temperature: { label: 'TEMP', icon: '🌡' },
+  humidity: { label: 'HUMIDITY', icon: '💧' },
+  wind: { label: 'WIND', icon: '💨' },
+  precipitation: { label: 'PRECIP', icon: '🌧' },
+  uv: { label: 'UV', icon: '☀' },
+  clouds: { label: 'CLOUDS', icon: '☁' },
+};
+
+export default function VibeCheckPage() {
+  const { theme } = useTheme();
+  const themeClasses = getComponentStyles((theme || 'nord') as ThemeType, 'weather');
+  const [data, setData] = useState<VibeData>({ current: null, daily: [], bestDay: null, location: '' });
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [selectedDay, setSelectedDay] = useState(0);
+
+  const fetchVibe = useCallback(async () => {
+    try {
+      // Get user location
+      const pos = await new Promise<GeolocationPosition>((resolve, reject) => {
+        navigator.geolocation.getCurrentPosition(resolve, reject, { timeout: 10000 });
+      });
+
+      const { latitude, longitude } = pos.coords;
+      const response = await fetch(`/api/weather/vibe?lat=${latitude}&lon=${longitude}`);
+
+      if (!response.ok) throw new Error('Failed to fetch vibe data');
+
+      const json = await response.json();
+      setData(json);
+    } catch (err) {
+      console.error('[Vibe Check]', err);
+      setError('Could not get your location. Enable location access to check the vibe.');
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchVibe();
+  }, [fetchVibe]);
+
+  const displayVibe = selectedDay === 0 ? data.current : data.daily[selectedDay] ?? null;
+
+  return (
+    <PageWrapper>
+      <div className="max-w-5xl mx-auto px-4 py-8 space-y-8">
+        {/* Header */}
+        <div className="text-center space-y-2">
+          <h1 className="text-3xl md:text-4xl font-extrabold tracking-tight font-mono uppercase">
+            Vibe Check
+          </h1>
+          <p className="text-sm font-mono text-muted-foreground tracking-wider">
+            // OUTDOOR COMFORT SCORE // WHAT&apos;S THE VIBE TODAY?
+          </p>
+        </div>
+
+        {/* Loading */}
+        {isLoading && (
+          <div className="text-center py-16">
+            <p className="text-lg font-mono text-muted-foreground animate-pulse">
+              CHECKING THE VIBE...
+            </p>
+          </div>
+        )}
+
+        {/* Error */}
+        {error && !isLoading && (
+          <div className="text-center py-16 border border-border rounded-lg bg-card/30">
+            <p className="text-lg font-mono text-orange-400">{error}</p>
+          </div>
+        )}
+
+        {/* Main Score */}
+        {displayVibe && !isLoading && (
+          <>
+            <div className={cn(
+              'border rounded-lg p-8 text-center',
+              categoryColors[displayVibe.category]
+            )}>
+              <p className="text-xs font-mono tracking-widest text-muted-foreground uppercase mb-2">
+                {selectedDay === 0 ? 'Current Vibe' : getDayName(data.daily[selectedDay]?.dt ?? 0, selectedDay)}
+              </p>
+              <div className="flex items-center justify-center gap-4 mb-2">
+                <span className="text-5xl">{categoryEmoji[displayVibe.category]}</span>
+                <span className="text-7xl md:text-8xl font-extrabold font-mono">{displayVibe.score}</span>
+                <span className="text-lg font-mono text-muted-foreground self-end mb-2">/ 100</span>
+              </div>
+              <p className={cn('text-2xl font-bold font-mono tracking-wider', categoryColors[displayVibe.category]?.split(' ')[0])}>
+                {displayVibe.category.toUpperCase()}
+              </p>
+            </div>
+
+            {/* Breakdown Grid */}
+            <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+              {Object.entries(displayVibe.breakdown).map(([key, value]) => {
+                const info = breakdownLabels[key];
+                if (!info) return null;
+                const barColor = value >= 80 ? 'bg-emerald-500' : value >= 60 ? 'bg-green-500' : value >= 40 ? 'bg-yellow-500' : value >= 20 ? 'bg-orange-500' : 'bg-red-500';
+                return (
+                  <div key={key} className="border border-border rounded-lg p-4 bg-card/30">
+                    <div className="flex items-center gap-2 mb-2">
+                      <span>{info.icon}</span>
+                      <span className="text-xs font-mono text-muted-foreground tracking-wider">{info.label}</span>
+                    </div>
+                    <p className="text-2xl font-bold font-mono mb-2">{value}</p>
+                    <div className="w-full bg-muted/30 rounded-full h-2">
+                      <div className={cn('h-2 rounded-full transition-all', barColor)} style={{ width: `${value}%` }} />
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </>
+        )}
+
+        {/* 7-Day Forecast */}
+        {data.daily.length > 0 && !isLoading && (
+          <div className="space-y-4">
+            <h2 className="text-xl font-bold font-mono tracking-wider uppercase">
+              7-Day Vibe Forecast
+            </h2>
+            <div className="grid grid-cols-7 gap-2">
+              {data.daily.map((day, i) => {
+                const isSelected = i === selectedDay;
+                const isBest = data.bestDay?.dt === day.dt;
+                return (
+                  <button
+                    key={day.dt}
+                    onClick={() => setSelectedDay(i)}
+                    className={cn(
+                      'border rounded-lg p-3 text-center transition-all font-mono',
+                      isSelected
+                        ? cn('border-2', categoryColors[day.category])
+                        : 'border-border bg-card/30 hover:bg-card/60',
+                    )}
+                  >
+                    <p className="text-xs text-muted-foreground">{getDayName(day.dt, i)}</p>
+                    <p className="text-xs text-muted-foreground">{getDayDate(day.dt)}</p>
+                    <p className={cn(
+                      'text-2xl font-extrabold my-1',
+                      isSelected ? categoryColors[day.category]?.split(' ')[0] : ''
+                    )}>
+                      {day.score}
+                    </p>
+                    <p className="text-xs font-bold">{day.category}</p>
+                    <p className="text-xs text-muted-foreground mt-1">
+                      {day.highTemp}° / {day.lowTemp}°
+                    </p>
+                    {isBest && (
+                      <span className="text-xs text-emerald-400 font-bold">BEST</span>
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        )}
+      </div>
+    </PageWrapper>
+  );
+}

--- a/app/winter/page.tsx
+++ b/app/winter/page.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+/**
+ * 16-Bit Weather Platform - Winter Weather Page
+ *
+ * Filtered view of NWS alerts for winter storms, blizzards,
+ * ice, snow, and freeze warnings.
+ */
+
+import React, { useEffect, useState, useCallback } from 'react';
+import { cn } from '@/lib/utils';
+import { useTheme } from '@/components/theme-provider';
+import { getComponentStyles, type ThemeType } from '@/lib/theme-utils';
+import PageWrapper from '@/components/page-wrapper';
+import type { NWSAlert } from '@/lib/services/nws-alerts-service';
+
+const WINTER_KEYWORDS = ['winter', 'snow', 'ice', 'blizzard', 'freeze', 'cold', 'wind chill', 'frost'];
+
+const severityBadge: Record<string, string> = {
+  Extreme: 'bg-red-500/20 text-red-400 border-red-500/50',
+  Severe: 'bg-orange-500/20 text-orange-400 border-orange-500/50',
+  Moderate: 'bg-yellow-500/20 text-yellow-400 border-yellow-500/50',
+  Minor: 'bg-blue-500/20 text-blue-400 border-blue-500/50',
+};
+
+function getTimeRemaining(expires: string): string {
+  const diff = new Date(expires).getTime() - Date.now();
+  if (diff <= 0) return 'EXPIRED';
+  const h = Math.floor(diff / 3600000);
+  const m = Math.floor((diff % 3600000) / 60000);
+  return h > 0 ? `${h}h ${m}m left` : `${m}m left`;
+}
+
+export default function WinterPage() {
+  const { theme } = useTheme();
+  getComponentStyles((theme || 'nord') as ThemeType, 'weather');
+  const [alerts, setAlerts] = useState<NWSAlert[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const fetchData = useCallback(async () => {
+    try {
+      const res = await fetch('/api/weather/alerts');
+      if (!res.ok) return;
+      const data = await res.json();
+      const filtered = (data.alerts ?? []).filter((a: NWSAlert) =>
+        WINTER_KEYWORDS.some(kw => a.event.toLowerCase().includes(kw))
+      );
+      filtered.sort((a: NWSAlert, b: NWSAlert) => {
+        const order: Record<string, number> = { Extreme: 0, Severe: 1, Moderate: 2, Minor: 3 };
+        return (order[a.severity] ?? 4) - (order[b.severity] ?? 4);
+      });
+      setAlerts(filtered);
+    } catch (e) { console.error('[Winter]', e); }
+    finally { setIsLoading(false); }
+  }, []);
+
+  useEffect(() => { fetchData(); const i = setInterval(fetchData, 300000); return () => clearInterval(i); }, [fetchData]);
+
+  return (
+    <PageWrapper>
+      <div className="max-w-7xl mx-auto px-4 py-8 space-y-8">
+        <div className="text-center space-y-2">
+          <h1 className="text-3xl md:text-4xl font-extrabold tracking-tight font-mono uppercase">Winter Weather</h1>
+          <p className="text-sm font-mono text-muted-foreground tracking-wider">// WINTER STORM, BLIZZARD, ICE &amp; SNOW WARNINGS</p>
+        </div>
+
+        {isLoading && <p className="text-center text-lg font-mono text-muted-foreground animate-pulse py-12">SCANNING FOR WINTER WEATHER...</p>}
+
+        {!isLoading && alerts.length === 0 && (
+          <div className="text-center py-12 border border-border rounded-lg bg-card/30">
+            <p className="text-lg font-mono text-blue-400 font-bold">NO WINTER ALERTS</p>
+            <p className="text-sm font-mono text-muted-foreground mt-2">No active winter weather advisories across the United States</p>
+          </div>
+        )}
+
+        {!isLoading && alerts.length > 0 && (
+          <div className="space-y-4">
+            <div className="flex items-center justify-between">
+              <h2 className="text-xl font-bold font-mono tracking-wider uppercase">Active Winter Alerts</h2>
+              <span className="text-xs font-mono text-muted-foreground">{alerts.length} active</span>
+            </div>
+            <div className="grid gap-3">
+              {alerts.map((alert, i) => (
+                <div key={alert.id || i} className="border border-border rounded-lg p-4 bg-card/50 hover:bg-card/80 transition-colors">
+                  <div className="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-4">
+                    <div className="flex items-center gap-2 shrink-0">
+                      <span className="text-xs font-mono text-muted-foreground w-8">#{String(i + 1).padStart(2, '0')}</span>
+                      <span className={cn('px-2 py-0.5 rounded text-xs font-mono font-bold border', severityBadge[alert.severity])}>{alert.severity.toUpperCase()}</span>
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <p className="font-mono font-bold text-sm truncate">{alert.event}</p>
+                      <p className="text-xs font-mono text-muted-foreground truncate">{alert.areaDesc}</p>
+                    </div>
+                    {alert.expires && <span className="text-xs font-mono text-muted-foreground shrink-0">{getTimeRemaining(alert.expires)}</span>}
+                  </div>
+                  {alert.headline && <p className="mt-2 text-xs font-mono text-muted-foreground line-clamp-2">{alert.headline}</p>}
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </PageWrapper>
+  );
+}

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -18,7 +18,7 @@
 import { useState } from "react"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
-import { Menu, X, Home, Map, Plane, GraduationCap, Gamepad2, Newspaper, Sparkles, Sun } from "lucide-react"
+import { Menu, X, Home, Map, Plane, GraduationCap, Gamepad2, Newspaper, Sparkles, Sun, Thermometer } from "lucide-react"
 import { useTheme } from "@/components/theme-provider"
 import { getComponentStyles, type ThemeType } from "@/lib/theme-utils"
 import AuthButton from "@/components/auth/auth-button"
@@ -126,6 +126,7 @@ export default function Navigation({ weatherLocation, weatherTemperature, weathe
     { href: "/education", label: "EDUCATION", icon: GraduationCap },
     { href: "/games", label: "GAMES", icon: Gamepad2 },
     { href: "/news", label: "NEWS", icon: Newspaper },
+    { href: "/vibe-check", label: "VIBE", icon: Thermometer },
     { href: "/ai", label: "AI", icon: Sparkles }
   ]
 

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -18,7 +18,7 @@
 import { useState } from "react"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
-import { Menu, X, Home, Map, Plane, GraduationCap, Gamepad2, Newspaper, Sparkles, Sun, Thermometer } from "lucide-react"
+import { Menu, X, Home, Map, Plane, GraduationCap, Gamepad2, Newspaper, Sparkles, Sun, Thermometer, ChevronDown, Cloud, Wrench, AlertTriangle } from "lucide-react"
 import { useTheme } from "@/components/theme-provider"
 import { getComponentStyles, type ThemeType } from "@/lib/theme-utils"
 import AuthButton from "@/components/auth/auth-button"
@@ -40,6 +40,8 @@ interface NavigationProps {
  */
 export default function Navigation({ weatherLocation, weatherTemperature, weatherUnit }: NavigationProps) {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
+  const [weatherMenuOpen, setWeatherMenuOpen] = useState(false)
+  const [toolsMenuOpen, setToolsMenuOpen] = useState(false)
   const pathname = usePathname()
   const { theme } = useTheme()
 
@@ -118,17 +120,40 @@ export default function Navigation({ weatherLocation, weatherTemperature, weathe
   };
 
 
-  const mainNavItems = [
+  const topNavItems = [
     { href: "/", label: "HOME", icon: Home },
+  ]
+
+  const weatherItems = [
     { href: "/radar", label: "RADAR", icon: Map },
     { href: "/aviation", label: "AVIATION", icon: Plane },
     { href: "/space-weather", label: "SPACE", icon: Sun },
+    { href: "/situation", label: "SITUATION", icon: AlertTriangle },
+    { href: "/vibe-check", label: "VIBE CHECK", icon: Thermometer },
+  ]
+
+  const toolsItems = [
     { href: "/education", label: "EDUCATION", icon: GraduationCap },
     { href: "/games", label: "GAMES", icon: Gamepad2 },
-    { href: "/news", label: "NEWS", icon: Newspaper },
-    { href: "/vibe-check", label: "VIBE", icon: Thermometer },
-    { href: "/ai", label: "AI", icon: Sparkles }
   ]
+
+  const rightNavItems = [
+    { href: "/news", label: "NEWS", icon: Newspaper },
+    { href: "/ai", label: "AI", icon: Sparkles },
+  ]
+
+  // All items flat for mobile menu
+  const allNavItems = [
+    ...topNavItems,
+    ...weatherItems,
+    ...toolsItems,
+    ...rightNavItems,
+  ]
+
+  const weatherPaths = weatherItems.map(i => i.href)
+  const toolsPaths = toolsItems.map(i => i.href)
+  const isWeatherActive = weatherPaths.includes(pathname)
+  const isToolsActive = toolsPaths.includes(pathname)
 
   return (
     <>
@@ -154,24 +179,101 @@ export default function Navigation({ weatherLocation, weatherTemperature, weathe
 
           {/* Main Navigation Links - TOP CENTER */}
           <div className="flex items-center space-x-1">
-            {mainNavItems.map((item) => {
+            {/* Home */}
+            {topNavItems.map((item) => {
               const Icon = item.icon
               const isActive = pathname === item.href
-
               return (
-                <Button
-                  key={item.href}
-                  variant={isActive ? "secondary" : "ghost"}
-                  size="sm"
-                  asChild
-                  className={cn(
-                    "font-semibold transition-all duration-200",
-                    isActive && "font-bold shadow-sm"
-                  )}
-                >
+                <Button key={item.href} variant={isActive ? "secondary" : "ghost"} size="sm" asChild
+                  className={cn("font-semibold transition-all duration-200", isActive && "font-bold shadow-sm")}>
                   <Link href={item.href} className="flex items-center gap-2">
-                    <Icon className="w-4 h-4" />
-                    <span>{item.label}</span>
+                    <Icon className="w-4 h-4" /><span>{item.label}</span>
+                  </Link>
+                </Button>
+              )
+            })}
+
+            {/* Weather Dropdown */}
+            <div className="relative"
+              onMouseEnter={() => setWeatherMenuOpen(true)}
+              onMouseLeave={() => setWeatherMenuOpen(false)}
+            >
+              <Button
+                variant={isWeatherActive ? "secondary" : "ghost"}
+                size="sm"
+                className={cn("font-semibold transition-all duration-200 gap-1", isWeatherActive && "font-bold shadow-sm")}
+                onClick={() => setWeatherMenuOpen(!weatherMenuOpen)}
+              >
+                <Cloud className="w-4 h-4" />
+                <span>Weather</span>
+                <ChevronDown className={cn("w-3 h-3 transition-transform", weatherMenuOpen && "rotate-180")} />
+              </Button>
+              {weatherMenuOpen && (
+                <div className="absolute top-full left-0 mt-1 w-48 rounded-lg border border-border bg-background/95 backdrop-blur-lg shadow-xl animate-in slide-in-from-top-2 z-50 py-1">
+                  {weatherItems.map((item) => {
+                    const Icon = item.icon
+                    const isActive = pathname === item.href
+                    return (
+                      <Link key={item.href} href={item.href}
+                        className={cn(
+                          "flex items-center gap-3 px-4 py-2.5 text-sm font-semibold transition-colors",
+                          isActive ? "bg-secondary text-secondary-foreground" : "text-foreground hover:bg-muted"
+                        )}
+                        onClick={() => setWeatherMenuOpen(false)}
+                      >
+                        <Icon className="w-4 h-4" />{item.label}
+                      </Link>
+                    )
+                  })}
+                </div>
+              )}
+            </div>
+
+            {/* Tools Dropdown */}
+            <div className="relative"
+              onMouseEnter={() => setToolsMenuOpen(true)}
+              onMouseLeave={() => setToolsMenuOpen(false)}
+            >
+              <Button
+                variant={isToolsActive ? "secondary" : "ghost"}
+                size="sm"
+                className={cn("font-semibold transition-all duration-200 gap-1", isToolsActive && "font-bold shadow-sm")}
+                onClick={() => setToolsMenuOpen(!toolsMenuOpen)}
+              >
+                <Wrench className="w-4 h-4" />
+                <span>Tools</span>
+                <ChevronDown className={cn("w-3 h-3 transition-transform", toolsMenuOpen && "rotate-180")} />
+              </Button>
+              {toolsMenuOpen && (
+                <div className="absolute top-full left-0 mt-1 w-48 rounded-lg border border-border bg-background/95 backdrop-blur-lg shadow-xl animate-in slide-in-from-top-2 z-50 py-1">
+                  {toolsItems.map((item) => {
+                    const Icon = item.icon
+                    const isActive = pathname === item.href
+                    return (
+                      <Link key={item.href} href={item.href}
+                        className={cn(
+                          "flex items-center gap-3 px-4 py-2.5 text-sm font-semibold transition-colors",
+                          isActive ? "bg-secondary text-secondary-foreground" : "text-foreground hover:bg-muted"
+                        )}
+                        onClick={() => setToolsMenuOpen(false)}
+                      >
+                        <Icon className="w-4 h-4" />{item.label}
+                      </Link>
+                    )
+                  })}
+                </div>
+              )}
+            </div>
+
+            {/* News, AI */}
+            {rightNavItems.map((item) => {
+              const Icon = item.icon
+              const isActive = pathname === item.href
+              return (
+                <Button key={item.href} variant={isActive ? "secondary" : "ghost"} size="sm" asChild
+                  className={cn("font-semibold transition-all duration-200", isActive && "font-bold shadow-sm")}>
+                  <Link href={item.href} className="flex items-center gap-2">
+                    <Icon className="w-4 h-4" /><span>{item.label}</span>
                   </Link>
                 </Button>
               )
@@ -230,7 +332,7 @@ export default function Navigation({ weatherLocation, weatherTemperature, weathe
           >
             <div className="p-4 space-y-2">
               {/* All main nav items */}
-              {mainNavItems.map((item) => {
+              {allNavItems.map((item) => {
                 const Icon = item.icon
                 const isActive = pathname === item.href
 

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -18,7 +18,7 @@
 import { useState } from "react"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
-import { Menu, X, Home, Map, Plane, GraduationCap, Gamepad2, Newspaper, Sparkles, Sun, Thermometer, ChevronDown, Cloud, Wrench, AlertTriangle } from "lucide-react"
+import { Menu, X, Home, Map, Plane, GraduationCap, Gamepad2, Newspaper, Sparkles, Sun, Thermometer, ChevronDown, Cloud, Wrench, AlertTriangle, CloudLightning, Snowflake, CloudRain, Route, Info } from "lucide-react"
 import { useTheme } from "@/components/theme-provider"
 import { getComponentStyles, type ThemeType } from "@/lib/theme-utils"
 import AuthButton from "@/components/auth/auth-button"
@@ -126,9 +126,13 @@ export default function Navigation({ weatherLocation, weatherTemperature, weathe
 
   const weatherItems = [
     { href: "/radar", label: "RADAR", icon: Map },
+    { href: "/situation", label: "SITUATION", icon: AlertTriangle },
+    { href: "/severe", label: "SEVERE", icon: CloudLightning },
+    { href: "/winter", label: "WINTER", icon: Snowflake },
+    { href: "/tropical", label: "TROPICAL", icon: CloudRain },
+    { href: "/travel", label: "TRAVEL", icon: Route },
     { href: "/aviation", label: "AVIATION", icon: Plane },
     { href: "/space-weather", label: "SPACE", icon: Sun },
-    { href: "/situation", label: "SITUATION", icon: AlertTriangle },
     { href: "/vibe-check", label: "VIBE CHECK", icon: Thermometer },
   ]
 
@@ -140,6 +144,7 @@ export default function Navigation({ weatherLocation, weatherTemperature, weathe
   const rightNavItems = [
     { href: "/news", label: "NEWS", icon: Newspaper },
     { href: "/ai", label: "AI", icon: Sparkles },
+    { href: "/about", label: "ABOUT", icon: Info },
   ]
 
   // All items flat for mobile menu

--- a/lib/ai/tools.ts
+++ b/lib/ai/tools.ts
@@ -10,6 +10,7 @@
  */
 
 import { tool } from 'ai';
+import { calculateVibeScore, type VibeInput } from '@/lib/services/vibe-check';
 import { z } from 'zod';
 import {
     fetchRecentEarthquakes,
@@ -502,6 +503,54 @@ export const weatherTools = {
                 aviation_alerts: aviationData?.hasActiveAlerts
                     ? { count: aviationData.alertCount, details: aviationData.contextBlock }
                     : { count: 0, message: 'No active aviation advisories' },
+            };
+        },
+    }),
+
+
+    // 11. Vibe check / comfort score
+    get_vibe_check: tool({
+        description:
+            'Get the outdoor comfort "vibe check" score for a location. Returns a 0-100 score with category (Rough/Meh/Decent/Vibin/Immaculate) and component breakdown. Use when someone asks "how nice is it outside?" or "is it a good day to go out?" or "whats the vibe?"',
+        inputSchema: z.object({
+            location: z.string().describe('City name, ZIP code, or "City, State" format'),
+        }),
+        execute: async ({ location }) => {
+            const coords = await geocodeLocation(location);
+            if (!coords) return { error: `Could not find location: ${location}` };
+
+            const apiKey = OWM_KEY();
+            const url = `https://api.openweathermap.org/data/3.0/onecall?lat=${coords.lat}&lon=${coords.lon}&units=imperial&exclude=minutely,alerts&appid=${apiKey}`;
+            const { data, error } = await safeFetch(url, 'Weather data unavailable');
+            if (error || !data) return { error };
+
+            const current = data.current as Record<string, unknown>;
+            const hourly = data.hourly as Array<Record<string, unknown>>;
+
+            const input: VibeInput = {
+                tempF: (current?.temp as number) ?? 72,
+                humidity: (current?.humidity as number) ?? 50,
+                windMph: (current?.wind_speed as number) ?? 5,
+                precipChance: ((hourly?.[0]?.pop as number) ?? 0) * 100,
+                uvIndex: (current?.uvi as number) ?? 3,
+                cloudCover: (current?.clouds as number) ?? 20,
+            };
+
+            const vibe = calculateVibeScore(input);
+
+            return {
+                location: coords.name,
+                score: vibe.score,
+                category: vibe.category,
+                breakdown: vibe.breakdown,
+                conditions: {
+                    temp: Math.round((current?.temp as number) ?? 0),
+                    feels_like: Math.round((current?.feels_like as number) ?? 0),
+                    humidity: (current?.humidity as number) ?? 0,
+                    wind_mph: Math.round((current?.wind_speed as number) ?? 0),
+                    uv_index: (current?.uvi as number) ?? 0,
+                    cloud_cover: (current?.clouds as number) ?? 0,
+                },
             };
         },
     }),

--- a/lib/services/vibe-check.ts
+++ b/lib/services/vibe-check.ts
@@ -1,0 +1,101 @@
+/**
+ * 16-Bit Weather Platform - Vibe Check Service
+ *
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ *
+ * Comfort scoring algorithm: "What's the vibe today?"
+ * Categories: Rough → Meh → Decent → Vibin → Immaculate
+ */
+
+export interface VibeInput {
+  tempF: number
+  humidity: number
+  windMph: number
+  precipChance: number
+  uvIndex: number
+  cloudCover: number
+}
+
+export interface VibeResult {
+  score: number
+  category: string
+  breakdown: {
+    temperature: number
+    humidity: number
+    wind: number
+    precipitation: number
+    uv: number
+    clouds: number
+  }
+}
+
+const CATEGORIES = [
+  { min: 80, label: 'Immaculate' },
+  { min: 60, label: 'Vibin' },
+  { min: 40, label: 'Decent' },
+  { min: 20, label: 'Meh' },
+  { min: 0, label: 'Rough' },
+] as const
+
+export function getVibeCategory(score: number): string {
+  for (const cat of CATEGORIES) {
+    if (score >= cat.min) return cat.label
+  }
+  return 'Rough'
+}
+
+export function calculateVibeScore(input: VibeInput): VibeResult {
+  // Temperature (40%): peaks at 72°F, parabolic dropoff
+  const tempDiff = Math.abs(input.tempF - 72)
+  const temperature = Math.max(0, 100 - (tempDiff * tempDiff) / 12.5)
+
+  // Humidity (25%): peaks at 45%, drops outside 30-60%
+  const humDiff = input.humidity < 30
+    ? (30 - input.humidity) * 3.33
+    : input.humidity > 60
+      ? (input.humidity - 60) * 2.5
+      : 0
+  const humidity = Math.max(0, 100 - humDiff)
+
+  // Wind (15%): peaks at 5mph, drops above 15mph
+  const windPenalty = input.windMph <= 5
+    ? 0
+    : (input.windMph - 5) * 5
+  const wind = Math.max(0, 100 - windPenalty)
+
+  // Precipitation (10%): linear 100→0 as chance increases
+  const precipitation = Math.max(0, 100 - input.precipChance)
+
+  // UV (5%): peaks at UV 3, drops above 7
+  const uvPenalty = input.uvIndex <= 3
+    ? 0
+    : (input.uvIndex - 3) * 12.5
+  const uv = Math.max(0, 100 - uvPenalty)
+
+  // Cloud cover (5%): peaks at 20%, drops at extremes
+  const cloudDiff = Math.abs(input.cloudCover - 20)
+  const clouds = Math.max(0, 100 - cloudDiff * 1.25)
+
+  const score = Math.round(
+    temperature * 0.40 +
+    humidity * 0.25 +
+    wind * 0.15 +
+    precipitation * 0.10 +
+    uv * 0.05 +
+    clouds * 0.05
+  )
+
+  return {
+    score: Math.min(100, Math.max(0, score)),
+    category: getVibeCategory(score),
+    breakdown: {
+      temperature: Math.round(temperature),
+      humidity: Math.round(humidity),
+      wind: Math.round(wind),
+      precipitation: Math.round(precipitation),
+      uv: Math.round(uv),
+      clouds: Math.round(clouds),
+    },
+  }
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -12,6 +12,9 @@ if (process.env.ANALYZE === 'true') {
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  // Allow 127.0.0.1 in dev mode (Playwright E2E tests connect via this origin)
+  allowedDevOrigins: ['http://127.0.0.1:3000', '127.0.0.1'],
+
   // Note: ESLint config moved to eslint.config.mjs (Next.js 16+)
   // To ignore during builds, use: ESLINT_NO_DEV_ERRORS=true or run lint separately
   typescript: {


### PR DESCRIPTION
## Summary
- Adds a **Vibe Check** page (`/vibe-check`) that scores outdoor comfort on a 0-100 scale
- Weighted algorithm: temperature (40%), humidity (25%), wind (15%), precipitation (10%), UV (5%), clouds (5%)
- Five retro categories: Rough, Meh, Decent, Vibin, Immaculate
- Interactive 7-day forecast selector highlighting the best day to go outside

## New Files
- `lib/services/vibe-check.ts` - Scoring algorithm and category mapping
- `app/api/weather/vibe/route.ts` - API endpoint (current + 7-day scores via OneCall)
- `app/vibe-check/page.tsx` - Full page with score display, breakdown bars, 7-day selector
- `__tests__/vibe-check.test.ts` - 4 unit tests

## Modified Files
- `components/navigation.tsx` - Added "VIBE" nav item with Thermometer icon
- `lib/ai/tools.ts` - Added `get_vibe_check` tool so AI chat can answer "how nice is it outside?"

## Test plan
- [x] 92 unit tests pass (4 new + 88 existing)
- [x] TypeScript compiles with zero errors
- [ ] Verify page renders with location access
- [ ] Test AI chat responds to "whats the vibe in NYC?"
- [ ] Check theme compatibility

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Vibe Check UI: comfort scores for current + 7-day forecasts with per-factor breakdowns, highlights best day, and uses your location
  * VIBE navigation link for quick access
  * New pages: Severe Weather (auto-refreshing alerts), Travel Weather (origin vs destination), Tropical Tracker, Winter Weather
  * About page refreshed with accordion sections and module overview

* **Tests**
  * Added unit tests covering vibe scoring and category mapping
<!-- end of auto-generated comment: release notes by coderabbit.ai -->