### PR TITLE
fix(extremes): validate lat/lon query params and abort stale client fetches

### DIFF
--- a/__tests__/parse-query-coords.test.ts
+++ b/__tests__/parse-query-coords.test.ts
@@ -1,0 +1,28 @@
+import { parseOptionalLatLonQuery } from '@/lib/extremes/parse-query-coords'
+
+describe('parseOptionalLatLonQuery', () => {
+  it('returns null when either param is null', () => {
+    expect(parseOptionalLatLonQuery(null, null)).toBeNull()
+    expect(parseOptionalLatLonQuery('1', null)).toBeNull()
+    expect(parseOptionalLatLonQuery(null, '1')).toBeNull()
+  })
+
+  it('returns null for empty or whitespace-only', () => {
+    expect(parseOptionalLatLonQuery('', '')).toBeNull()
+    expect(parseOptionalLatLonQuery('  ', '  ')).toBeNull()
+    expect(parseOptionalLatLonQuery('40.7', '')).toBeNull()
+  })
+
+  it('returns null for non-numeric or out of range', () => {
+    expect(parseOptionalLatLonQuery('abc', '-74')).toBeNull()
+    expect(parseOptionalLatLonQuery('91', '0')).toBeNull()
+    expect(parseOptionalLatLonQuery('0', '181')).toBeNull()
+  })
+
+  it('returns coords for valid pairs', () => {
+    expect(parseOptionalLatLonQuery('40.7128', '-74.0060')).toEqual({
+      lat: 40.7128,
+      lon: -74.0060,
+    })
+  })
+})

