### PR TITLE
stargazer: per-hour scoring, best window, cirrus penalty, and UX polish

### DIFF
--- a/__tests__/stargazer/score.test.ts
+++ b/__tests__/stargazer/score.test.ts
@@ -120,10 +120,10 @@ describe('Stargazer Score Algorithm', () => {
       expect(stargazerScore(0, 0, 0, 0, 0)).toBe(0);
     });
 
-    it('weights cloud cover highest (35%)', () => {
+    it('weights cloud cover highest (40%)', () => {
       const withClouds = stargazerScore(0, 100, 100, 100, 100);
       const withoutClouds = stargazerScore(100, 100, 100, 100, 100);
-      expect(withoutClouds - withClouds).toBe(35);
+      expect(withoutClouds - withClouds).toBe(40);
     });
   });
 

--- a/app/api/stargazer/route.ts
+++ b/app/api/stargazer/route.ts
@@ -8,12 +8,13 @@ import {
   calculateUpcomingSkyEvents,
 } from '@/lib/stargazer/astronomy';
 import {
-  cloudScore,
-  moonScore,
-  seeingScore,
-  transparencyScore,
-  groundScore,
+  scoreHour,
+  findBestWindow,
+  findLimitingFactor,
   calculateStargazerScore,
+  getScoreLabel,
+  getScoreColor,
+  getSubScoreLabel,
 } from '@/lib/stargazer/score';
 import {
   fetchSevenTimerData,
@@ -27,11 +28,14 @@ import meteorShowerData from '@/data/meteor-showers.json';
 
 import type {
   StargazerData,
+  StargazerSubScores,
   HourlyCondition,
   DeepSkyHighlight,
   DeepSkyObject,
   MeteorShowerEvent,
   MeteorShower,
+  BestWindow,
+  LimitingFactor,
 } from '@/lib/stargazer/types';
 import { estimateBortleClass } from '@/lib/stargazer/bortle';
 
@@ -234,59 +238,138 @@ export async function GET(request: NextRequest) {
       });
     }
 
-    // ---- Calculate Stargazer Score ----
-    // Use dark-window hours for averages
+    // ---- Per-Hour Scoring ----
     const darkDuskMs = darkWindow.astronomicalDusk.getTime();
     const darkDawnMs = darkWindow.astronomicalDawn.getTime();
-    const darkHours = hourlyConditions.filter(
-      (h) => h.time.getTime() >= darkDuskMs && h.time.getTime() <= darkDawnMs,
-    );
+    // moonInfo.illumination is already 0-100 (percentage)
+    const moonIllumPct = moonInfo.illumination;
+    const moonUpPct = moonInfo.moonUpDuringDarkWindowPercent;
 
