### PR TITLE
chore(security): add gitleaks pre-commit and pre-push hooks

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -62,5 +62,9 @@ regexes = [
 ]
 
 commits = [
-    "f091ee9530ec59c357c851f1c38a0b81030bf2ef"
+    "f091ee9530ec59c357c851f1c38a0b81030bf2ef",
+    "aafbcf5f8ca6e85c8ef5b525fb939521b24bc76d",
+    "ebad606e9f80014cda5fc3aef0d8c262b77338d0",
+    "314fcb653057a0b350821a7312ef28fe4a0b6e83",
+    "59044748bced975d40fd7fe42427001cc0e4765a",
 ]

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+# Block commits that introduce secrets.
+# Scans only the staged diff — fast (typically <100ms).
+# Bypass in a true emergency with `git commit --no-verify`.
+
+if ! command -v gitleaks >/dev/null 2>&1; then
+  echo "[pre-commit] gitleaks not installed — install with: brew install gitleaks"
+  echo "[pre-commit] skipping secret scan (NOT recommended)"
+  exit 0
+fi
+
+gitleaks protect --staged --redact -v --no-banner

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,7 +4,10 @@
 # Bypass in a true emergency with `git commit --no-verify`.
 
 if ! command -v gitleaks >/dev/null 2>&1; then
-  echo "[pre-commit] gitleaks not installed — install with: brew install gitleaks"
+  echo "[pre-commit] gitleaks not installed. Install one of:"
+  echo "  - macOS:        brew install gitleaks"
+  echo "  - Debian/Ubuntu: sudo apt-get install gitleaks"
+  echo "  - Other:        https://github.com/gitleaks/gitleaks#installing"
   echo "[pre-commit] skipping secret scan (NOT recommended)"
   exit 0
 fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -9,4 +9,4 @@ if ! command -v gitleaks >/dev/null 2>&1; then
   exit 0
 fi
 
-gitleaks protect --staged --redact -v --no-banner
+gitleaks git --pre-commit --staged --redact -v --no-banner

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -4,7 +4,10 @@
 # committed without gitleaks installed.
 
 if ! command -v gitleaks >/dev/null 2>&1; then
-  echo "[pre-push] gitleaks not installed — install with: brew install gitleaks"
+  echo "[pre-push] gitleaks not installed. Install one of:"
+  echo "  - macOS:        brew install gitleaks"
+  echo "  - Debian/Ubuntu: sudo apt-get install gitleaks"
+  echo "  - Other:        https://github.com/gitleaks/gitleaks#installing"
   echo "[pre-push] skipping secret scan (NOT recommended)"
   exit 0
 fi

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+# Block pushes that contain secrets anywhere in unpushed commits.
+# Backstop in case pre-commit was bypassed (--no-verify) or a different machine
+# committed without gitleaks installed.
+
+if ! command -v gitleaks >/dev/null 2>&1; then
+  echo "[pre-push] gitleaks not installed — install with: brew install gitleaks"
+  echo "[pre-push] skipping secret scan (NOT recommended)"
+  exit 0
+fi
+
+gitleaks detect --redact -v --no-banner

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -9,4 +9,12 @@ if ! command -v gitleaks >/dev/null 2>&1; then
   exit 0
 fi
 
-gitleaks detect --redact -v --no-banner
+# Limit the scan to commits that haven't been pushed yet. If the branch
+# has no upstream configured (e.g., first push), scan the full reachable
+# history as a safe fallback.
+upstream="$(git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null || true)"
+if [ -n "$upstream" ]; then
+  gitleaks git --log-opts="${upstream}..HEAD" --redact -v --no-banner
+else
+  gitleaks git --redact -v --no-banner
+fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,6 +70,7 @@
         "dotenv": "^17.4.2",
         "eslint": "^10.3.0",
         "eslint-config-next": "^16.2.4",
+        "husky": "^9.1.7",
         "identity-obj-proxy": "^3.0.0",
         "jest": "^30.2.0",
         "jest-environment-jsdom": "^30.2.0",
@@ -13313,6 +13314,22 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iceberg-js": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "validate:pr": "npm run build && npm run test:e2e && npm run lighthouse",
     "knip": "knip",
     "knip:fix": "knip --fix",
-    "validate:images": "tsx scripts/newsletter/validate-images.ts"
+    "validate:images": "tsx scripts/newsletter/validate-images.ts",
+    "prepare": "husky"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.74",
@@ -84,6 +85,7 @@
     "dotenv": "^17.4.2",
     "eslint": "^10.3.0",
     "eslint-config-next": "^16.2.4",
+    "husky": "^9.1.7",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^30.2.0",
     "jest-environment-jsdom": "^30.2.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "knip": "knip",
     "knip:fix": "knip --fix",
     "validate:images": "tsx scripts/newsletter/validate-images.ts",
-    "prepare": "husky"
+    "prepare": "husky || true"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.74",


### PR DESCRIPTION
## Summary
- Adds `.husky/pre-commit` and `.husky/pre-push` hooks that run gitleaks before commits and pushes — catches secret leaks at the developer's machine instead of days later via the scheduled CI scan.
- Allowlists 4 historical leak commits + 1 doc-placeholder false positive in `.gitleaks.toml` so scheduled scans stay green. All real secrets in those commits are already rotated/revoked.
- Adds `husky` as a dev dependency with a `prepare` script so hooks install automatically on `npm install`.

## Why
Three production secrets reached `main` between May and Oct 2025:
- Sentry user auth token (`sntryu_…`) in `SENTRY_SETUP_GUIDE.md`
- Sentry org auth token (`sntrys_…`) in `.claude/settings.local.json`
- OpenWeatherMap API key in `local-dev-config.ts`

Root cause: `.gitignore` only matches paths, not content. Patterns like `*sntryu_*` only match filenames containing that text, not tokens pasted *inside* a file. The scheduled gitleaks workflow caught them, but only after they'd been public for months.

## What this protects against now
- Pasting tokens into any tracked file (md, ts, json) — caught at commit
- Claude Code allowlist storing literal `SECRET=value` Bash entries — caught
- Bypass attempts via a different machine — caught at push as backstop
- Scheduled CI workflow — passes (allowlist applies there too)

## Caveats
- Hooks travel with the repo, but `gitleaks` itself does not. Run `brew install gitleaks` once per dev machine. Hooks degrade gracefully (warn + skip) if not installed.
- `git commit --no-verify` / `git push --no-verify` still bypass these hooks.

## Test plan
- [x] Full repo scan: `gitleaks detect` reports 0 leaks
- [x] Tried committing a fake `sntryu_…` token → blocked by pre-commit (exit 1)
- [x] This branch's own commit passed both pre-commit and pre-push hooks
- [ ] CI scheduled secret-scanning workflow goes green on next run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated secret scanning before commits and pushes to help prevent sensitive data from entering the repository.

* **Chores**
  * Expanded the scanning allowlist to include additional approved commits.
  * Added Husky setup (prepare script and dev dependency) to manage the Git hooks for the scanning workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->