### PR TITLE
fix: patch lodash security vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16576,10 +16576,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.0.tgz",
-      "integrity": "sha512-l1mfj2atMqndAHI3ls7XqPxEjV2J9ZkcNyHpoZA3r2T1LLwDB69jgkMWh71YKwhBbK0G2f4WSn05ahmQXVxupA==",
-      "deprecated": "Bad release. Please use lodash@4.17.21 instead.",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -16576,9 +16576,10 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.0.tgz",
+      "integrity": "sha512-l1mfj2atMqndAHI3ls7XqPxEjV2J9ZkcNyHpoZA3r2T1LLwDB69jgkMWh71YKwhBbK0G2f4WSn05ahmQXVxupA==",
+      "deprecated": "Bad release. Please use lodash@4.17.21 instead.",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -94,6 +94,6 @@
     "typescript": "^6.0.2"
   },
   "overrides": {
-    "lodash": "4.18.0"
+    "lodash": "4.18.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -92,5 +92,8 @@
     "ts-jest": "^29.4.9",
     "tsx": "^4.20.6",
     "typescript": "^6.0.2"
+  },
+  "overrides": {
+    "lodash": "4.18.0"
   }
 }


### PR DESCRIPTION
## Summary
- Override `lodash` to `4.18.0` to resolve 2 Dependabot security alerts:
  - **#58 (high)**: Code Injection via `_.template` import key names
  - **#56 (medium)**: Prototype Pollution via `_.unset` and `_.omit` array path bypass
- Vulnerable `lodash@4.17.23` was a transitive dependency from `@lhci/cli` -> `inquirer@6.5.2`
- Uses npm `overrides` in `package.json` since `@lhci/cli` is already at its latest version (0.15.1) and pins the old `inquirer`

## Test plan
- [x] `npm ls lodash` confirms `4.18.0 overridden`
- [x] All 278 tests pass
- [ ] Verify Dependabot alerts auto-close after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Locked a transitive dependency to a specific version to reduce installation variability.
  * This change improves stability and consistency of installs, reducing unexpected issues and helping ensure a more reliable app behavior for end users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->