### PR TITLE
fix: post-audit batch — middleware wiring, open-meteo units, ownership checks

### DIFF
--- a/__tests__/open-meteo-forecast-route.test.ts
+++ b/__tests__/open-meteo-forecast-route.test.ts
@@ -71,7 +71,12 @@ describe('GET /api/open-meteo/forecast', () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.latitude).toBe(40.71);
-    expect(mockedFetch).toHaveBeenCalledWith(40.71, -74.01, { forecastDays: 7 });
+    expect(mockedFetch).toHaveBeenCalledWith(40.71, -74.01, {
+      forecastDays: 7,
+      temperatureUnit: 'fahrenheit',
+      windSpeedUnit: 'mph',
+      precipitationUnit: 'inch',
+    });
   });
 
   it('should return 400 for invalid coordinates', async () => {
@@ -107,6 +112,11 @@ describe('GET /api/open-meteo/forecast', () => {
     const req = new NextRequest('http://localhost/api/open-meteo/forecast?lat=40.71&lon=-74.01&days=30');
     const res = await GET(req);
     expect(res.status).toBe(200);
-    expect(mockedFetch).toHaveBeenCalledWith(40.71, -74.01, { forecastDays: 16 });
+    expect(mockedFetch).toHaveBeenCalledWith(40.71, -74.01, {
+      forecastDays: 16,
+      temperatureUnit: 'fahrenheit',
+      windSpeedUnit: 'mph',
+      precipitationUnit: 'inch',
+    });
   });
 });

