### PR TITLE
fix(precip): use true rolling 24h sum for accurate precipitation

### DIFF
--- a/app/api/weather/precipitation-history/route.ts
+++ b/app/api/weather/precipitation-history/route.ts
@@ -12,7 +12,7 @@ import { fetchOpenMeteoForecast } from '@/lib/open-meteo';
 
 // Simple in-memory cache with 1-hour TTL
 const precipitationCache = new Map<string, { data: PrecipitationResponse; expires: number }>();
-const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+const CACHE_TTL_MS = 15 * 60 * 1000; // 15 minutes — precipitation changes fast during active rain
 
 interface PrecipitationResponse {
   currentRain: number;
@@ -71,16 +71,18 @@ export async function GET(request: NextRequest) {
       return NextResponse.json(cached.data, {
         headers: {
           'X-Cache': 'HIT',
-          'Cache-Control': 'private, max-age=3600',
+          'Cache-Control': 'private, max-age=900',
           ...rateLimit.headers,
         },
       });
     }
 
-    // Fetch from Open-Meteo with 2 days of data (today + yesterday)
-    // Request in mm for precipitation, fahrenheit for temperature (to determine snow vs rain)
+    // Fetch from Open-Meteo with past_days=1 + forecast_days=1
+    // This gives us yesterday + today in daily/hourly arrays (chronological order)
+    // Hourly data spans yesterday midnight → today end, covering a full 24h rolling window
     const forecast = await fetchOpenMeteoForecast(latitude, longitude, {
-      forecastDays: 2,
+      pastDays: 1,
+      forecastDays: 1,
       temperatureUnit: 'fahrenheit',
       windSpeedUnit: 'mph',
       precipitationUnit: 'mm', // We convert to inches ourselves for precision
@@ -99,13 +101,14 @@ export async function GET(request: NextRequest) {
     const currentSnow = isSnow ? mmToInches(currentPrecipMm) : 0;
 
     // Daily totals from Open-Meteo daily.precipitation_sum
-    const todayPrecipMm = daily?.precipitation_sum?.[0] ?? 0;
-    const yesterdayPrecipMm = daily?.precipitation_sum?.[1] ?? 0;
+    // With past_days=1, forecast_days=1: index 0 = yesterday, index 1 = today
+    const yesterdayPrecipMm = daily?.precipitation_sum?.[0] ?? 0;
+    const todayPrecipMm = daily?.precipitation_sum?.[1] ?? 0;
 
     // Determine snow vs rain for daily totals using daily temperature
     // If max temp is <= 32F, classify as snow
-    const todayMaxF = daily?.temperature_2m_max?.[0] ?? 40;
-    const yesterdayMaxF = daily?.temperature_2m_max?.[1] ?? 40;
+    const yesterdayMaxF = daily?.temperature_2m_max?.[0] ?? 40;
+    const todayMaxF = daily?.temperature_2m_max?.[1] ?? 40;
 
     const todayIsSnow = todayMaxF <= 32;
     const yesterdayIsSnow = yesterdayMaxF <= 32;
@@ -115,44 +118,44 @@ export async function GET(request: NextRequest) {
     const yesterdayRain = yesterdayIsSnow ? 0 : mmToInches(yesterdayPrecipMm);
     const yesterdaySnow = yesterdayIsSnow ? mmToInches(yesterdayPrecipMm) : 0;
 
-    // Calculate 24h rolling total using weighted average
-    // Get current local hour from hourly data timezone
+    // Calculate true rolling 24h precipitation total from hourly data
+    // With past_days=1, hourly data spans yesterday midnight → today end
     const now = new Date();
-    let currentHour = now.getUTCHours();
-    if (forecast.utc_offset_seconds) {
-      currentHour = (currentHour + Math.round(forecast.utc_offset_seconds / 3600)) % 24;
-      if (currentHour < 0) currentHour += 24;
-    }
-
-    // Also sum hourly precipitation for last 24 hours if available
     let hourly24hPrecipMm = 0;
+    let hourlySnow24hMm = 0;
     let hourlyDataAvailable = false;
+
     if (hourly?.time && hourly?.precipitation) {
       const nowMs = now.getTime();
       const oneDayAgo = nowMs - 24 * 60 * 60 * 1000;
       for (let i = 0; i < hourly.time.length; i++) {
         const hourMs = new Date(hourly.time[i]).getTime();
         if (hourMs >= oneDayAgo && hourMs <= nowMs) {
-          hourly24hPrecipMm += hourly.precipitation[i] ?? 0;
+          const precipMm = hourly.precipitation[i] ?? 0;
+          // Per-hour snow classification using hourly temperature if available
+          const hourTempF = hourly.temperature_2m?.[i];
+          const hourIsSnow = hourTempF != null ? hourTempF <= 32 : currentTempF <= 32;
+          if (hourIsSnow) {
+            hourlySnow24hMm += precipMm;
+          } else {
+            hourly24hPrecipMm += precipMm;
+          }
           hourlyDataAvailable = true;
         }
       }
     }
 
-    // Prefer hourly sum if available, otherwise use weighted daily
     let rain24h: number;
     let snow24h: number;
-    if (hourlyDataAvailable && hourly24hPrecipMm > 0) {
-      // Use hourly sum — more accurate
-      const avg24hTempBelow32 = currentTempF <= 32; // simplified
-      rain24h = avg24hTempBelow32 ? 0 : mmToInches(hourly24hPrecipMm);
-      snow24h = avg24hTempBelow32 ? mmToInches(hourly24hPrecipMm) : 0;
+
+    if (hourlyDataAvailable) {
+      // Primary path: true rolling 24h sum from hourly data
+      rain24h = mmToInches(hourly24hPrecipMm);
+      snow24h = mmToInches(hourlySnow24hMm);
     } else {
-      // Weighted daily approach
-      const todayWeight = currentHour / 24;
-      const yesterdayWeight = 1 - todayWeight;
-      rain24h = Math.round(((todayRain * todayWeight) + (yesterdayRain * yesterdayWeight)) * 100) / 100;
-      snow24h = Math.round(((todaySnow * todayWeight) + (yesterdaySnow * yesterdayWeight)) * 10) / 10;
+      // Fallback: sum daily totals (conservative — may slightly overcount)
+      rain24h = todayRain + yesterdayRain;
+      snow24h = todaySnow + yesterdaySnow;
     }
 
     const dataAvailable = daily?.time != null && daily.time.length > 0;
@@ -191,7 +194,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json(precipitationData, {
       headers: {
         'X-Cache': 'MISS',
-        'Cache-Control': 'private, max-age=3600',
+        'Cache-Control': 'private, max-age=900',
         ...rateLimit.headers,
       },
     });

--- a/app/api/weather/precipitation-history/route.ts
+++ b/app/api/weather/precipitation-history/route.ts
@@ -120,16 +120,22 @@ export async function GET(request: NextRequest) {
 
     // Calculate true rolling 24h precipitation total from hourly data
     // With past_days=1, hourly data spans yesterday midnight → today end
+    //
+    // TIMEZONE FIX: Open-Meteo returns local wall-clock times (no UTC offset)
+    // when timezone=auto. Parse with 'Z' suffix to treat as UTC, then subtract
+    // the location's utc_offset_seconds to get the true UTC epoch.
     const now = new Date();
+    const utcOffsetMs = (forecast.utc_offset_seconds ?? 0) * 1000;
     let hourly24hPrecipMm = 0;
     let hourlySnow24hMm = 0;
-    let hourlyDataAvailable = false;
+    let hourlySamplesInWindow = 0;
 
     if (hourly?.time && hourly?.precipitation) {
       const nowMs = now.getTime();
       const oneDayAgo = nowMs - 24 * 60 * 60 * 1000;
       for (let i = 0; i < hourly.time.length; i++) {
-        const hourMs = new Date(hourly.time[i]).getTime();
+        // Convert location-local timestamp to true UTC epoch
+        const hourMs = new Date(hourly.time[i] + 'Z').getTime() - utcOffsetMs;
         if (hourMs >= oneDayAgo && hourMs <= nowMs) {
           const precipMm = hourly.precipitation[i] ?? 0;
           // Per-hour snow classification using hourly temperature if available
@@ -140,15 +146,19 @@ export async function GET(request: NextRequest) {
           } else {
             hourly24hPrecipMm += precipMm;
           }
-          hourlyDataAvailable = true;
+          hourlySamplesInWindow++;
         }
       }
     }
 
+    // Require near-full coverage (22+ of 24 hours) to trust hourly rolling sum.
+    // With past_days=1 we get 48 hours of data, so this should almost always pass.
+    const hourlyHasFullCoverage = hourlySamplesInWindow >= 22;
+
     let rain24h: number;
     let snow24h: number;
 
-    if (hourlyDataAvailable) {
+    if (hourlyHasFullCoverage) {
       // Primary path: true rolling 24h sum from hourly data
       rain24h = mmToInches(hourly24hPrecipMm);
       snow24h = mmToInches(hourlySnow24hMm);
@@ -172,7 +182,7 @@ export async function GET(request: NextRequest) {
       lastUpdated: new Date().toISOString(),
       dataSource: 'day_summary',
       dataAvailable,
-      dataQuality: daily?.time && daily.time.length >= 2 ? 'full' : 'partial',
+      dataQuality: hourlyHasFullCoverage ? 'full' : 'partial',
     };
 
     // Only cache successful responses

--- a/lib/open-meteo.ts
+++ b/lib/open-meteo.ts
@@ -23,6 +23,7 @@ export async function fetchOpenMeteoForecast(
   lon: number,
   options?: {
     forecastDays?: number;
+    pastDays?: number;
     temperatureUnit?: 'fahrenheit' | 'celsius';
     windSpeedUnit?: 'mph' | 'kmh' | 'ms' | 'kn';
     precipitationUnit?: 'inch' | 'mm';
@@ -32,6 +33,7 @@ export async function fetchOpenMeteoForecast(
 ): Promise<OpenMeteoForecastResponse> {
   const {
     forecastDays = 7,
+    pastDays,
     temperatureUnit = 'fahrenheit',
     windSpeedUnit = 'mph',
     precipitationUnit = 'inch',
@@ -96,6 +98,9 @@ export async function fetchOpenMeteoForecast(
   url.searchParams.set('precipitation_unit', precipitationUnit);
   url.searchParams.set('timezone', 'auto');
   url.searchParams.set('forecast_days', forecastDays.toString());
+  if (pastDays != null && pastDays > 0) {
+    url.searchParams.set('past_days', pastDays.toString());
+  }
 
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), 8000);


### PR DESCRIPTION
## Summary
- Fixed precipitation-history API severely underreporting rainfall (0.14" shown vs 0.75-1.24" actual for San Ramon, CA)
- Root cause: `forecastDays: 2` returns today+tomorrow, but code assumed index [1] was yesterday — it was actually tomorrow's forecast. Without `past_days=1`, hourly data only covered midnight-today forward, missing yesterday's hours entirely
- Now requests `past_days=1` from Open-Meteo to get actual historical hourly data, sums a true rolling 24h window, and classifies snow per-hour using hourly temperature
- Removed broken weighted average fallback, reduced cache TTL from 1h to 15min

## Test plan
- [x] `npm run build` passes
- [x] All 293 unit tests pass
- [x] Tested `/api/weather/precipitation-history?lat=37.78&lon=-121.98` (San Ramon) — now reports 0.64" vs 0.14" before
- [x] Verified Open-Meteo returns 48h of hourly data with `past_days=1`
- [ ] Verify on production after deploy by comparing with weather.gov station data

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-hour rain vs. snow partitioning for 24‑hour totals using hourly temperature when available.
  * Query now includes recent past day to ensure yesterday + today coverage.

* **Bug Fixes**
  * True rolling 24‑hour precipitation sum from hourly samples; improved timezone handling for hourly timestamps.
  * Fallback now sums today + yesterday daily totals when hourly coverage is insufficient.
  * Data quality now requires near-full hourly coverage (>=22 samples).

* **Performance**
  * Cache TTL reduced from 1 hour to 15 minutes for fresher data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->