### PR TITLE
fix(newsletter): rotate closer header and gate image pool by data signals

### DIFF
--- a/__tests__/newsletter/closers.test.ts
+++ b/__tests__/newsletter/closers.test.ts
@@ -1,0 +1,48 @@
+import { pickCloser } from '../../scripts/newsletter/closers';
+
+describe('pickCloser', () => {
+  it('returns a CloserChoice with stable id and instruction', () => {
+    const choice = pickCloser(new Date('2026-04-29T12:00:00Z'));
+    expect(typeof choice.id).toBe('string');
+    expect(choice.id.length).toBeGreaterThan(0);
+    expect(typeof choice.instruction).toBe('string');
+    expect(choice.instruction.length).toBeGreaterThan(20);
+  });
+
+  it('produces distinct closers for Wed and Sun in the same week', () => {
+    // April 29 is Wednesday, May 3 is Sunday — 4 days apart.
+    // With an 8-element rotation, Wed=N and Sun=N+4 always differ.
+    const wed = pickCloser(new Date('2026-04-29T12:00:00Z'));
+    const sun = pickCloser(new Date('2026-05-03T12:00:00Z'));
+    expect(wed.id).not.toBe(sun.id);
+  });
+
+  it('cycles through every closer over the year', () => {
+    const seen = new Set<string>();
+    for (let day = 0; day < 16; day++) {
+      const date = new Date(Date.UTC(2026, 0, 1 + day, 12, 0, 0));
+      seen.add(pickCloser(date).id);
+    }
+    // 8 entries in the rotation; 16 sample days should hit all of them.
+    expect(seen.size).toBe(8);
+  });
+
+  it('drops the labeled section once per cycle (natural wrap-up)', () => {
+    // Find a date where the rotation lands on the null slot — the
+    // 8th entry. Day-of-year 7 (Jan 8) modulo 8 → index 7.
+    const choice = pickCloser(new Date('2026-01-08T12:00:00Z'));
+    expect(choice.header).toBeNull();
+    expect(choice.id).toBe('natural-wrapup');
+    expect(choice.instruction).toMatch(/natural wrap-up|closing paragraph/i);
+  });
+
+  it('never returns "Bottom Line"', () => {
+    const seen = new Set<string>();
+    for (let day = 0; day < 8; day++) {
+      const date = new Date(Date.UTC(2026, 0, 1 + day, 12, 0, 0));
+      const c = pickCloser(date);
+      seen.add(c.header ?? 'null');
+      expect(c.header).not.toBe('Bottom Line');
+    }
+  });
+});

--- a/__tests__/newsletter/images.test.ts
+++ b/__tests__/newsletter/images.test.ts
@@ -1,6 +1,7 @@
 import {
   IMAGES,
   countImagesByTopic,
+  getActiveTopics,
   selectImages,
   type ImageEntry,
 } from '../../scripts/newsletter/images';
@@ -119,6 +120,81 @@ describe('selectImages', () => {
         rng: () => 0,
       }),
     ).toThrow(/catalog could not satisfy/);