--- a/app/api/dashboard-weather/route.ts
+++ b/app/api/dashboard-weather/route.ts
@@ -33,6 +33,7 @@ export async function GET(request: NextRequest) {
     const { searchParams } = new URL(request.url)
     const lat = searchParams.get('lat')
     const lon = searchParams.get('lon')
+    const units = searchParams.get('units') === 'metric' ? 'metric' : 'imperial'
 
     if (!lat || !lon) {
       return NextResponse.json({ error: 'Latitude and longitude are required' }, { status: 400 })
@@ -48,26 +49,29 @@ export async function GET(request: NextRequest) {
     // Phase 2: Use Open-Meteo instead of OpenWeatherMap
     const forecast = await fetchOpenMeteoForecast(latitude, longitude, {
       forecastDays: 1,
-      temperatureUnit: 'fahrenheit',
-      windSpeedUnit: 'mph',
-      precipitationUnit: 'inch',
+      temperatureUnit: units === 'metric' ? 'celsius' : 'fahrenheit',
+      windSpeedUnit: units === 'metric' ? 'kmh' : 'mph',
+      precipitationUnit: units === 'metric' ? 'mm' : 'inch',
     })
 
     const current = forecast.current
     const hourly = forecast.hourly
 
-    // Find current hour's visibility
+    // Find current hour's visibility (Open-Meteo returns meters regardless of unit prefs)
     const now = new Date()
-    let visibilityKm = 10
+    let visibilityRaw = 10000
     if (hourly?.time && hourly?.visibility) {
       for (let i = 0; i < hourly.time.length; i++) {
         if (new Date(hourly.time[i]) >= now) {
-          // visibility is in meters from Open-Meteo
-          visibilityKm = Math.round((hourly.visibility[i] ?? 10000) / 1000)
+          visibilityRaw = hourly.visibility[i] ?? 10000
           break
         }
       }
     }
+    const visibility =
+      units === 'metric'
+        ? Math.round(visibilityRaw / 1000) // km
+        : Math.round(visibilityRaw / 1609) // miles
 
     // Transform to dashboard format (same shape as before)
     const dashboardWeather = {
@@ -78,7 +82,8 @@ export async function GET(request: NextRequest) {
       icon: wmoToOWMIcon(current?.weather_code ?? 0, current?.is_day ?? 1),
       feelsLike: Math.round(current?.apparent_temperature ?? 0),
       pressure: Math.round(current?.surface_pressure ?? 1013),
-      visibility: visibilityKm
+      visibility,
+      units,
     }
 
     return NextResponse.json(dashboardWeather, {

--- a/app/api/open-meteo/forecast/route.ts
+++ b/app/api/open-meteo/forecast/route.ts
@@ -37,10 +37,25 @@ export async function GET(request: NextRequest) {
       );
     }
 
+    // Allowlist unit values — they're forwarded into the upstream Open-Meteo URL.
+    const tempUnitParam = sp.get('temperature_unit');
+    const windUnitParam = sp.get('wind_speed_unit');
+    const precipUnitParam = sp.get('precipitation_unit');
+    const temperatureUnit: 'celsius' | 'fahrenheit' =
+      tempUnitParam === 'celsius' ? 'celsius' : 'fahrenheit';
+    const windSpeedUnit: 'mph' | 'kmh' | 'ms' | 'kn' =
+      windUnitParam === 'kmh' || windUnitParam === 'ms' || windUnitParam === 'kn'
+        ? windUnitParam
+        : 'mph';
+    const precipitationUnit: 'inch' | 'mm' = precipUnitParam === 'mm' ? 'mm' : 'inch';
+
     const parsedDays = days ? parseInt(days, 10) : 7;
     const forecastDays = Number.isNaN(parsedDays) ? 7 : Math.min(Math.max(parsedDays, 1), 16);
     const data = await fetchOpenMeteoForecast(latitude, longitude, {
       forecastDays,
+      temperatureUnit,
+      windSpeedUnit,
+      precipitationUnit,
     });
 
     return NextResponse.json(data, {

--- a/app/api/stargazer/route.ts
+++ b/app/api/stargazer/route.ts
@@ -391,7 +391,8 @@ export async function GET(request: NextRequest) {
           peakDate.setFullYear(peakDate.getFullYear() + 1);
         }
         const peakMoon = calculateMoonInfo(lat, lon, calculateDarkWindow(lat, lon, peakDate));
-        const moonIllumPct = peakMoon.illumination * 100;
+        // peakMoon.illumination is already 0-100 (see lib/stargazer/astronomy.ts)
+        const moonIllumPct = peakMoon.illumination;
 
         let moonInterference: MeteorShowerEvent['moonInterference'];
         if (moonIllumPct < 15) {

--- a/app/warnings/warnings-client.tsx
+++ b/app/warnings/warnings-client.tsx
@@ -77,53 +77,67 @@ export default function WarningsClient() {
   const [userPoint, setUserPoint] = useState<{ lat: number; lon: number } | null>(null)
   const [geoBusy, setGeoBusy] = useState(false)
 
-  const load = useCallback(async (point: { lat: number; lon: number } | null) => {
-    setLoading(true)
-    setError(null)
-    const qp = point ? `&point=${point.lat},${point.lon}` : ''
-    try {
-      const [dRes, gRes, sRes, cRes] = await Promise.all([
-        fetch(`/api/weather/alerts?detail=1${qp}`),
-        fetch(`/api/weather/alerts?geojson=1${qp}`),
-        fetch('/api/weather/storm-reports?days=2'),
-        fetch('/api/storm-reports'),
-      ])
-      if (!dRes.ok) throw new Error('alerts detail failed')
-      const dJson = (await dRes.json()) as { alerts: NWSAlertDetail[]; wis: WISScore }
-      setAlerts(dJson.alerts ?? [])
-      setWis(dJson.wis ?? null)
+  const load = useCallback(
+    async (point: { lat: number; lon: number } | null, signal?: AbortSignal) => {
+      setLoading(true)
+      setError(null)
+      const qp = point ? `&point=${point.lat},${point.lon}` : ''
+      try {
+        const [dRes, gRes, sRes, cRes] = await Promise.all([
+          fetch(`/api/weather/alerts?detail=1${qp}`, { signal }),
+          fetch(`/api/weather/alerts?geojson=1${qp}`, { signal }),
+          fetch('/api/weather/storm-reports?days=2', { signal }),
+          fetch('/api/storm-reports', { signal }),
+        ])
+        if (!dRes.ok) throw new Error('alerts detail failed')
+        const dJson = (await dRes.json()) as { alerts: NWSAlertDetail[]; wis: WISScore }
+        if (signal?.aborted) return
+        setAlerts(dJson.alerts ?? [])
+        setWis(dJson.wis ?? null)
 
-      if (gRes.ok) {
-        const gj = (await gRes.json()) as AlertsFeatureCollection
-        setGeoJson(gj?.type === 'FeatureCollection' ? gj : null)
-      } else {
-        setGeoJson(null)
+        if (gRes.ok) {
+          const gj = (await gRes.json()) as AlertsFeatureCollection
+          if (signal?.aborted) return
+          setGeoJson(gj?.type === 'FeatureCollection' ? gj : null)
+        } else {
+          setGeoJson(null)
+        }
+
+        if (sRes.ok) {
+          const sJson = (await sRes.json()) as { reports?: SpcReport[] }
+          if (signal?.aborted) return
+          setSpcReports(sJson.reports ?? [])
+        } else setSpcReports([])
+
+        if (cRes.ok) {
+          const cJson = (await cRes.json()) as { reports?: CommunityReport[] }
+          if (signal?.aborted) return
+          setCommunity(cJson.reports ?? [])
+        } else setCommunity([])
+      } catch (e) {
+        if ((e as Error)?.name === 'AbortError') return
+        console.error('[warnings-client]', e)
+        setError('Could not load warnings data. Try again shortly.')
+      } finally {
+        if (!signal?.aborted) setLoading(false)
       }
-
-      if (sRes.ok) {
-        const sJson = (await sRes.json()) as { reports?: SpcReport[] }
-        setSpcReports(sJson.reports ?? [])
-      } else setSpcReports([])
-
-      if (cRes.ok) {
-        const cJson = (await cRes.json()) as { reports?: CommunityReport[] }
-        setCommunity(cJson.reports ?? [])
-      } else setCommunity([])
-    } catch (e) {
-      console.error('[warnings-client]', e)
-      setError('Could not load warnings data. Try again shortly.')
-    } finally {
-      setLoading(false)
-    }
-  }, [])
+    },
+    []
+  )
 
   useEffect(() => {
-    load(userPoint)
+    const ctrl = new AbortController()
+    load(userPoint, ctrl.signal)
+    return () => ctrl.abort()
   }, [load, userPoint])
 
   useEffect(() => {
-    const t = setInterval(() => load(userPoint), 90_000)
-    return () => clearInterval(t)
+    const ctrl = new AbortController()
+    const t = setInterval(() => load(userPoint, ctrl.signal), 90_000)
+    return () => {
+      clearInterval(t)
+      ctrl.abort()
+    }
   }, [load, userPoint])
 
   const sorted = useMemo(() => {

--- a/components/dashboard/location-card.tsx
+++ b/components/dashboard/location-card.tsx
@@ -5,16 +5,24 @@ import Link from 'next/link'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { MapPin, Star, Trash2, RefreshCw, Thermometer, Droplets, Wind, Eye, Sun } from 'lucide-react'
-import { SavedLocation } from '@/lib/supabase/types'
-import { toggleLocationFavorite, deleteSavedLocation } from '@/lib/supabase/database'
+import { SavedLocation, UserPreferences } from '@/lib/supabase/types'
+import { toggleLocationFavorite, deleteSavedLocation, getUserPreferences } from '@/lib/supabase/database'
 import { getDashboardWeather, getWeatherIcon, getTemperatureColor } from '@/lib/dashboard-weather'
 import { useTheme } from '@/components/theme-provider'
+import { useAuth } from '@/lib/auth'
 import { getComponentStyles, type ThemeType } from '@/lib/theme-utils'
 
 interface LocationCardProps {
   location: SavedLocation
   onUpdate: () => void
 }
+
+const tempUnitLabel = (u: UserPreferences['temperature_unit'] | undefined) =>
+  u === 'celsius' ? '°C' : '°F'
+const windUnitLabel = (u: UserPreferences['wind_unit'] | undefined) =>
+  u === 'kmh' ? 'km/h' : u === 'ms' ? 'm/s' : 'mph'
+const owmUnits = (u: UserPreferences['temperature_unit'] | undefined) =>
+  u === 'celsius' ? 'metric' : 'imperial'
 
 interface BasicWeatherData {
   temperature: number
@@ -25,6 +33,7 @@ interface BasicWeatherData {
   feelsLike: number
   pressure: number
   visibility: number
+  units?: 'metric' | 'imperial'
 }
 
 interface DetailedWeatherData {
@@ -57,13 +66,19 @@ export default function LocationCard({ location, onUpdate }: LocationCardProps) 
   const [showDetailedWeather, setShowDetailedWeather] = useState(false)
   const [detailedWeatherData, setDetailedWeatherData] = useState<DetailedWeatherData | null>(null)
   const [detailedLoading, setDetailedLoading] = useState(false)
+  const [preferences, setPreferences] = useState<UserPreferences | null>(null)
   const { theme } = useTheme()
+  const { user } = useAuth()
   const themeClasses = getComponentStyles(theme as ThemeType, 'dashboard')
+
+  const tempUnit = tempUnitLabel(preferences?.temperature_unit)
+  const windUnit = windUnitLabel(preferences?.wind_unit)
+  const apiUnits = owmUnits(preferences?.temperature_unit)
 
   const fetchWeather = async () => {
     setLoading(true)
     try {
-      const weatherData = await getDashboardWeather(location.latitude, location.longitude)
+      const weatherData = await getDashboardWeather(location.latitude, location.longitude, apiUnits)
       setWeather(weatherData)
     } catch (error) {
       console.error('Error fetching weather for location:', error)
@@ -74,12 +89,32 @@ export default function LocationCard({ location, onUpdate }: LocationCardProps) 
 
   useEffect(() => {
     fetchWeather()
-  }, [location.id])
+    // Refresh when coordinates or unit pref change (not just id) so edits and pref toggles refetch.
+  }, [location.id, location.latitude, location.longitude, apiUnits])
+
+  useEffect(() => {
+    let cancelled = false
+    if (!user) {
+      setPreferences(null)
+      return
+    }
+    getUserPreferences(user.id)
+      .then((prefs) => {
+        if (!cancelled) setPreferences(prefs)
+      })
+      .catch(() => {
+        if (!cancelled) setPreferences(null)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [user])
 
   const handleToggleFavorite = async () => {
+    if (!user) return
     setActionLoading('favorite')
     try {
-      await toggleLocationFavorite(location.id, !location.is_favorite)
+      await toggleLocationFavorite(user.id, location.id, !location.is_favorite)
       onUpdate()
     } catch (error) {
       console.error('Error toggling favorite:', error)
@@ -89,13 +124,14 @@ export default function LocationCard({ location, onUpdate }: LocationCardProps) 
   }
 
   const handleDelete = async () => {
+    if (!user) return
     if (!confirm(`Remove ${location.custom_name || location.location_name} from saved locations?`)) {
       return
     }
 
     setActionLoading('delete')
     try {
-      await deleteSavedLocation(location.id)
+      await deleteSavedLocation(user.id, location.id)
       onUpdate()
     } catch (error) {
       console.error('Error deleting location:', error)
@@ -110,14 +146,26 @@ export default function LocationCard({ location, onUpdate }: LocationCardProps) 
     try {
       // Fetch current weather
       const currentResponse = await fetch(
-        `/api/weather/current?lat=${location.latitude}&lon=${location.longitude}&units=imperial`
+        `/api/weather/current?lat=${location.latitude}&lon=${location.longitude}&units=${apiUnits}`
       )
       if (!currentResponse.ok) throw new Error('Failed to fetch current weather')
-      const currentData = await currentResponse.json()
+      const currentRaw = await currentResponse.json()
+
+      // OWM /weather response shape — map to BasicWeatherData
+      const currentData: BasicWeatherData = {
+        temperature: Math.round(currentRaw?.main?.temp ?? 0),
+        feelsLike: Math.round(currentRaw?.main?.feels_like ?? 0),
+        humidity: currentRaw?.main?.humidity ?? 0,
+        windSpeed: currentRaw?.wind?.speed ?? 0,
+        pressure: currentRaw?.main?.pressure ?? 0,
+        visibility: currentRaw?.visibility != null ? Math.round(currentRaw.visibility / 1000) : 0,
+        description: currentRaw?.weather?.[0]?.description ?? '',
+        icon: currentRaw?.weather?.[0]?.icon ?? '',
+      }
 
       // Fetch forecast
       const forecastResponse = await fetch(
-        `/api/weather/forecast?lat=${location.latitude}&lon=${location.longitude}&units=imperial`
+        `/api/weather/forecast?lat=${location.latitude}&lon=${location.longitude}&units=${apiUnits}`
       )
       if (!forecastResponse.ok) throw new Error('Failed to fetch forecast')
       const forecastData = await forecastResponse.json()
@@ -130,7 +178,7 @@ export default function LocationCard({ location, onUpdate }: LocationCardProps) 
         )
         if (uvResponse.ok) {
           const uvData = await uvResponse.json()
-          uvIndex = uvData.value || 0
+          uvIndex = uvData.value ?? 0
         }
       } catch (err) {
         console.warn('UV index fetch failed:', err)
@@ -145,25 +193,59 @@ export default function LocationCard({ location, onUpdate }: LocationCardProps) 
         )
         if (aqiResponse.ok) {
           const aqiData = await aqiResponse.json()
-          aqi = aqiData.aqi || 0
+          aqi = aqiData.aqi ?? 0
           aqiCategory = aqiData.category || 'No Data'
         }
       } catch (err) {
         console.warn('Air quality fetch failed:', err)
       }
 
-      // Process forecast data
-      const processedForecast = forecastData.list?.slice(0, 5).map((item: any, index: number) => {
-        const date = new Date()
-        date.setDate(date.getDate() + index)
-        return {
-          day: date.toLocaleDateString('en-US', { weekday: 'short' }),
-          highTemp: Math.round(item.main.temp_max),
-          lowTemp: Math.round(item.main.temp_min),
-          condition: item.weather[0].main,
-          description: item.weather[0].description
+      // OWM /forecast returns 3-hour intervals (40 entries over 5 days). Group
+      // by calendar date and aggregate min/max so each forecast tile maps to a
+      // real day instead of a 3-hour slice.
+      type OwmListEntry = {
+        dt: number
+        dt_txt?: string
+        main?: { temp_max?: number; temp_min?: number }
+        weather?: Array<{ main?: string; description?: string }>
+      }
+      const list: OwmListEntry[] = forecastData.list ?? []
+      const byDate = new Map<
+        string,
+        { highTemp: number; lowTemp: number; entries: OwmListEntry[] }
+      >()
+      for (const item of list) {
+        const date = new Date((item.dt ?? 0) * 1000)
+        const key = date.toISOString().slice(0, 10)
+        const max = item.main?.temp_max ?? -Infinity
+        const min = item.main?.temp_min ?? Infinity
+        const existing = byDate.get(key)
+        if (existing) {
+          existing.highTemp = Math.max(existing.highTemp, max)
+          existing.lowTemp = Math.min(existing.lowTemp, min)
+          existing.entries.push(item)
+        } else {
+          byDate.set(key, { highTemp: max, lowTemp: min, entries: [item] })
         }
-      }) || []
+      }
+      const processedForecast = Array.from(byDate.entries())
+        .slice(0, 5)
+        .map(([dateKey, agg]) => {
+          // Pick the entry closest to local noon as the day's representative weather
+          const noon = agg.entries.reduce((best, e) => {
+            const eHour = new Date((e.dt ?? 0) * 1000).getUTCHours()
+            const bestHour = new Date((best.dt ?? 0) * 1000).getUTCHours()
+            return Math.abs(eHour - 12) < Math.abs(bestHour - 12) ? e : best
+          }, agg.entries[0])
+          const date = new Date(`${dateKey}T12:00:00Z`)
+          return {
+            day: date.toLocaleDateString('en-US', { weekday: 'short' }),
+            highTemp: Math.round(agg.highTemp),
+            lowTemp: Math.round(agg.lowTemp),
+            condition: noon.weather?.[0]?.main ?? '',
+            description: noon.weather?.[0]?.description ?? '',
+          }
+        })
 
       // Combine all data
       const fullWeatherData: DetailedWeatherData = {
@@ -279,13 +361,13 @@ export default function LocationCard({ location, onUpdate }: LocationCardProps) 
                 </div>
                 <div>
                   <p className={`text-3xl font-bold font-mono ${getTemperatureColor(weather.temperature)}`}>
-                    {weather.temperature}°F
+                    {weather.temperature}{tempUnit}
                   </p>
                   <p className={`text-sm font-mono capitalize ${themeClasses.mutedText}`}>
                     {weather.description}
                   </p>
                   <p className={`text-xs font-mono ${themeClasses.mutedText}`}>
-                    Feels like {weather.feelsLike}°F
+                    Feels like {weather.feelsLike}{tempUnit}
                   </p>
                 </div>
               </div>
@@ -301,7 +383,7 @@ export default function LocationCard({ location, onUpdate }: LocationCardProps) 
 
               <div className={`p-3 border-0 rounded-sm`}>
                 <Wind className={`w-4 h-4 mx-auto mb-1 ${themeClasses.mutedText}`} />
-                <p className={`text-sm font-mono font-bold ${themeClasses.text}`}>{Math.round(weather.windSpeed)} mph</p>
+                <p className={`text-sm font-mono font-bold ${themeClasses.text}`}>{Math.round(weather.windSpeed)} {windUnit}</p>
                 <p className={`text-xs font-mono ${themeClasses.mutedText}`}>Wind Speed</p>
               </div>
 
@@ -313,7 +395,9 @@ export default function LocationCard({ location, onUpdate }: LocationCardProps) 
 
               <div className={`p-3 border-0 rounded-sm`}>
                 <MapPin className={`w-4 h-4 mx-auto mb-1 ${themeClasses.mutedText}`} />
-                <p className={`text-sm font-mono font-bold ${themeClasses.text}`}>{weather.visibility} km</p>
+                <p className={`text-sm font-mono font-bold ${themeClasses.text}`}>
+                  {weather.visibility} {(weather.units ?? apiUnits) === 'metric' ? 'km' : 'mi'}
+                </p>
                 <p className={`text-xs font-mono ${themeClasses.mutedText}`}>Visibility</p>
               </div>
             </div>
@@ -378,10 +462,10 @@ export default function LocationCard({ location, onUpdate }: LocationCardProps) 
                           {day.day}
                         </p>
                         <p className={`font-mono text-sm mb-1 ${getTemperatureColor(day.highTemp)}`}>
-                          {day.highTemp}°
+                          {day.highTemp}{tempUnit}
                         </p>
                         <p className={`font-mono text-xs ${themeClasses.mutedText}`}>
-                          {day.lowTemp}°
+                          {day.lowTemp}{tempUnit}
                         </p>
                         <p className={`font-mono text-[10px] mt-1 ${themeClasses.mutedText} truncate`}>
                           {day.condition}

--- a/components/dashboard/location-card.tsx
+++ b/components/dashboard/location-card.tsx
@@ -231,10 +231,12 @@ export default function LocationCard({ location, onUpdate }: LocationCardProps) 
       const processedForecast = Array.from(byDate.entries())
         .slice(0, 5)
         .map(([dateKey, agg]) => {
-          // Pick the entry closest to local noon as the day's representative weather
+          // Pick the entry closest to local noon as the day's representative weather.
+          // Uses viewer-local time (getHours) rather than UTC so a sunny afternoon
+          // in US Eastern doesn't get represented by 7am UTC-noon overcast skies.
           const noon = agg.entries.reduce((best, e) => {
-            const eHour = new Date((e.dt ?? 0) * 1000).getUTCHours()
-            const bestHour = new Date((best.dt ?? 0) * 1000).getUTCHours()
+            const eHour = new Date((e.dt ?? 0) * 1000).getHours()
+            const bestHour = new Date((best.dt ?? 0) * 1000).getHours()
             return Math.abs(eHour - 12) < Math.abs(bestHour - 12) ? e : best
           }, agg.entries[0])
           const date = new Date(`${dateKey}T12:00:00Z`)

--- a/lib/dashboard-weather.ts
+++ b/lib/dashboard-weather.ts
@@ -10,14 +10,19 @@ interface DashboardWeatherData {
   feelsLike: number
   pressure: number
   visibility: number
+  units?: 'metric' | 'imperial'
 }
 
-export async function getDashboardWeather(latitude: number, longitude: number): Promise<DashboardWeatherData | null> {
+export async function getDashboardWeather(
+  latitude: number,
+  longitude: number,
+  units: 'metric' | 'imperial' = 'imperial'
+): Promise<DashboardWeatherData | null> {
   try {
     // Use our API route instead of calling OpenWeather directly
     const response = await fetch(
-      `/api/dashboard-weather?lat=${latitude}&lon=${longitude}`,
-      { 
+      `/api/dashboard-weather?lat=${latitude}&lon=${longitude}&units=${units}`,
+      {
         cache: 'default',
         headers: {
           'Cache-Control': 'public, s-maxage=600, stale-while-revalidate=1200'

--- a/lib/playwright-test-mode.ts
+++ b/lib/playwright-test-mode.ts
@@ -1,8 +1,8 @@
 import type { NextRequest } from 'next/server';
 
 /**
- * Mirrors proxy.ts test-mode rules so API routes can align with middleware bypass.
- * Never true in production NODE_ENV unless CI/preview + explicit header/cookie (see proxy).
+ * Mirrors middleware.ts test-mode rules so API routes can align with middleware bypass.
+ * Never true in production NODE_ENV unless CI/preview + explicit header/cookie (see middleware).
  */
 export function isPlaywrightTestModeRequest(request: NextRequest): boolean {
   const testModeHeader = request.headers.get('x-playwright-test-mode');

--- a/lib/services/spc-storm-reports-service.ts
+++ b/lib/services/spc-storm-reports-service.ts
@@ -91,8 +91,8 @@ function parseCsv(text: string, isoDate: string): SpcReport[] {
       location: location?.trim() ?? '',
       county: county?.trim() ?? '',
       state: state?.trim() ?? '',
-      lat: parseFloat(lat ?? '') || null,
-      lon: parseFloat(lon ?? '') || null,
+      lat: Number.isFinite(parseFloat(lat ?? '')) ? parseFloat(lat ?? '') : null,
+      lon: Number.isFinite(parseFloat(lon ?? '')) ? parseFloat(lon ?? '') : null,
       comments: rest.join(',').trim(),
       date: isoDate,
     })

--- a/lib/supabase/database.ts
+++ b/lib/supabase/database.ts
@@ -202,8 +202,13 @@ const saveLocation = async (locationData: SavedLocationInsert): Promise<SavedLoc
   return data
 }
 
+// All saved-location mutators take userId so they always filter by both
+// (id, user_id). Server callers run with the service-role key, which bypasses
+// RLS — without the explicit user_id check, any authenticated session could
+// pass another user's locationId and mutate their row.
 const updateSavedLocation = async (
-  locationId: string, 
+  userId: string,
+  locationId: string,
   updates: SavedLocationUpdate
 ): Promise<SavedLocation | null> => {
   const supabase = getSupabaseClient()
@@ -211,41 +216,51 @@ const updateSavedLocation = async (
     .from('saved_locations')
     .update(updates)
     .eq('id', locationId)
+    .eq('user_id', userId)
     .select()
     .single()
 
   if (error) {
-    captureDbError('updateSavedLocation', error, { locationId })
+    captureDbError('updateSavedLocation', error, { userId, locationId })
     return null
   }
 
   return data
 }
 
-export const deleteSavedLocation = async (locationId: string): Promise<boolean> => {
+export const deleteSavedLocation = async (
+  userId: string,
+  locationId: string
+): Promise<boolean> => {
   const supabase = getSupabaseClient()
   const { error } = await supabase
     .from('saved_locations')
     .delete()
     .eq('id', locationId)
+    .eq('user_id', userId)
 
   if (error) {
-    captureDbError('deleteSavedLocation', error, { locationId })
+    captureDbError('deleteSavedLocation', error, { userId, locationId })
     return false
   }
 
   return true
 }
 
-export const toggleLocationFavorite = async (locationId: string, isFavorite: boolean): Promise<boolean> => {
+export const toggleLocationFavorite = async (
+  userId: string,
+  locationId: string,
+  isFavorite: boolean
+): Promise<boolean> => {
   const supabase = getSupabaseClient()
   const { error } = await supabase
     .from('saved_locations')
     .update({ is_favorite: isFavorite })
     .eq('id', locationId)
+    .eq('user_id', userId)
 
   if (error) {
-    captureDbError('toggleLocationFavorite', error, { locationId, isFavorite })
+    captureDbError('toggleLocationFavorite', error, { userId, locationId, isFavorite })
     return false
   }
 
@@ -325,13 +340,22 @@ const getFavoriteLocations = async (userId: string): Promise<SavedLocation[]> =>
   return data || []
 }
 
+// PostgREST .or() interpolates raw strings into a filter expression.
+// Strip characters that have meaning to the filter parser before composing
+// the .or() clause so a search term like `x,user_id.eq.<other>` cannot
+// append OR conditions and exfiltrate other rows.
+const sanitizeSearchTerm = (term: string): string =>
+  term.replace(/[,()*:\\"]/g, '').trim()
+
 const searchSavedLocations = async (userId: string, searchTerm: string): Promise<SavedLocation[]> => {
   const supabase = getSupabaseClient()
+  const safeTerm = sanitizeSearchTerm(searchTerm)
+  if (!safeTerm) return []
   const { data, error } = await supabase
     .from('saved_locations')
     .select('*')
     .eq('user_id', userId)
-    .or(`location_name.ilike.%${searchTerm}%,city.ilike.%${searchTerm}%,custom_name.ilike.%${searchTerm}%`)
+    .or(`location_name.ilike.%${safeTerm}%,city.ilike.%${safeTerm}%,custom_name.ilike.%${safeTerm}%`)
     .order('is_favorite', { ascending: false })
     .order('updated_at', { ascending: false })
 

--- a/lib/weather/open-meteo-adapter.ts
+++ b/lib/weather/open-meteo-adapter.ts
@@ -59,8 +59,16 @@ export async function buildWeatherDataFromOpenMeteo(
   const windSpeedUnit = unitSystem === 'metric' ? 'kmh' as const : 'mph' as const;
   const precipitationUnit = unitSystem === 'metric' ? 'mm' as const : 'inch' as const;
 
+  const forecastQuery = new URLSearchParams({
+    lat: String(lat),
+    lon: String(lon),
+    days: '7',
+    temperature_unit: temperatureUnit,
+    wind_speed_unit: windSpeedUnit,
+    precipitation_unit: precipitationUnit,
+  });
   const [forecastRes, airQualityRes, pollenData] = await Promise.all([
-    fetch(getApiUrl(`/api/open-meteo/forecast?lat=${lat}&lon=${lon}&days=7`)),
+    fetch(getApiUrl(`/api/open-meteo/forecast?${forecastQuery.toString()}`)),
     fetch(getApiUrl(`/api/open-meteo/air-quality?lat=${lat}&lon=${lon}`)).catch(() => null),
     fetchPollenData(lat, lon),
   ]);

--- a/lib/weather/weather-current.ts
+++ b/lib/weather/weather-current.ts
@@ -286,7 +286,7 @@ async function buildWeatherDataFromOneCall(
         details: {
           humidity: d.humidity ?? 0,
           windSpeed: Math.round(d.wind_speed ?? 0),
-          windDirection: d.wind_deg ? getWindDirection(d.wind_deg) : undefined,
+          windDirection: d.wind_deg != null ? getWindDirection(d.wind_deg) : undefined,
           pressure: `${d.pressure ?? 1013} hPa`,
           cloudCover: d.clouds ?? 0,
           precipitationChance: Math.round((d.pop ?? 0) * 100),

--- a/lib/weather/weather-forecast.ts
+++ b/lib/weather/weather-forecast.ts
@@ -226,9 +226,9 @@ export const processHourlyForecast = (
       description: hour.weather?.[0]?.description || 'clear sky',
       precipChance: Math.round((hour.pop ?? 0) * 100),
       windSpeed: hour.wind_speed,
-      windDirection: hour.wind_deg ? getWindDirection(hour.wind_deg) : undefined,
+      windDirection: hour.wind_deg != null ? getWindDirection(hour.wind_deg) : undefined,
       humidity: hour.humidity,
-      uvIndex: hour.uvi ? Math.round(hour.uvi) : undefined,
+      uvIndex: hour.uvi != null ? Math.round(hour.uvi) : undefined,
       icon: hour.weather?.[0]?.icon
     };
   });

--- a/middleware.ts
+++ b/middleware.ts
@@ -37,7 +37,7 @@ function buildCspHeader(isProd: boolean): string {
   ].join('; ')
 }
 
-export async function proxy(request: NextRequest) {
+export async function middleware(request: NextRequest) {
   const requestHeaders = new Headers(request.headers)
 
   const isProd = process.env.NODE_ENV === 'production'
@@ -80,15 +80,15 @@ export async function proxy(request: NextRequest) {
   )
 
   const {
-    data: { session },
-  } = await supabase.auth.getSession()
+    data: { user },
+  } = await supabase.auth.getUser()
 
   const protectedRoutes = ['/dashboard', '/profile', '/settings', '/saved-locations']
   const isProtectedRoute = protectedRoutes.some((route) =>
     request.nextUrl.pathname.startsWith(route)
   )
 
-  if (isProtectedRoute && !session) {
+  if (isProtectedRoute && !user) {
     const redirectUrl = new URL('/auth/login', request.url)
     redirectUrl.searchParams.set('next', request.nextUrl.pathname)
     return NextResponse.redirect(redirectUrl)
@@ -99,7 +99,7 @@ export async function proxy(request: NextRequest) {
     request.nextUrl.pathname.startsWith(route)
   )
 
-  if (isAuthRoute && session) {
+  if (isAuthRoute && user) {
     return NextResponse.redirect(new URL('/', request.url))
   }
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -48,7 +48,7 @@ const nextConfig = {
   productionBrowserSourceMaps: false,
 
   // Add headers for better caching and security.
-  // NOTE: Content-Security-Policy is set per-request in proxy.ts so we can
+  // NOTE: Content-Security-Policy is set per-request in middleware.ts so we can
   // use a fresh nonce for script-src in production. Do NOT duplicate CSP
   // here — a static CSP would collide with the nonce CSP.
   async headers() {


### PR DESCRIPTION
## Summary

Restores main to a working state after the audit pass that revealed seven runtime bugs (PR #376 closed for being unsalvageable; this batch is the actual fix).

## What changed

- **middleware (was dead code)** — `proxy.ts` is renamed to `middleware.ts` and the function `proxy` to `middleware` so Next.js actually loads it. Production CSP, the auth gate for `/dashboard|/profile|/settings|/saved-locations`, and the Playwright bypass guard now run on every request. `getSession()` switched to `getUser()` so the gate verifies the JWT instead of trusting the cookie.

- **open-meteo unit forwarding** — `/api/open-meteo/forecast` now accepts `temperature_unit / wind_speed_unit / precipitation_unit` and the adapter passes them through. Metric users were silently getting fahrenheit/mph/inch values displayed under metric labels. Units in the URL also segment the cache key so the imperial and metric responses stop sharing a key.

- **stargazer moon illumination** — `app/api/stargazer/route.ts` was multiplying `peakMoon.illumination` by 100 even though `lib/stargazer/astronomy.ts` already returns 0–100. The 15/40/70 thresholds therefore never fired and every meteor shower except an exact new moon was tagged `'high'` interference.

- **saved-locations modal** — `components/dashboard/location-card.tsx` now reads user `temperature_unit / wind_unit` prefs, forwards units to `/api/dashboard-weather` (which previously hardcoded imperial), aggregates the OWM 5-day forecast by date instead of slicing the first 5 of 40 three-hour entries (which produced 15 hours mislabelled Mon/Tue/...), and refreshes on lat/lon changes — not just id. Hardcoded `°F` / `mph` / `km` labels are gone.

- **supabase ownership** — `deleteSavedLocation`, `toggleLocationFavorite`, and `updateSavedLocation` now require `userId` and filter on `.eq('user_id', userId)` in addition to `.eq('id', locationId)`. Server callers run with the service-role key (RLS-bypassing); without the explicit user_id filter, any authenticated session could pass another user's locationId to mutate their row. `searchSavedLocations` now sanitizes the search term before composing the PostgREST `.or()` filter to block clauses like `x,user_id.eq.<other>`.

- **warnings page race** — `app/warnings/warnings-client.tsx` now threads an AbortController through `load()` and the 90-second polling effect, plus skips `setState` calls if the request was aborted. Previously a fast point toggle could let an older request resolve last and overwrite state.

- **falsy 0 checks** — `wind_deg` / `uvi` truthy checks become `!= null`, so a legitimate 0 (true north wind, nighttime UV index) isn't treated as missing data. SPC storm reports `lat`/`lon` now use `Number.isFinite` so reports at the equator or prime meridian aren't dropped.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 387/387 passing (one assertion updated for the new unit defaults in the open-meteo route)
- [x] `npm run lint` — 0 errors
- [ ] Manual: visit `/dashboard` while signed out → redirects to `/auth/login` (verifies middleware now runs)
- [ ] Manual: toggle metric prefs and reload `/profile` → temperatures and wind speeds in saved-location cards show °C/km·h, not °F/mph
- [ ] Manual: open `/warnings` and toggle "Use my location" twice quickly → final state matches the second click
- [ ] Manual: open browser devtools, toggle off the bearer auth header on a `DELETE /api/locations/...` (or call `deleteSavedLocation` directly with a fabricated locationId from another user) → no rows mutated

## Notes
- Skipped the audit's "visibility unit mismatch in `lib/ai/tools.ts`" finding. Open-Meteo returns visibility in meters regardless of the other unit settings, so `visMeters / 1609` is correct.
- `CODEBASE_INDEX.md` is intentionally not in this PR — it was untracked locally and unrelated to these fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added customizable units (metric/imperial) for temperature, wind speed, precipitation, and visibility
  * Enhanced 5-day forecast with daily high/low temperatures
  * Integrated user preferences to personalize weather unit display
  * Improved request cancellation for better responsiveness

* **Bug Fixes**
  * Fixed moon illumination calculation
  * Corrected wind direction handling for 0-degree values
  * Improved robustness in storm report data parsing

* **Chores**
  * Strengthened authentication requirements for saved locations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->