--- a/app/api/extremes/route.ts
+++ b/app/api/extremes/route.ts
@@ -19,6 +19,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { HOT_LOCATIONS, COLD_LOCATIONS, LOCATION_FACTS, HISTORICAL_AVERAGES, type LocationTemperature } from '@/lib/extremes/extremes-data';
+import { parseOptionalLatLonQuery } from '@/lib/extremes/parse-query-coords';
 
 /**
  * Fetch temperature data for a specific location using server-side API
@@ -76,8 +77,10 @@ export async function GET(request: NextRequest) {
     
     // Get user coordinates from query params (optional)
     const searchParams = request.nextUrl.searchParams;
-    const userLat = searchParams.get('lat');
-    const userLon = searchParams.get('lon');
+    const userCoords = parseOptionalLatLonQuery(
+      searchParams.get('lat'),
+      searchParams.get('lon')
+    );
     
     // Fetch all hot locations
     const hotPromises = HOT_LOCATIONS.map(loc => fetchLocationTemperature(loc, apiKey));
@@ -93,12 +96,12 @@ export async function GET(request: NextRequest) {
     validHotResults.sort((a, b) => b.temp - a.temp);
     validColdResults.sort((a, b) => a.temp - b.temp);
     
-    // Get user location temperature if provided
+    // Get user location temperature only when valid lat/lon query params are present
     let userLocation;
-    if (userLat !== undefined && userLon !== undefined) {
+    if (userCoords) {
       try {
         const response = await fetch(
-          `https://api.openweathermap.org/data/2.5/weather?lat=${userLat}&lon=${userLon}&units=imperial&appid=${apiKey}`
+          `https://api.openweathermap.org/data/2.5/weather?lat=${userCoords.lat}&lon=${userCoords.lon}&units=imperial&appid=${apiKey}`
         );
         
         if (response.ok) {

--- a/app/extremes/page.tsx
+++ b/app/extremes/page.tsx
@@ -67,13 +67,18 @@ export default function ExtremesPage() {
   const [autoRefresh, setAutoRefresh] = useState(true)
   const [selectedLocation, setSelectedLocation] = useState<LocationTemperature | null>(null)
   const refreshIntervalRef = useRef<NodeJS.Timeout | null>(null)
+  const fetchAbortRef = useRef<AbortController | null>(null)
 
   const handleLocationClick = (location: LocationTemperature) => {
     setSelectedLocation(location)
   }
 
-  // Fetch extremes data
+  // Fetch extremes data (abort in-flight request when a newer one starts — geolocation vs initial load)
   const fetchData = async (skipCache = false) => {
+    fetchAbortRef.current?.abort()
+    const controller = new AbortController()
+    fetchAbortRef.current = controller
+
     try {
       // Check client-side cache first
       if (!skipCache) {
@@ -93,20 +98,25 @@ export default function ExtremesPage() {
         url += `?lat=${userCoords.lat}&lon=${userCoords.lon}`
       }
 
-      const response = await fetch(url)
+      const response = await fetch(url, { signal: controller.signal })
       const responseData = await response.json()
 
       if (!response.ok) {
         throw new Error(responseData.error || 'Failed to fetch extreme temperatures')
       }
 
+      if (controller.signal.aborted) return
+
       setData(responseData)
       setCachedExtremesClient(responseData) // Cache on client side
     } catch (err) {
+      if ((err as Error).name === 'AbortError') return
       console.error('Error fetching extremes:', err)
       setError(err instanceof Error ? err.message : 'An error occurred')
     } finally {
-      setLoading(false)
+      if (!controller.signal.aborted) {
+        setLoading(false)
+      }
     }
   }
 
@@ -127,10 +137,13 @@ export default function ExtremesPage() {
     }
   }
 
-  // Initial fetch
+  // Initial fetch + request browser location (second fetch runs when userCoords is set)
   useEffect(() => {
     getUserLocation()
-    fetchData()
+    void fetchData()
+    return () => {
+      fetchAbortRef.current?.abort()
+    }
   }, [])
 
   // Re-fetch when user coords change

--- a/lib/extremes/parse-query-coords.ts
+++ b/lib/extremes/parse-query-coords.ts
@@ -1,0 +1,18 @@
+/**
+ * Parse optional lat/lon from URL search params (NextRequest / URLSearchParams).
+ * Returns null if either is missing, blank, non-numeric, or out of WGS84 range.
+ */
+export function parseOptionalLatLonQuery(
+  latRaw: string | null,
+  lonRaw: string | null
+): { lat: number; lon: number } | null {
+  if (latRaw == null || lonRaw == null) return null
+  const tLat = latRaw.trim()
+  const tLon = lonRaw.trim()
+  if (tLat === '' || tLon === '') return null
+  const lat = Number.parseFloat(tLat)
+  const lon = Number.parseFloat(tLon)
+  if (!Number.isFinite(lat) || !Number.isFinite(lon)) return null
+  if (lat < -90 || lat > 90 || lon < -180 || lon > 180) return null
+  return { lat, lon }
+}

--- a/lib/validations/storm-report.ts
+++ b/lib/validations/storm-report.ts
@@ -10,8 +10,6 @@ export const stormReportSubmitSchema = z.object({
   occurred_at: z.string().datetime().optional(),
 })
 
-export type StormReportSubmitInput = z.infer<typeof stormReportSubmitSchema>
-
 export function formatStormReportValidationErrors(err: z.ZodError): string {
   return err.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; ')
 }


### PR DESCRIPTION
QA audit follow-up.

## Changes
- **API `/api/extremes`:** `searchParams.get()` returns `null` when absent; the previous `!== undefined` check was always true, so OpenWeather could be called with literal `lat=null&lon=null`. Added `parseOptionalLatLonQuery` with trim, finite numbers, and WGS84 bounds.
- **Extremes page:** `AbortController` on fetch so the initial request cannot overwrite data after geolocation returns and triggers a second fetch.
- **Hygiene:** Removed unused `StormReportSubmitInput` export (Knip).

## Tests
- New unit tests: `__tests__/parse-query-coords.test.ts`
- Full Jest suite and Knip pass locally.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for location coordinate validation.

* **Bug Fixes**
  * Improved validation of latitude/longitude query parameters to properly reject invalid or out-of-range values.
  * Implemented automatic cancellation of previous requests to prevent stale data responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->