-    const avgOrAll = darkHours.length > 0 ? darkHours : hourlyConditions;
+    // Score each hour in the dark window individually
+    const darkHourIndices: number[] = [];
+    for (let i = 0; i < hourlyConditions.length; i++) {
+      const h = hourlyConditions[i];
+      const tMs = h.time.getTime();
+      if (tMs >= darkDuskMs && tMs <= darkDawnMs) {
+        darkHourIndices.push(i);
+      }
 
-    const avgCloudCover =
-      avgOrAll.length > 0
-        ? avgOrAll.reduce((sum, h) => sum + h.cloudCover, 0) / avgOrAll.length
+      // Score every hour (dark window or not) for the timeline display
+      const result = scoreHour(
+        h.cloudCover,
+        moonIllumPct,
+        moonUpPct,
+        h.seeing,
+        h.transparency,
+        kmhToMph(h.windSpeed),
+        h.humidity,
+        cToF(h.temperature),
+        cToF(h.dewpoint),
+        h.cloudCoverHigh,
+        h.cloudCover,
+      );
+      hourlyConditions[i].hourlyScore = result.score;
+      hourlyConditions[i].hourlySubScores = result.subScores;
+      hourlyConditions[i].cirrusWarning = result.cirrusWarning;
+    }
+
+    // Extract dark-window hourly scores for best window calculation
+    const darkHourScores = darkHourIndices.map((i) => hourlyConditions[i].hourlyScore!);
+
+    // Find the best 3-hour contiguous block
+    const bestWindowResult = findBestWindow(darkHourScores, 3);
+
+    let bestWindow: BestWindow | null = null;
+    let headlineSubScores: StargazerSubScores;
+    let headlineScore: number;
+
+    if (bestWindowResult && darkHourIndices.length > 0) {
+      const bwStartIdx = darkHourIndices[bestWindowResult.startIndex];
+      const bwEndIdx = darkHourIndices[bestWindowResult.endIndex];
+
+      bestWindow = {
+        startTime: hourlyConditions[bwStartIdx].time,
+        endTime: hourlyConditions[bwEndIdx].time,
+        score: bestWindowResult.score,
+        label: getScoreLabel(bestWindowResult.score),
+        color: getScoreColor(getScoreLabel(bestWindowResult.score)),
+      };
+
+      // Average sub-scores across the best window for the headline breakdown
+      const bwHours = darkHourIndices
+        .slice(bestWindowResult.startIndex, bestWindowResult.endIndex + 1)
+        .map((i) => hourlyConditions[i].hourlySubScores!);
+      headlineSubScores = {
+        cloud: Math.round(bwHours.reduce((s, h) => s + h.cloud, 0) / bwHours.length),
+        moon: Math.round(bwHours.reduce((s, h) => s + h.moon, 0) / bwHours.length),
+        seeing: Math.round(bwHours.reduce((s, h) => s + h.seeing, 0) / bwHours.length),
+        transparency: Math.round(bwHours.reduce((s, h) => s + h.transparency, 0) / bwHours.length),
+        ground: Math.round(bwHours.reduce((s, h) => s + h.ground, 0) / bwHours.length),
+      };
+      headlineScore = bestWindowResult.score;
+    } else {
+      // Fallback: no dark hours, score from all available conditions
+      const fallback = hourlyConditions.length > 0
+        ? hourlyConditions.map((h) => h.hourlySubScores!)
+        : null;
+      if (fallback && fallback.length > 0) {
+        headlineSubScores = {
+          cloud: Math.round(fallback.reduce((s, h) => s + h.cloud, 0) / fallback.length),
+          moon: Math.round(fallback.reduce((s, h) => s + h.moon, 0) / fallback.length),
+          seeing: Math.round(fallback.reduce((s, h) => s + h.seeing, 0) / fallback.length),
+          transparency: Math.round(fallback.reduce((s, h) => s + h.transparency, 0) / fallback.length),
+          ground: Math.round(fallback.reduce((s, h) => s + h.ground, 0) / fallback.length),
+        };
+      } else {
+        headlineSubScores = { cloud: 50, moon: 50, seeing: 50, transparency: 50, ground: 50 };
+      }
+      headlineScore = hourlyConditions.length > 0
+        ? Math.round(hourlyConditions.reduce((s, h) => s + (h.hourlyScore ?? 0), 0) / hourlyConditions.length)
         : 50;
-    const avgSeeing =
-      avgOrAll.length > 0
-        ? avgOrAll.reduce((sum, h) => sum + h.seeing, 0) / avgOrAll.length
-        : 4;
-    const avgTransparency =
-      avgOrAll.length > 0
-        ? avgOrAll.reduce((sum, h) => sum + h.transparency, 0) / avgOrAll.length
-        : 4;
-    const avgWindKmh =
-      avgOrAll.length > 0
-        ? avgOrAll.reduce((sum, h) => sum + h.windSpeed, 0) / avgOrAll.length
-        : 0;
-    const avgHumidity =
-      avgOrAll.length > 0
-        ? avgOrAll.reduce((sum, h) => sum + h.humidity, 0) / avgOrAll.length
+    }
+
+    // Full-night average for secondary display
+    const nightAverage = darkHourScores.length > 0
+      ? Math.round(darkHourScores.reduce((s, v) => s + v, 0) / darkHourScores.length)
+      : headlineScore;
+
+    // Compute average cloud cover for summary generation
+    const avgCloudCover = darkHourIndices.length > 0
+      ? darkHourIndices.reduce((s, i) => s + hourlyConditions[i].cloudCover, 0) / darkHourIndices.length
+      : hourlyConditions.length > 0
+        ? hourlyConditions.reduce((s, h) => s + h.cloudCover, 0) / hourlyConditions.length
         : 50;
