### PR TITLE
fix(blog): unbreak /api/og endpoints by making OPENWEATHER_API_KEY optional

### DIFF
--- a/lib/env-validation.ts
+++ b/lib/env-validation.ts
@@ -19,13 +19,12 @@ interface EnvConfig {
 }
 
 const envConfig: EnvConfig = {
-  required: {
+  required: {},
+  optional: {
     OPENWEATHER_API_KEY: {
       name: 'OPENWEATHER_API_KEY',
-      description: 'OpenWeatherMap API key (required for weather data) - server-only for security',
+      description: 'OpenWeatherMap API key. Optional after the Open-Meteo migration — only used by legacy fallback endpoints (pollen, UV onecall v3, precipitation history, extremes). Routes that need it check at request time.',
     },
-  },
-  optional: {
     NEXT_PUBLIC_SUPABASE_URL: {
       name: 'NEXT_PUBLIC_SUPABASE_URL',
       description: 'Supabase project URL (optional - for authentication)',
@@ -72,10 +71,6 @@ export function validateEnv(): void {
 
   // Check required variables
   for (const [key, config] of Object.entries(envConfig.required)) {
-    // In Playwright E2E runs we stub API calls, so allow missing API keys.
-    if (isPlaywright && key === 'OPENWEATHER_API_KEY') {
-      continue;
-    }
     if (!process.env[key]) {
       missingRequired.push(key);
       console.error(`❌ Missing required environment variable: ${config.name}`);


### PR DESCRIPTION
## The bug
Latest blog post hero image (and every other dynamic OG image on the site) was failing to load — both on the blog index card and on the article page.

## Root cause
Production logs showed every \`/api/og/*\` call returning 500 with \`Error: Missing required environment variable\`. Tracing it back:

1. \`instrumentation.ts\` calls \`validateEnv()\` on every function startup.
2. \`validateEnv()\` throws when \`OPENWEATHER_API_KEY\` is missing.
3. \`instrumentation.register()\` re-throws in production.
4. Edge function startup aborts → 500 to the client, no image rendered.

But \`/api/og/blog\` doesn't use \`OPENWEATHER_API_KEY\` at all. The validation was killing edge functions for a key they don't need.

The key is no longer actually required since the Open-Meteo migration. \`.env.example\` already says so:
> NOTE: Primary weather data comes from Open-Meteo (free, no key needed)... This key is only still referenced by legacy/fallback endpoints: pollen, UV (onecall v3), precipitation history, extremes.

## Fix
Move \`OPENWEATHER_API_KEY\` from \`required\` → \`optional\` in \`lib/env-validation.ts\`. Routes that still need it check at request time and handle missing keys themselves (verified — every legacy caller does \`process.env.OPENWEATHER_API_KEY\` at request scope).

## Diagnosis trace
- Probed live site with Playwright: confirmed \`/api/og/blog?title=...&type=space\` returns 500, hero \`<img>\` has \`naturalWidth: 0\`.
- Tested \`/api/og\`, \`/api/og/weather-card\`, \`/api/og/blog\` with curl — all 500.
- Vercel runtime logs (production, level=error, last 2h): every \`/api/og/*\` shows \`Missing required environment variable\`. Same message also flooding non-OG routes (\`/blog\`, \`/weather/[city]\`) but those return 200 because the throw doesn't kill node-runtime serverless functions the same way it kills edge functions.

## Test plan
- [ ] Vercel preview deploys; hit \`/api/og/blog?title=test&type=space\` on the preview URL — expect 200 + a PNG.
- [ ] Visit \`/blog\` on preview, confirm featured-card hero image renders.
- [ ] Click into latest post, confirm article hero image renders.
- [ ] After merge, re-probe production: \`curl -I https://www.16bitweather.co/api/og/blog?title=test&type=space\` should return 200.

## Side benefit
The cascade of \`Missing required environment variable\` log spam on \`/blog\`, \`/weather/[city]\`, etc. (visible in the runtime logs but ignored because pages still rendered) will also stop. Cleaner production logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * OpenWeather API key is now optional in environment configuration, streamlining setup requirements and reducing mandatory configuration parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->