### PR TITLE
fix(seo): restore missing space in city page H1

### DIFF
--- a/app/weather/[city]/page.tsx
+++ b/app/weather/[city]/page.tsx
@@ -200,7 +200,7 @@ export default async function CityWeatherPage({ params }: PageParams) {
           {/* Hero / H1 — the single authoritative heading for the page */}
           <header className="mb-8">
             <h1 className="text-3xl md:text-4xl font-bold uppercase tracking-tight text-weather-primary mb-3">
-              {fullLocation} Weather Forecast &amp; Climate Guide
+              {`${fullLocation} Weather Forecast & Climate Guide`}
             </h1>
             <p className="text-sm md:text-base text-weather-muted leading-relaxed max-w-3xl">
               {cityInfo.content.intro}


### PR DESCRIPTION
## Summary

- Fixes a JSX whitespace-collapse bug that caused the city page H1 to render as "New York, NYWeather Forecast & Climate Guide" (no space between city name and "Weather") in the deployed HTML
- Uses a template literal to force the entire heading into a single interpolated string, bypassing the whitespace edge case

## Background

Follow-up to #342. After deploying, view-source on `/weather/new-york-ny` showed:

\`\`\`html
<h1>New York, NY<!-- -->Weather Forecast &amp; Climate Guide</h1>
\`\`\`

The \`<!-- -->\` marker is React's text-boundary indicator between two adjacent children, and there was no space character between them. The React serialized payload confirmed the children array was \`["New York, NY", "Weather Forecast & Climate Guide"]\` — two separate strings with no intervening space.

The source code had \`{fullLocation} Weather Forecast &amp; Climate Guide\` on one line, which looked correct, but JSX collapsed the whitespace between the expression and the literal text during compilation for this particular case.

## Fix

Switched to a template literal so the entire heading is a single interpolated string that JSX cannot split:

\`\`\`tsx
<h1 ...>
  {\`\${fullLocation} Weather Forecast & Climate Guide\`}
</h1>
\`\`\`

This guarantees the space is part of the rendered text regardless of how JSX decides to parse the children.

## Test plan

- [ ] Deploy and view-source on `/weather/new-york-ny` — H1 should read "New York, NY Weather Forecast & Climate Guide" with a real space
- [ ] Spot-check a few other cities (`/weather/chicago-il`, `/weather/miami-fl`) to confirm the fix applies everywhere
- [ ] Typecheck and build both pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Internal code quality improvements in the weather page rendering logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->