-    const avgTempC =
-      avgOrAll.length > 0
-        ? avgOrAll.reduce((sum, h) => sum + h.temperature, 0) / avgOrAll.length
-        : 15;
-    const avgDewpointC =
-      avgOrAll.length > 0
-        ? avgOrAll.reduce((sum, h) => sum + h.dewpoint, 0) / avgOrAll.length
-        : 10;
 
-    const subScores = {
-      cloud: cloudScore(avgCloudCover),
-      moon: moonScore(moonInfo.illumination * 100, moonInfo.moonUpDuringDarkWindowPercent),
-      seeing: seeingScore(Math.round(avgSeeing)),
-      transparency: transparencyScore(Math.round(avgTransparency)),
-      ground: groundScore(
-        kmhToMph(avgWindKmh),
-        avgHumidity,
-        cToF(avgTempC),
-        cToF(avgDewpointC),
-      ),
-    };
+    const score = calculateStargazerScore(headlineSubScores, moonIllumPct, avgCloudCover);
+    // Override the overall with the best-window score (calculateStargazerScore recomputes from sub-scores)
+    score.overall = headlineScore;
+    score.label = getScoreLabel(headlineScore);
+    score.color = getScoreColor(score.label);
 
-    const score = calculateStargazerScore(subScores, moonInfo.illumination * 100, avgCloudCover);
+    // ---- Limiting Factor ----
+    let limitingFactor: LimitingFactor | null = null;
+    if (headlineScore < 85) {
+      const { category, score: limitScore } = findLimitingFactor(headlineSubScores);
+      const label = getSubScoreLabel(category, limitScore);
+
+      // Generate contextual detail string
+      let detail = '';
+      if (category === 'moon' && moonInfo.rise) {
+        const moonRiseStr = new Date(moonInfo.rise).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
+        detail = `rises at ${moonRiseStr} with ${Math.round(moonIllumPct)}% illumination`;
+      } else if (category === 'cloud') {
+        detail = `${Math.round(avgCloudCover)}% average cloud cover`;
+      } else if (category === 'seeing') {
+        detail = 'atmospheric turbulence limiting resolution';
+      } else if (category === 'transparency') {
+        const hasCirrus = hourlyConditions.some((h) => h.cirrusWarning);
+        detail = hasCirrus ? 'high-altitude cirrus reducing clarity' : 'haze or moisture reducing clarity';
+      } else if (category === 'ground') {
+        detail = 'wind, humidity, or dew risk affecting conditions';
+      }
+
+      limitingFactor = { category, label, detail };
+    }
 
     // ---- Meteor showers with moon interference ----
     const showers = meteorShowerData as MeteorShower[];
