### PR TITLE
fix(games): keep /games/[slug] static-eligible by skipping cookies()

### DIFF
--- a/app/games/[slug]/page.tsx
+++ b/app/games/[slug]/page.tsx
@@ -8,15 +8,17 @@
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 
-import { createServerSupabaseClient } from '@/lib/supabase/server';
+import { createPublicSupabaseClient } from '@/lib/supabase/server';
 import type { Game } from '@/lib/types/games';
 import GameDetailClient from './game-detail-client';
 
 const BASE_URL = 'https://www.16bitweather.co';
 
+// Public reads only — no auth/cookies — so this page stays static-eligible.
+// See createPublicSupabaseClient docstring for why this matters.
 async function getGameBySlug(slug: string): Promise<Game | null> {
   try {
-    const supabase = await createServerSupabaseClient();
+    const supabase = createPublicSupabaseClient();
     const { data, error } = await supabase
       .from('games')
       .select('*')
@@ -33,7 +35,7 @@ async function getGameBySlug(slug: string): Promise<Game | null> {
 
 export async function generateStaticParams(): Promise<Array<{ slug: string }>> {
   try {
-    const supabase = await createServerSupabaseClient();
+    const supabase = createPublicSupabaseClient();
     const { data } = await supabase
       .from('games')
       .select('slug')

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,7 +1,29 @@
 import { createServerClient } from '@supabase/ssr'
+import { createClient } from '@supabase/supabase-js'
 import { cookies } from 'next/headers'
 import { Database } from './types'
 import { PLACEHOLDER_URL, PLACEHOLDER_ANON_KEY, warnIfPlaceholder } from './constants'
+
+/**
+ * Cookie-free server-side Supabase client for public reads from static
+ * pages. Use this in `generateStaticParams`, `generateMetadata`, and any
+ * static-eligible page that only needs anon-key access.
+ *
+ * Why: createServerSupabaseClient (below) wires cookies() so it can carry
+ * the user's session. Calling cookies() inside a page that declares
+ * generateStaticParams forces Next.js to switch the page from static to
+ * dynamic at runtime ("Page changed from static to dynamic at runtime,
+ * reason: cookies"), which Sentry logs as an error. For routes that read
+ * truly-public data (e.g. `/games/[slug]`), use this client instead.
+ */
+export const createPublicSupabaseClient = () => {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || PLACEHOLDER_URL
+  const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || PLACEHOLDER_ANON_KEY
+  warnIfPlaceholder(supabaseUrl, supabaseKey, 'createPublicSupabaseClient')
+  return createClient<Database>(supabaseUrl, supabaseKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  })
+}
 
 // Create a server-side supabase client
 export const createServerSupabaseClient = async () => {


### PR DESCRIPTION
## Summary

Resolves Sentry [JAVASCRIPT-NEXTJS-Z](https://16bitweather.sentry.io/issues/JAVASCRIPT-NEXTJS-Z) — 14 events, 0 users (server-side noise) — \`Error: Page changed from static to dynamic at runtime /games/weather-trivia, reason: cookies\`.

## Root cause

\`/games/[slug]/page.tsx\` declares \`generateStaticParams\` (intent: static), but \`getGameBySlug\` calls \`createServerSupabaseClient()\` which wires \`cookies()\` through \`@supabase/ssr\`'s \`createServerClient\`. Next.js detects the runtime \`cookies()\` call and forces the page from static to dynamic, logging an error per request.

The page only does a public read of the \`games\` table. No session. No user-dependent RLS. The cookie wiring is dead weight that breaks static rendering for SEO.

## Fix

Added \`createPublicSupabaseClient()\` in \`lib/supabase/server.ts\` — a cookie-free anon-key client built on \`@supabase/supabase-js\`'s \`createClient\` (not the SSR variant). Switched both \`getGameBySlug\` and \`generateStaticParams\` to use it.

Future static pages doing public reads should use this helper rather than the cookie-wired \`createServerSupabaseClient\`.

## Test plan

- [x] Type-check clean
- [x] 378/378 unit tests passing
- [ ] After merge, watch Sentry — JAVASCRIPT-NEXTJS-Z should stop accruing events
- [ ] Verify in build output that \`/games/[slug]\` shows as \`SSG\` (static) rather than \`λ\` (dynamic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)