+  });
+
+  it('excludes tropical from active topics outside hurricane season', () => {
+    // April — not hurricane season — and no severe/space data signals.
+    const active = getActiveTopics({
+      severeReportCount: 0,
+      maxKpPastWeek: 0,
+      notableFlareCount: 0,
+      significantQuakeCount: 0,
+      now: new Date('2026-04-26T12:00:00Z'),
+    });
+    expect(active.has('tropical')).toBe(false);
+    // Atmosphere/aviation/marine etc. should always be allowed.
+    expect(active.has('atmosphere_layers')).toBe(true);
+    expect(active.has('marine')).toBe(true);
+  });
+
+  it('includes tropical during hurricane season', () => {
+    const active = getActiveTopics({
+      severeReportCount: 0,
+      maxKpPastWeek: 0,
+      notableFlareCount: 0,
+      significantQuakeCount: 0,
+      now: new Date('2026-09-15T12:00:00Z'),
+    });
+    expect(active.has('tropical')).toBe(true);
+  });
+
+  it('gates severe_storms behind real report counts', () => {
+    const quiet = getActiveTopics({
+      severeReportCount: 0,
+      maxKpPastWeek: 0,
+      notableFlareCount: 0,
+      significantQuakeCount: 0,
+      now: new Date('2026-04-26T12:00:00Z'),
+    });
+    expect(quiet.has('severe_storms')).toBe(false);
+
+    const active = getActiveTopics({
+      severeReportCount: 47,
+      maxKpPastWeek: 0,
+      notableFlareCount: 0,
+      significantQuakeCount: 0,
+      now: new Date('2026-04-26T12:00:00Z'),
+    });
+    expect(active.has('severe_storms')).toBe(true);
+  });
+
+  it('gates space_weather on Kp >= 4 OR notable flares', () => {
+    const quiet = getActiveTopics({
+      severeReportCount: 0,
+      maxKpPastWeek: 2,
+      notableFlareCount: 0,
+      significantQuakeCount: 0,
+      now: new Date('2026-04-26T12:00:00Z'),
+    });
+    expect(quiet.has('space_weather')).toBe(false);
+
+    const flareOnly = getActiveTopics({
+      severeReportCount: 0,
+      maxKpPastWeek: 0,
+      notableFlareCount: 1,
+      significantQuakeCount: 0,
+      now: new Date('2026-04-26T12:00:00Z'),
+    });
+    expect(flareOnly.has('space_weather')).toBe(true);
+
+    const stormy = getActiveTopics({
+      severeReportCount: 0,
+      maxKpPastWeek: 5,
+      notableFlareCount: 0,
+      significantQuakeCount: 0,
+      now: new Date('2026-04-26T12:00:00Z'),
+    });
+    expect(stormy.has('space_weather')).toBe(true);
   });
 
   it('produces different orderings across rng seeds', () => {

--- a/__tests__/newsletter/voice.test.ts
+++ b/__tests__/newsletter/voice.test.ts
@@ -13,7 +13,7 @@ The polar jet sagged south of 40°N this week, dropping freezing levels across t
 
 The pattern relaxes by Wednesday as a Pacific ridge rebuilds.
 
-## Bottom Line
+## What to Watch
 
 - Cold persists through Tuesday across the upper Midwest.
 - Severe risk shifts to the Gulf Coast late week.`;
@@ -149,8 +149,11 @@ describe('VOICE_SYSTEM_PROMPT', () => {
     expect(VOICE_SYSTEM_PROMPT).toMatch(/no\s+emoji|no emojis/i);
   });
 
-  it('mentions the Bottom Line section requirement', () => {
+  it('warns against defaulting to "## Bottom Line"', () => {
+    // The closer is rotated per-run via scripts/newsletter/closers.ts; the
+    // voice spec explicitly tells the model NOT to fall back to "Bottom Line".
     expect(VOICE_SYSTEM_PROMPT).toMatch(/Bottom Line/);
+    expect(VOICE_SYSTEM_PROMPT).toMatch(/rotated out|do not default/i);
   });
 
   it('mentions the 2-3 image requirement', () => {

--- a/lib/blog/index.ts
+++ b/lib/blog/index.ts
@@ -31,6 +31,7 @@ export interface BlogPost {
   spotlight_active?: string | null
   generation_retries?: number
   word_count?: number
+  closer_used?: string
 }
 
 export function getAllPosts(): BlogPost[] {
@@ -66,6 +67,7 @@ export function getAllPosts(): BlogPost[] {
       spotlight_active: data.spotlight_active,
       generation_retries: data.generation_retries,
       word_count: data.word_count,
+      closer_used: data.closer_used,
     } as BlogPost
   })
   

--- a/scripts/newsletter/closers.ts
+++ b/scripts/newsletter/closers.ts
@@ -1,0 +1,52 @@
+/**
+ * Closer-section rotation. Every post ending with "## Bottom Line" is the
+ * AI tell readers learn to spot. Rotate by day-of-year so back-to-back
+ * Wed → Sun runs land on different closers, and a `null` slot drops the
+ * labeled header entirely once per cycle in favor of a natural wrap-up.
+ *
+ * Ported from the legacy generator (commit a334c00). With 8 entries and
+ * Wed/Sun being 4 days apart, same-week posts always pull distinct closers.
+ */
+
+const CLOSER_HEADERS: (string | null)[] = [
+  'What to Watch',
+  'The Takeaway',
+  'Looking Ahead',
+  'Eyes on the Sky',
+  'Heads Up',
+  'On the Radar',
+  'Field Notes',
+  null,
+];
+
+export interface CloserChoice {
+  /** Header text for the section, or null when no labeled section. */
+  header: string | null;
+  /** Prompt fragment instructing the model how to close. */
+  instruction: string;
+  /** Stable identifier for the chosen style — recorded in frontmatter. */
+  id: string;
+}
+
+/**
+ * Returns the closer style for a given run date. Defaults to `new Date()`
+ * for normal use; tests can pin the date for determinism.
+ */
+export function pickCloser(now: Date = new Date()): CloserChoice {
+  const startOfYear = new Date(Date.UTC(now.getUTCFullYear(), 0, 1));
+  const dayOfYear = Math.floor((now.getTime() - startOfYear.getTime()) / 86_400_000);
+  const choice = CLOSER_HEADERS[dayOfYear % CLOSER_HEADERS.length];
+  if (choice === null) {
+    return {
+      header: null,
+      instruction:
+        'Close with a strong, natural wrap-up paragraph (2-3 sentences) that ties the piece together. Do NOT use a labeled section like "Bottom Line" or "Takeaway" — just a clean closing paragraph.',
+      id: 'natural-wrapup',
+    };
+  }
+  return {
+    header: choice,
+    instruction: `End with a "## ${choice}" section — 2-3 brief points, each one sentence. Concrete things to do, watch for, or remember.`,
+    id: choice.toLowerCase().replace(/\s+/g, '-'),
+  };
+}

--- a/scripts/newsletter/images.ts
+++ b/scripts/newsletter/images.ts
@@ -576,6 +576,59 @@ function pickFrom(
   }
 }
 
+/**
+ * Returns the set of topic slugs that are "live" given the week's actual
+ * data. Used by Sunday image selection so we don't drop Hurricane Katrina
+ * into a post about late-April Plains tornadoes (it has happened).
+ *
+ * Topics that are always relevant — atmosphere structure, tech_and_models
+ * (satellite imagery), aviation, marine, climate background — stay on. The
+ * gates only filter event-driven topics: severe_storms, tropical, space_weather.
+ */
+export interface ActivityIndicators {
+  severeReportCount: number;
+  maxKpPastWeek: number;
+  notableFlareCount: number;
+  significantQuakeCount: number;
+  /** Caller can pass a date override for tests. Defaults to now. */
+  now?: Date;
+}
+
+export function getActiveTopics(indicators: ActivityIndicators): Set<TopicSlug> {
+  const now = indicators.now ?? new Date();
+  const month = now.getUTCMonth() + 1; // 1-12
+  // Atlantic hurricane season is June 1 – November 30. Eastern Pacific is
+  // similar. Outside this window, only allow tropical imagery if there is
+  // an explicit signal — and we currently don't pull NHC active basins,
+  // so for v1 we simply gate by season.
+  const inHurricaneSeason = month >= 6 && month <= 11;
+
+  const active = new Set<TopicSlug>();
+  // Always-on (content-neutral atmospheric and structural imagery)
+  for (const slug of [
+    'atmosphere_layers',
+    'aviation',
+    'marine',
+    'tech_and_models',
+    'cryosphere',
+    'paleoclimate',
+    'urban_climate',
+    'biometeorology',
+    'agricultural',
+    'historical_events',
+    'volcanoes',
+    'ocean_currents',
+  ] as TopicSlug[]) {
+    active.add(slug);
+  }
+  if (indicators.severeReportCount > 0) active.add('severe_storms');
+  if (indicators.maxKpPastWeek >= 4 || indicators.notableFlareCount > 0) {
+    active.add('space_weather');
+  }
+  if (inHurricaneSeason) active.add('tropical');
+  return active;
+}
+
 export function countImagesByTopic(): Record<TopicSlug, number> {
   const counts = Object.fromEntries(TOPIC_SLUGS.map((s) => [s, 0])) as Record<TopicSlug, number>;
   for (const img of IMAGES) {

--- a/scripts/newsletter/index.ts
+++ b/scripts/newsletter/index.ts
@@ -69,6 +69,7 @@ async function main() {
         spotlight: result.spotlight,
         retries: result.retries,
         wordCount: result.wordCount,
+        closerUsed: result.closer.id,
       },
       { dryRun },
     );
@@ -92,6 +93,7 @@ async function main() {
         spotlight: result.spotlight,
         retries: result.retries,
         wordCount: result.wordCount,
+        closerUsed: result.closer.id,
       },
       { dryRun },
     );

--- a/scripts/newsletter/publish.ts
+++ b/scripts/newsletter/publish.ts
@@ -26,6 +26,7 @@ export interface PublishWednesdayInput {
   spotlight: string | null;
   retries: number;
   wordCount: number;
+  closerUsed: string;
 }
 
 export interface PublishSundayInput {
@@ -40,6 +41,7 @@ export interface PublishSundayInput {
   spotlight: string | null;
   retries: number;
   wordCount: number;
+  closerUsed: string;
 }
 
 export type PublishInput = PublishWednesdayInput | PublishSundayInput;
@@ -78,6 +80,7 @@ export async function publishPost(input: PublishInput, opts: { dryRun?: boolean 
     spotlight_active: input.spotlight,
     generation_retries: input.retries,
     word_count: input.wordCount,
+    closer_used: input.closerUsed,
   };
 
   if (input.cadence === 'wednesday_topic') {

--- a/scripts/newsletter/sunday.ts
+++ b/scripts/newsletter/sunday.ts
@@ -12,7 +12,9 @@ import { fetchForecastOutlook } from './data/forecast';
 import { fetchPastWeekWarnings, MesonetEmptyError } from './data/mesonet';
 import { fetchSpaceWeatherSummary } from './data/space-weather';
 import { fetchPastWeekReports } from './data/spc-reports';
-import { selectImages, type ImageEntry } from './images';
+import { pickCloser, type CloserChoice } from './closers';
+import { getActiveTopics, selectImages, type ImageEntry } from './images';
+import type { TopicSlug } from './topics';
 import {
   callAnthropic,
   checkOpenerCollision,
@@ -43,6 +45,7 @@ export interface SundayResult {
   images: ImageEntry[];
   retries: number;
   wordCount: number;
+  closer: CloserChoice;
 }
 
 export async function runSunday(): Promise<SundayResult> {
@@ -78,14 +81,30 @@ export async function runSunday(): Promise<SundayResult> {
   ]);
   console.log(`[sunday] SPC: ${spcSummary.total} reports, max Kp: ${spaceSummary.maxKpPastWeek}, quakes: ${quakeSummary.significantCount} significant`);
 
-  // Sunday recap is a multi-domain summary, not a single topic. Pick
-  // images that span severe + tropical + space + marine/agricultural so
-  // the visual palette matches the content.
-  const sundayImageTopics = ['severe_storms', 'tropical', 'space_weather', 'tech_and_models'] as const;
+  // Sunday image pool is filtered by what's actually active in this
+  // week's data — see getActiveTopics. Without this, hurricane imagery
+  // ends up in April recaps because tropical was hardcoded.
+  const activeTopics = getActiveTopics({
+    severeReportCount: spcSummary.total,
+    maxKpPastWeek: spaceSummary.maxKpPastWeek,
+    notableFlareCount: spaceSummary.notableFlares.length,
+    significantQuakeCount: quakeSummary.significantCount,
+  });
+  const candidateOrder: TopicSlug[] = [
+    'severe_storms',
+    'space_weather',
+    'tech_and_models',
+    'atmosphere_layers',
+    'tropical',
+    'marine',
+    'aviation',
+    'agricultural',
+  ];
   const images: ImageEntry[] = [];
   const usedIds = new Set<string>(recentImageIds);
-  for (const t of sundayImageTopics) {
+  for (const t of candidateOrder) {
     if (images.length >= 3) break;
+    if (!activeTopics.has(t)) continue;
     try {
       const picked = selectImages({ topic: t, count: 1, excludeIds: usedIds });
       for (const p of picked) {
@@ -93,17 +112,21 @@ export async function runSunday(): Promise<SundayResult> {
         images.push(p);
       }
     } catch {
-      // pool starved — skip and try the next topic
+      // pool starved on this topic — skip and try the next
     }
   }
   if (images.length < 2) {
-    // Fallback: just pull any 2 unused images via a broad neighbor lookup.
+    // Last-resort fallback: any unused content-neutral images.
     const broadPicks = selectImages({ topic: 'tech_and_models', count: 2, excludeIds: usedIds });
     for (const p of broadPicks) images.push(p);
   }
-  console.log(`[sunday] selected images: ${images.map((i) => i.id).join(', ')}`);
+  console.log(
+    `[sunday] selected images: ${images.map((i) => i.id).join(', ')} (active topics: ${[...activeTopics].join(',')})`,
+  );
 
   const spotlight = getSpotlight();
+  const closer = pickCloser();
+  console.log(`[sunday] closer: ${closer.id}`);
 
   let draft = await generate({
     warnings,
@@ -115,6 +138,7 @@ export async function runSunday(): Promise<SundayResult> {
     denyPhrases,
     images,
     correction: null,
+    closer,
   });
 
   let retries = 0;
@@ -145,6 +169,7 @@ export async function runSunday(): Promise<SundayResult> {
       denyPhrases,
       images,
       correction: corrections.join('\n\n'),
+      closer,
     });
     openerHash = computeOpenerHash(draft);
     voiceViolations = sweepVoice(draft);
@@ -171,6 +196,7 @@ export async function runSunday(): Promise<SundayResult> {
       denyPhrases: [...denyPhrases, ...similarity.triggerPhrases],
       images,
       correction,
+      closer,
     });
     openerHash = computeOpenerHash(draft);
     try {
@@ -191,10 +217,12 @@ export async function runSunday(): Promise<SundayResult> {
     images,
     retries,
     wordCount: wordCount(draft),
+    closer,
   };
 }
 
 interface GenerateOpts {
+  closer: CloserChoice;
   warnings: Awaited<ReturnType<typeof fetchPastWeekWarnings>>;
   spcSummary: Awaited<ReturnType<typeof fetchPastWeekReports>>;
   spaceSummary: Awaited<ReturnType<typeof fetchSpaceWeatherSummary>>;
@@ -217,6 +245,7 @@ async function generate(opts: GenerateOpts): Promise<string> {
     denyPhrases,
     images,
     correction,
+    closer,
   } = opts;
 
   const systemBlocks = [
@@ -249,7 +278,7 @@ async function generate(opts: GenerateOpts): Promise<string> {
 - Open with a concrete specific hook from the past week's data — a named storm, a record, a count.
 - ## Rearview: 3-5 specific events. Cite states, magnitudes, dates. No generalities.
 - ## Roadmap: pattern overview, then 2-3 regional cuts (CONUS quadrants + a notable international callout). Tie to mechanism (jet stream position, ridge, trough, MJO phase, etc.) where you can.
-- ## Bottom Line: 2-3 actionable takeaways.`);
+- ${closer.instruction}`);
 
   if (correction) {
     sections.push(`CORRECTIONS FROM PRIOR ATTEMPT:\n${correction}`);

--- a/scripts/newsletter/voice.ts
+++ b/scripts/newsletter/voice.ts
@@ -29,7 +29,7 @@ Forbidden formatting:
 - No all-caps for emphasis. Use specificity instead.
 
 Required structure:
-- End with "## Bottom Line" — 2-3 actionable or memorable takeaways, each one sentence.
+- Close with whatever closing instruction the run-time prompt gives you. Do NOT default to "## Bottom Line" — that wording is a known AI tell and is rotated out per-run.
 - Include 2-3 inline images, separated by body text. Never at the very top, never at the very bottom.
 - Use ## section headers. Sub-sections only when they earn it. Skip ### unless the structure genuinely needs three levels.
 

--- a/scripts/newsletter/wednesday.ts
+++ b/scripts/newsletter/wednesday.ts
@@ -4,6 +4,7 @@
  */
 
 import { getSpotlight } from '../blog-spotlight';
+import { pickCloser, type CloserChoice } from './closers';
 import { selectImages, type ImageEntry } from './images';
 import { findAngleForTopic, fetchHeadlines, type NewsAngle } from './news';
 import {
@@ -42,6 +43,7 @@ export interface WednesdayResult {
   images: ImageEntry[];
   retries: number;
   wordCount: number;
+  closer: CloserChoice;
 }
 
 export async function runWednesday(): Promise<WednesdayResult> {
@@ -62,6 +64,8 @@ export async function runWednesday(): Promise<WednesdayResult> {
   }
 
   const spotlight = getSpotlight();
+  const closer = pickCloser();
+  console.log(`[wednesday] closer: ${closer.id}`);
   const denyPhrases = getKeyPhraseDenyList(history, 'wednesday_topic');
   const recentOpenerHashes = getOpenerHashes(history, 'wednesday_topic');
   const recentImageIds = new Set(getRecentImages(history));
@@ -81,6 +85,7 @@ export async function runWednesday(): Promise<WednesdayResult> {
     denyPhrases,
     images,
     correction: null,
+    closer,
   });
 
   let retries = 0;
@@ -106,6 +111,7 @@ export async function runWednesday(): Promise<WednesdayResult> {
       denyPhrases,
       images,
       correction: corrections.join('\n\n'),
+      closer,
     });
     openerHash = computeOpenerHash(draft);
     voiceViolations = sweepVoice(draft);
@@ -129,6 +135,7 @@ export async function runWednesday(): Promise<WednesdayResult> {
       denyPhrases: [...denyPhrases, ...similarity.triggerPhrases],
       images,
       correction,
+      closer,
     });
     openerHash = computeOpenerHash(draft);
     try {
@@ -151,6 +158,7 @@ export async function runWednesday(): Promise<WednesdayResult> {
     images,
     retries,
     wordCount: wordCount(draft),
+    closer,
   };
 }
 
@@ -161,10 +169,11 @@ interface GenerateOpts {
   denyPhrases: string[];
   images: ImageEntry[];
   correction: string | null;
+  closer: CloserChoice;
 }
 
 async function generate(opts: GenerateOpts): Promise<string> {
-  const { topic, newsAngle, spotlight, denyPhrases, images, correction } = opts;
+  const { topic, newsAngle, spotlight, denyPhrases, images, correction, closer } = opts;
 
   const systemBlocks = [
     { type: 'text' as const, text: VOICE_SYSTEM_PROMPT, cache_control: { type: 'ephemeral' as const } },
@@ -199,7 +208,7 @@ async function generate(opts: GenerateOpts): Promise<string> {
   sections.push(`STRUCTURE:
 - Open with a concrete specific hook — a number, a place, a date, a measurement.
 - 2 or 3 ## section headers within the body. Use them to give the piece shape.
-- End with "## Bottom Line" — 2-3 actionable or memorable takeaways, each one sentence.
+- ${closer.instruction}
 - Word count target: 600-900.`);
 
   if (correction) {


### PR DESCRIPTION
## Summary

Two follow-ups to the newsletter redesign based on yesterday's Sunday post (PR #365 → merged as commit aa6294a):

1. **Hurricane Katrina shipped in an April Plains-tornado recap.** Sunday's image topic list was hardcoded `['severe_storms', 'tropical', 'space_weather', 'tech_and_models']`. April has no tropical activity, the only `tropical`-tagged image in our 51-entry catalog is Hurricane Katrina, so it got picked.

2. **Post ended with `## Bottom Line`** — the AI tell that was already removed in the legacy generator (commit a334c00) and that my redesign undid by mistake.

## Fixes

### Image relevance — `getActiveTopics(indicators, now)`

New helper in `images.ts` returns a `Set<TopicSlug>` filtered by the week's real data. Sunday now iterates a wider candidate ordering through that filter:

| Topic | Gate |
|---|---|
| `tropical` | Only inside June 1 – November 30 (Atlantic season) |
| `severe_storms` | Only when `spcSummary.total > 0` |
| `space_weather` | Only when `maxKpPastWeek >= 4` OR `notableFlares.length > 0` |
| atmosphere/aviation/marine/cryosphere/etc. | Always on (content-neutral) |

Verified locally — today's Sunday data (932 SPC reports, X2.5 flare, max Kp 0) yields:
- `tropical` excluded ✓
- `severe_storms` included (932 reports) ✓
- `space_weather` included (X-class flare) ✓
- 12 other topics always available

### Closer rotation — `scripts/newsletter/closers.ts`

Ported the legacy day-of-year rotation from a334c00. 8 entries:

```
What to Watch · The Takeaway · Looking Ahead · Eyes on the Sky
Heads Up · On the Radar · Field Notes · (no header — natural wrap-up)
```

With 8 entries and Wed/Sun being 4 days apart, same-week posts always pull distinct closers. Voice spec updated to instruct the model NOT to default to "Bottom Line". `closer_used` recorded in frontmatter.

Today's Sunday: closer is **"## Heads Up"**.

## Test plan

- [x] 9 new tests (6 closer rotation including "never returns Bottom Line"; 3 active-topics gating)
- [x] 378/378 unit tests passing
- [x] TypeScript clean
- [x] Local verification: today's Sunday config excludes `tropical`, picks "Heads Up"
- [ ] Trigger `newsletter-sunday.yml` after merge to confirm the next post (a) doesn't show Hurricane Katrina, (b) ends with `## Heads Up` instead of `## Bottom Line`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Newsletter closings now rotate dynamically throughout the year instead of using a fixed format.
  * Newsletter topics and images now activate dynamically based on current weather, storm, and space weather activity.

* **Updates**
  * Blog posts now include metadata tracking which closing style was used in each newsletter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->