@@ -362,6 +445,9 @@ export async function GET(request: NextRequest) {
     // ---- Build response ----
     const data: StargazerData = {
       score,
+      bestWindow,
+      nightAverage,
+      limitingFactor,
       darkWindow,
       hourlyConditions,
       moon: moonInfo,

--- a/app/stargazer/page.tsx
+++ b/app/stargazer/page.tsx
@@ -85,7 +85,7 @@ function SkeletonCard({ rows = 3 }: { rows?: number }) {
 // ============================================================================
 
 function PersistentHeader({ data }: { data: StargazerData }) {
-  const { score, darkWindow, moon, location } = data;
+  const { score, bestWindow, nightAverage, limitingFactor, darkWindow, moon, location } = data;
 
   return (
     <div className="container-primary p-4 sm:p-6">
@@ -117,7 +117,32 @@ function PersistentHeader({ data }: { data: StargazerData }) {
             <span className={cn('text-xl font-bold font-mono uppercase', scoreColor(score.overall))}>
               {score.label}
             </span>
+            {nightAverage != null && nightAverage !== score.overall && (
+              <span className="text-sm font-mono text-muted-foreground ml-1">
+                (night avg: {nightAverage})
+              </span>
+            )}
           </div>
+
+          {/* Best window callout */}
+          {bestWindow && (
+            <div className="mb-2 px-3 py-1.5 bg-white/5 border border-subtle rounded inline-flex items-center gap-2 text-sm font-mono">
+              <span className="text-muted-foreground">Best window:</span>
+              <span className="font-bold">
+                {formatTime(bestWindow.startTime)} &ndash; {formatTime(bestWindow.endTime)}
+              </span>
+              <span className={cn('font-bold', scoreColor(bestWindow.score))}>
+                ({bestWindow.score})
+              </span>
+            </div>
+          )}
+
+          {/* Limiting factor */}
+          {limitingFactor && (
+            <p className="text-xs font-mono text-amber-400/90 mb-2">
+              Limiting factor: <span className="capitalize">{limitingFactor.category}</span> &mdash; {limitingFactor.label.toLowerCase()}{limitingFactor.detail ? ` (${limitingFactor.detail})` : ''}
+            </p>
+          )}
 
           {(location.displayName || location.name) && (
             <div className="text-xs font-mono text-muted-foreground mb-2 space-y-0.5">
@@ -157,20 +182,26 @@ function PersistentHeader({ data }: { data: StargazerData }) {
             )}
           </div>
 
-          {/* Sub-score mini-bars */}
-          <div className="grid grid-cols-5 gap-2 max-w-md text-xs font-mono">
-            {Object.entries(score.subScores).map(([key, val]) => (
-              <div key={key} className="flex flex-col items-center gap-1" title={getSubScoreLabel(key, val)}>
-                <span className="text-xs font-mono uppercase text-muted-foreground">{key}</span>
-                <div className="w-full h-2 bg-white/10 rounded overflow-hidden">
-                  <div
-                    className={cn('h-full rounded', scoreBarColor(val))}
-                    style={{ width: `${val}%` }}
-                  />
+          {/* Sub-score mini-bars with visible labels */}
+          <div className="grid grid-cols-5 gap-2 max-w-lg text-xs font-mono">
+            {Object.entries(score.subScores).map(([key, val]) => {
+              const label = getSubScoreLabel(key, val);
+              return (
+                <div key={key} className="flex flex-col items-center gap-1" title={label}>
+                  <span className="text-xs font-mono uppercase text-muted-foreground">{key}</span>
+                  <div className="w-full h-2 bg-white/10 rounded overflow-hidden">
+                    <div
+                      className={cn('h-full rounded', scoreBarColor(val))}
+                      style={{ width: `${val}%` }}
+                    />
+                  </div>
+                  <span className="font-bold font-mono">{Math.round(val)}</span>
+                  <span className="text-[10px] font-mono text-muted-foreground text-center leading-tight truncate w-full">
+                    {label}
+                  </span>
                 </div>
-                <span className="font-bold font-mono">{Math.round(val)}</span>
-              </div>
-            ))}
+              );
+            })}
           </div>
         </div>
       </div>
@@ -183,7 +214,7 @@ function PersistentHeader({ data }: { data: StargazerData }) {
 // ============================================================================
 
 function ConditionsPanel({ data }: { data: StargazerData }) {
-  const { hourlyConditions, darkWindow, moon } = data;
+  const { hourlyConditions, bestWindow, darkWindow, moon } = data;
 
   // Rehydrate dates from JSON serialization
   const conditions = hourlyConditions?.map((h) => ({
@@ -198,6 +229,34 @@ function ConditionsPanel({ data }: { data: StargazerData }) {
     astronomicalDawn: typeof darkWindow.astronomicalDawn === 'string' ? new Date(darkWindow.astronomicalDawn) : darkWindow.astronomicalDawn,
   } : undefined;
 
+  // Use best-window midpoint for ground conditions, fallback to dark window midpoint
+  const groundConditions = (() => {
+    if (conditions.length === 0) return null;
+
+    let targetMs: number;
+    if (bestWindow?.startTime && bestWindow?.endTime) {
+      const start = typeof bestWindow.startTime === 'string' ? new Date(bestWindow.startTime) : bestWindow.startTime;
+      const end = typeof bestWindow.endTime === 'string' ? new Date(bestWindow.endTime) : bestWindow.endTime;
+      targetMs = (start.getTime() + end.getTime()) / 2;
+    } else if (rehydratedDarkWindow) {
+      targetMs = (rehydratedDarkWindow.astronomicalDusk.getTime() + rehydratedDarkWindow.astronomicalDawn.getTime()) / 2;
+    } else {
+      return conditions[Math.floor(conditions.length / 2)];
+    }
+
+    // Find the hour closest to the target midpoint
+    let closest = conditions[0];
+    let minDiff = Infinity;
+    for (const c of conditions) {
+      const diff = Math.abs(c.time.getTime() - targetMs);
+      if (diff < minDiff) {
+        minDiff = diff;
+        closest = c;
+      }
+    }
+    return closest;
+  })();
+
   return (
     <div className="space-y-6">
       {conditions.length > 0 && rehydratedDarkWindow && (
@@ -209,33 +268,36 @@ function ConditionsPanel({ data }: { data: StargazerData }) {
         <div className="container-primary p-4 font-mono">
           <h2 className="border-b border-subtle py-3 mb-3 text-xs font-mono uppercase text-muted-foreground">
             Ground Conditions
+            <span className="text-muted-foreground font-normal ml-2">
+              (at {groundConditions ? formatTime(groundConditions.time) : '--:--'})
+            </span>
           </h2>
           <div className="grid grid-cols-2 gap-4">
-            {conditions.length > 0 && (
+            {groundConditions && (
               <>
                 <div>
                   <span className="text-xs font-mono uppercase text-muted-foreground block">Temperature</span>
-                  <span className="text-xl font-bold font-mono">{Math.round(conditions[0].temperature)}&deg;C</span>
+                  <span className="text-xl font-bold font-mono">{Math.round(groundConditions.temperature)}&deg;C</span>
                 </div>
                 <div>
                   <span className="text-xs font-mono uppercase text-muted-foreground block">Humidity</span>
-                  <span className="text-xl font-bold font-mono">{Math.round(conditions[0].humidity)}%</span>
+                  <span className="text-xl font-bold font-mono">{Math.round(groundConditions.humidity)}%</span>
                 </div>
                 <div>
                   <span className="text-xs font-mono uppercase text-muted-foreground block">Wind Speed</span>
-                  <span className="text-xl font-bold font-mono">{Math.round(conditions[0].windSpeed)} km/h</span>
+                  <span className="text-xl font-bold font-mono">{Math.round(groundConditions.windSpeed)} km/h</span>
                 </div>
                 <div>
                   <span className="text-xs font-mono uppercase text-muted-foreground block">Cloud Cover</span>
-                  <span className="text-xl font-bold font-mono">{Math.round(conditions[0].cloudCover)}%</span>
+                  <span className="text-xl font-bold font-mono">{Math.round(groundConditions.cloudCover)}%</span>
                 </div>
                 <div>
                   <span className="text-xs font-mono uppercase text-muted-foreground block">Dew Risk</span>
-                  <span className="text-xl font-bold font-mono capitalize">{String(conditions[0].dewRisk)}</span>
+                  <span className="text-xl font-bold font-mono capitalize">{String(groundConditions.dewRisk)}</span>
                 </div>
                 <div>
                   <span className="text-xs font-mono uppercase text-muted-foreground block">Seeing</span>
-                  <span className="text-xl font-bold font-mono">{conditions[0].seeing}/8</span>
+                  <span className="text-xl font-bold font-mono">{groundConditions.seeing}/8</span>
                 </div>
               </>
             )}

--- a/components/stargazer/HourlyTimeline.tsx
+++ b/components/stargazer/HourlyTimeline.tsx
@@ -109,6 +109,14 @@ const metrics: MetricKey[] = [
   'dewRisk',
 ];
 
+function getScoreRowColor(score: number): string {
+  if (score >= 75) return 'bg-emerald-600';
+  if (score >= 60) return 'bg-green-600';
+  if (score >= 45) return 'bg-yellow-600';
+  if (score >= 30) return 'bg-orange-600';
+  return 'bg-red-600';
+}
+
 export default function HourlyTimeline({
   conditions,
   darkWindow,
@@ -167,10 +175,30 @@ export default function HourlyTimeline({
             </tr>
           </thead>
           <tbody>
+            {/* Per-hour composite score row — guide rail at the top */}
+            <tr className="font-bold">
+              <td className="sticky left-0 bg-inherit px-2 py-1.5 text-xs font-mono font-bold uppercase tracking-wider text-foreground">
+                Score
+              </td>
+              {conditions.map((c, i) => (
+                <td
+                  key={i}
+                  className={cn(
+                    'border border-subtle px-1 py-1.5 text-center text-white text-sm font-mono font-bold',
+                    c.hourlyScore != null ? getScoreRowColor(c.hourlyScore) : 'bg-gray-600',
+                  )}
+                >
+                  {c.hourlyScore != null ? c.hourlyScore : '--'}
+                </td>
+              ))}
+            </tr>
             {metrics.map((metric) => (
               <tr key={metric}>
                 <td className="sticky left-0 bg-inherit px-2 py-1 text-xs font-mono uppercase tracking-wider text-muted-foreground">
                   {metricLabels[metric]}
+                  {metric === 'cloudCoverHigh' && conditions.some((c) => c.cirrusWarning) && (
+                    <span className="ml-1 text-amber-400" title="Cirrus penalty active">*</span>
+                  )}
                 </td>
                 {conditions.map((c, i) => {
                   const raw = c[metric as keyof HourlyCondition];
@@ -181,7 +209,8 @@ export default function HourlyTimeline({
                       key={i}
                       className={cn(
                         'border border-subtle px-1 py-1 text-center text-white text-xs font-mono',
-                        getCellColor(metric, value as number | string)
+                        getCellColor(metric, value as number | string),
+                        metric === 'cloudCoverHigh' && c.cirrusWarning && 'ring-1 ring-inset ring-amber-400/60',
                       )}
                     >
                       {formatCellValue(metric, value as number | string)}

--- a/lib/stargazer/score.ts
+++ b/lib/stargazer/score.ts
@@ -76,7 +76,7 @@ export function groundScore(
 // Composite Score
 // ============================================================================
 
-/** Weighted composite: cloud 35%, moon 25%, seeing 15%, transparency 15%, ground 10% */
+/** Weighted composite: cloud 40%, moon 25%, seeing 15%, transparency 15%, ground 5% */
 export function stargazerScore(
   cloud: number,
   moon: number,
@@ -85,12 +85,125 @@ export function stargazerScore(
   ground: number,
 ): number {
   return Math.round(
-    cloud * 0.35 +
+    cloud * 0.40 +
     moon * 0.25 +
     seeing * 0.15 +
     transparency * 0.15 +
-    ground * 0.10,
+    ground * 0.05,
   );
+}
+
+// ============================================================================
+// Cirrus Penalty
+// ============================================================================
+
+/**
+ * Apply cirrus (high cloud) penalty to a transparency sub-score.
+ * Thin cirrus reads as low total cloud cover but wrecks transparency.
+ */
+export function applyCirrusPenalty(
+  transparencySub: number,
+  cloudCoverHighPercent: number,
+  totalCloudCoverPercent: number,
+): { adjusted: number; cirrusWarning: boolean } {
+  if (cloudCoverHighPercent > 50) {
+    return { adjusted: Math.max(0, transparencySub - 25), cirrusWarning: true };
+  }
+  if (cloudCoverHighPercent > 30 && totalCloudCoverPercent < 25) {
+    return { adjusted: Math.max(0, transparencySub - 15), cirrusWarning: true };
+  }
+  return { adjusted: transparencySub, cirrusWarning: false };
+}
+
+// ============================================================================
+// Per-Hour Scoring
+// ============================================================================
+
+/** Compute composite score and sub-scores for a single hour. */
+export function scoreHour(
+  cloudCoverPercent: number,
+  moonIlluminationPercent: number,
+  moonUpDuringDarkWindowPercent: number,
+  seeing7timer: number,
+  transparency7timer: number,
+  windSpeedMph: number,
+  humidityPercent: number,
+  tempF: number,
+  dewpointF: number,
+  cloudCoverHighPercent: number,
+  totalCloudCoverPercent: number,
+): { score: number; subScores: StargazerSubScores; cirrusWarning: boolean } {
+  const cloud = cloudScore(cloudCoverPercent);
+  const moon = moonScore(moonIlluminationPercent, moonUpDuringDarkWindowPercent);
+  const seeing = seeingScore(seeing7timer);
+  const rawTransparency = transparencyScore(transparency7timer);
+  const { adjusted: transparency, cirrusWarning } = applyCirrusPenalty(
+    rawTransparency, cloudCoverHighPercent, totalCloudCoverPercent,
+  );
+  const ground = groundScore(windSpeedMph, humidityPercent, tempF, dewpointF);
+
+  const subScores: StargazerSubScores = { cloud, moon, seeing, transparency, ground };
+  const score = stargazerScore(cloud, moon, seeing, transparency, ground);
+
+  return { score, subScores, cirrusWarning };
+}
+
+// ============================================================================
+// Best Window (sliding 3-hour block)
+// ============================================================================
+
+export interface BestWindowResult {
+  startIndex: number;
+  endIndex: number;
+  score: number;
+}
+
+/** Find the highest-scoring contiguous block of `windowSize` hours. */
+export function findBestWindow(hourlyScores: number[], windowSize: number = 3): BestWindowResult | null {
+  if (hourlyScores.length === 0) return null;
+
+  const effectiveSize = Math.min(windowSize, hourlyScores.length);
+  let bestStart = 0;
+  let bestAvg = -1;
+
+  for (let i = 0; i <= hourlyScores.length - effectiveSize; i++) {
+    let sum = 0;
+    for (let j = i; j < i + effectiveSize; j++) {
+      sum += hourlyScores[j];
+    }
+    const avg = sum / effectiveSize;
+    if (avg > bestAvg) {
+      bestAvg = avg;
+      bestStart = i;
+    }
+  }
+
+  return {
+    startIndex: bestStart,
+    endIndex: bestStart + effectiveSize - 1,
+    score: Math.round(bestAvg),
+  };
+}
+
+// ============================================================================
+// Limiting Factor
+// ============================================================================
+
+/** Identify the weakest sub-score category from a set of sub-scores. */
+export function findLimitingFactor(
+  subScores: StargazerSubScores,
+): { category: keyof StargazerSubScores; score: number } {
+  let lowest = Infinity;
+  let category: keyof StargazerSubScores = 'cloud';
+
+  for (const [key, val] of Object.entries(subScores) as [keyof StargazerSubScores, number][]) {
+    if (val < lowest) {
+      lowest = val;
+      category = key;
+    }
+  }
+
+  return { category, score: lowest };
 }
 
 // ============================================================================

--- a/lib/stargazer/types.ts
+++ b/lib/stargazer/types.ts
@@ -52,6 +52,12 @@ export interface HourlyCondition {
   temperature: number;
   dewpoint: number;
   dewRisk: 'low' | 'moderate' | 'high';
+  /** Per-hour composite score (0-100), computed during dark window */
+  hourlyScore?: number;
+  /** Per-hour sub-scores breakdown */
+  hourlySubScores?: StargazerSubScores;
+  /** True if high cloud cover is penalizing transparency */
+  cirrusWarning?: boolean;
 }
 
 // ============================================================================
@@ -236,11 +242,32 @@ export interface SevenTimerResponse {
 }
 
 // ============================================================================
+// Best Window & Limiting Factor
+// ============================================================================
+
+export interface BestWindow {
+  startTime: Date;
+  endTime: Date;
+  score: number;
+  label: ScoreLabel;
+  color: string;
+}
+
+export interface LimitingFactor {
+  category: keyof StargazerSubScores;
+  label: string;
+  detail: string;
+}
+
+// ============================================================================
 // Consolidated API Response
 // ============================================================================
 
 export interface StargazerData {
   score: StargazerScore;
+  bestWindow: BestWindow | null;
+  nightAverage: number;
+  limitingFactor: LimitingFactor | null;
   darkWindow: DarkWindow;
   hourlyConditions: HourlyCondition[];
   moon: MoonInfo;


### PR DESCRIPTION
## Summary

- Replace nightly-average scoring with **per-hour composite scoring** and a sliding 3-hour best-window detector — a night that's clear until 1 AM then overcast now surfaces those 4 good hours instead of being averaged away
- Add **cirrus penalty** for thin high-cloud layers (the silent transparency killer that reads as low total cloud cover)
- Rebalance weights: cloud 35% -> 40%, ground 10% -> 5%
- UX: best-window callout, limiting factor highlight, visible sub-score labels (not tooltip-only), per-hour Score guide rail at the top of the hourly grid
- Fix pre-existing moon illumination double-scaling bug (was producing 2311% illumination in the scoring path)

## Context

Based on a professional audit of the Stargazer page. Every serious astrophotography tool (Astrospheric, Clear Outside, Meteoblue) scores each hour independently — the nightly average destroys the signal of what hours are actually worth going out for.

## Changes

### Scoring engine (`lib/stargazer/score.ts`)
- New: `scoreHour()`, `findBestWindow()`, `findLimitingFactor()`, `applyCirrusPenalty()`
- Weights rebalanced — cloud is now 40% (was 35%), ground is 5% (was 10%)
- Cirrus penalty: high clouds >50% -> -25 transparency; >30% with low total -> -15 transparency

### API route (`app/api/stargazer/route.ts`)
- Per-hour composite scores + sub-scores + cirrus warnings attached to each `HourlyCondition`
- Best 3-hour contiguous block computed from dark-window hours
- New response fields: `bestWindow`, `nightAverage`, `limitingFactor`
- Headline score = best window score; night average shown as secondary context
- 7Timer fallback (seeing/transparency = 4 when API unavailable) preserved

### UI (`app/stargazer/page.tsx`, `components/stargazer/HourlyTimeline.tsx`)
- Hourly grid: bold **Score** row at the top as a guide rail, color-coded per hour
- Cirrus-affected High Cloud cells get an amber ring with asterisk on the label
- Persistent header: best window time range callout, limiting factor line (hidden when score >= 85), visible sub-score text labels below each bar
- Ground Conditions card now reads from the best-window midpoint hour (not sunset)

## Test plan

- [x] All 293 unit tests pass (`npm test`)
- [x] 48 Stargazer-specific tests pass (`npm test -- __tests__/stargazer/`)
- [x] ESLint clean on all modified files
- [x] Production build succeeds (`npm run build`)
- [x] API integration verified against NYC (mixed conditions) and LA (clear night)
- [x] Best window score differs from night average when conditions vary (62 night avg vs 84 best window in NYC test)
- [x] Limiting factor correctly omitted when score >= 85
- [x] Cirrus penalty flag surfaces in API response
- [ ] Visual QA in browser across themes
- [ ] Mobile viewport check of sub-score label readability

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Per-hour scoring with automatic best 3-hour observation window detection
  * Night average score display for reference
  * Limiting factor identification showing what prevents a higher score
  * Cirrus cloud warnings with enhanced visibility in hourly timeline
  * Ground conditions now reflect best observation window timing

* **Improvements**
  * Refined scoring weights for cloud and ground factors
  * Enhanced hourly timeline with per-hour score display

<!-- end of auto-generated comment: release notes by coderabbit.ai -->