### PR TITLE
feat(aviation): real flight + turbulence data, theme tokens, demo toggle

### DIFF
--- a/__tests__/flight-lookup-service.test.ts
+++ b/__tests__/flight-lookup-service.test.ts
@@ -1,0 +1,591 @@
+/**
+ * Unit tests for lib/services/flight-lookup-service.
+ *
+ * Covers: flight-number parsing, provider fallback chain (AviationStack →
+ * mock), in-process schedule cache, OpenSky live-position enrichment, and
+ * the public lookupFlight() outcome shape.
+ */
+
+import {
+  parseFlightNumber,
+  lookupFlight,
+  fetchLivePosition,
+  _resetCacheForTests,
+  type FlightProvider,
+  type FlightLookupResult,
+} from '@/lib/services/flight-lookup-service';
+
+// Avoid dotenv side effects from real env in CI.
+const ORIGINAL_ENV = { ...process.env };
+
+beforeEach(() => {
+  _resetCacheForTests();
+  process.env = { ...ORIGINAL_ENV };
+  delete process.env.AVIATIONSTACK_API_KEY;
+  delete process.env.OPENSKY_USERNAME;
+  delete process.env.OPENSKY_PASSWORD;
+});
+
+afterAll(() => {
+  process.env = ORIGINAL_ENV;
+});
+
+describe('parseFlightNumber', () => {
+  test('extracts airline + number from compact form', () => {
+    expect(parseFlightNumber('AA123')).toEqual({
+      airlineCode: 'AA',
+      flightNum: '123',
+    });
+  });
+
+  test('handles spaces and lowercase', () => {
+    expect(parseFlightNumber('aa 123')).toEqual({
+      airlineCode: 'AA',
+      flightNum: '123',
+    });
+  });
+
+  test('rejects malformed input', () => {
+    expect(parseFlightNumber('NOT_A_FLIGHT')).toBeNull();
+    expect(parseFlightNumber('A123')).toBeNull();
+    expect(parseFlightNumber('AAA123')).toBeNull();
+    expect(parseFlightNumber('AA')).toBeNull();
+    expect(parseFlightNumber('AA12345')).toBeNull();
+  });
+});
+
+describe('lookupFlight - input validation', () => {
+  test('returns INVALID_FLIGHT_NUMBER for malformed input', async () => {
+    const out = await lookupFlight('garbage');
+    expect(out.ok).toBe(false);
+    if (!out.ok) {
+      expect(out.error.code).toBe('INVALID_FLIGHT_NUMBER');
+    }
+  });
+
+  test('returns UNKNOWN_AIRLINE when airline code is unrecognized', async () => {
+    const out = await lookupFlight('ZZ123');
+    expect(out.ok).toBe(false);
+    if (!out.ok) {
+      expect(out.error.code).toBe('UNKNOWN_AIRLINE');
+    }
+  });
+});
+
+describe('lookupFlight - provider fallback chain', () => {
+  test('uses first provider that returns a result', async () => {
+    const realProvider: FlightProvider = {
+      name: 'aviationstack',
+      isAvailable: () => true,
+      lookupFlight: jest.fn(async () => ({
+        flightNumber: 'AA123',
+        airline: { name: 'American Airlines', iata: 'AA', icao: 'AAL' },
+        departure: {
+          icao: 'KJFK',
+          iata: 'JFK',
+          name: 'JFK',
+          city: 'New York',
+          lat: 40.6413,
+          lon: -73.7781,
+        },
+        arrival: {
+          icao: 'KLAX',
+          iata: 'LAX',
+          name: 'LAX',
+          city: 'Los Angeles',
+          lat: 33.9425,
+          lon: -118.408,
+        },
+        status: 'active',
+        source: 'aviationstack',
+        mock: false,
+      })),
+    };
+
+    const fallbackProvider: FlightProvider = {
+      name: 'mock',
+      isAvailable: () => true,
+      lookupFlight: jest.fn(),
+    };
+
+    const out = await lookupFlight('AA123', {
+      providers: [realProvider, fallbackProvider],
+      includeLivePosition: false,
+    });
+
+    expect(out.ok).toBe(true);
+    if (out.ok) {
+      expect(out.result.source).toBe('aviationstack');
+      expect(out.result.mock).toBe(false);
+    }
+    expect(realProvider.lookupFlight).toHaveBeenCalledTimes(1);
+    expect(fallbackProvider.lookupFlight).not.toHaveBeenCalled();
+  });
+
+  test('falls through to next provider when first returns null', async () => {
+    const empty: FlightProvider = {
+      name: 'aviationstack',
+      isAvailable: () => true,
+      lookupFlight: jest.fn(async () => null),
+    };
+
+    const mockProv: FlightProvider = {
+      name: 'mock',
+      isAvailable: () => true,
+      lookupFlight: jest.fn(async (): Promise<FlightLookupResult> => ({
+        flightNumber: 'AA123',
+        airline: { name: 'American Airlines', iata: 'AA', icao: 'AAL' },
+        departure: {
+          icao: 'KJFK',
+          iata: 'JFK',
+          name: 'JFK',
+          city: 'New York',
+          lat: 40.6413,
+          lon: -73.7781,
+        },
+        arrival: {
+          icao: 'KLAX',
+          iata: 'LAX',
+          name: 'LAX',
+          city: 'Los Angeles',
+          lat: 33.9425,
+          lon: -118.408,
+        },
+        status: 'scheduled',
+        source: 'mock',
+        mock: true,
+      })),
+    };
+
+    const out = await lookupFlight('AA123', {
+      providers: [empty, mockProv],
+      includeLivePosition: false,
+    });
+
+    expect(out.ok).toBe(true);
+    if (out.ok) {
+      expect(out.result.source).toBe('mock');
+      expect(out.result.mock).toBe(true);
+    }
+    expect(empty.lookupFlight).toHaveBeenCalled();
+    expect(mockProv.lookupFlight).toHaveBeenCalled();
+  });
+
+  test('skips providers that report unavailable', async () => {
+    const unavailable: FlightProvider = {
+      name: 'aviationstack',
+      isAvailable: () => false,
+      lookupFlight: jest.fn(),
+    };
+
+    const mockProv: FlightProvider = {
+      name: 'mock',
+      isAvailable: () => true,
+      lookupFlight: jest.fn(async (): Promise<FlightLookupResult> => ({
+        flightNumber: 'AA123',
+        airline: { name: 'American Airlines', iata: 'AA', icao: 'AAL' },
+        departure: {
+          icao: 'KJFK',
+          iata: 'JFK',
+          name: 'JFK',
+          city: 'New York',
+          lat: 40.6413,
+          lon: -73.7781,
+        },
+        arrival: {
+          icao: 'KLAX',
+          iata: 'LAX',
+          name: 'LAX',
+          city: 'Los Angeles',
+          lat: 33.9425,
+          lon: -118.408,
+        },
+        status: 'scheduled',
+        source: 'mock',
+        mock: true,
+      })),
+    };
+
+    await lookupFlight('AA123', {
+      providers: [unavailable, mockProv],
+      includeLivePosition: false,
+    });
+
+    expect(unavailable.lookupFlight).not.toHaveBeenCalled();
+    expect(mockProv.lookupFlight).toHaveBeenCalled();
+  });
+
+  test('returns FLIGHT_NOT_FOUND when no provider can resolve the flight', async () => {
+    const empty1: FlightProvider = {
+      name: 'aviationstack',
+      isAvailable: () => true,
+      lookupFlight: jest.fn(async () => null),
+    };
+    const empty2: FlightProvider = {
+      name: 'mock',
+      isAvailable: () => true,
+      lookupFlight: jest.fn(async () => null),
+    };
+
+    const out = await lookupFlight('AA9999', {
+      providers: [empty1, empty2],
+      includeLivePosition: false,
+    });
+
+    expect(out.ok).toBe(false);
+    if (!out.ok) {
+      expect(out.error.code).toBe('FLIGHT_NOT_FOUND');
+    }
+  });
+
+  test('continues past provider that throws', async () => {
+    const broken: FlightProvider = {
+      name: 'aviationstack',
+      isAvailable: () => true,
+      lookupFlight: jest.fn(async () => {
+        throw new Error('boom');
+      }),
+    };
+    const mockProv: FlightProvider = {
+      name: 'mock',
+      isAvailable: () => true,
+      lookupFlight: jest.fn(async (): Promise<FlightLookupResult> => ({
+        flightNumber: 'AA123',
+        airline: { name: 'American Airlines', iata: 'AA', icao: 'AAL' },
+        departure: {
+          icao: 'KJFK',
+          iata: 'JFK',
+          name: 'JFK',
+          city: 'New York',
+          lat: 40.6413,
+          lon: -73.7781,
+        },
+        arrival: {
+          icao: 'KLAX',
+          iata: 'LAX',
+          name: 'LAX',
+          city: 'Los Angeles',
+          lat: 33.9425,
+          lon: -118.408,
+        },
+        status: 'scheduled',
+        source: 'mock',
+        mock: true,
+      })),
+    };
+
+    const out = await lookupFlight('AA123', {
+      providers: [broken, mockProv],
+      includeLivePosition: false,
+    });
+
+    expect(out.ok).toBe(true);
+    if (out.ok) {
+      expect(out.result.source).toBe('mock');
+    }
+  });
+});
+
+describe('lookupFlight - schedule cache', () => {
+  test('caches a successful lookup so the second call skips providers', async () => {
+    const provider: FlightProvider = {
+      name: 'aviationstack',
+      isAvailable: () => true,
+      lookupFlight: jest.fn(async (): Promise<FlightLookupResult> => ({
+        flightNumber: 'AA123',
+        airline: { name: 'American Airlines', iata: 'AA', icao: 'AAL' },
+        departure: {
+          icao: 'KJFK',
+          iata: 'JFK',
+          name: 'JFK',
+          city: 'New York',
+          lat: 40.6413,
+          lon: -73.7781,
+        },
+        arrival: {
+          icao: 'KLAX',
+          iata: 'LAX',
+          name: 'LAX',
+          city: 'Los Angeles',
+          lat: 33.9425,
+          lon: -118.408,
+        },
+        status: 'active',
+        source: 'aviationstack',
+        mock: false,
+      })),
+    };
+
+    await lookupFlight('AA123', { providers: [provider], includeLivePosition: false });
+    await lookupFlight('AA123', { providers: [provider], includeLivePosition: false });
+
+    expect(provider.lookupFlight).toHaveBeenCalledTimes(1);
+  });
+
+  test('bypassCache forces a refetch', async () => {
+    const provider: FlightProvider = {
+      name: 'aviationstack',
+      isAvailable: () => true,
+      lookupFlight: jest.fn(async (): Promise<FlightLookupResult> => ({
+        flightNumber: 'AA123',
+        airline: { name: 'American Airlines', iata: 'AA', icao: 'AAL' },
+        departure: {
+          icao: 'KJFK',
+          iata: 'JFK',
+          name: 'JFK',
+          city: 'New York',
+          lat: 40.6413,
+          lon: -73.7781,
+        },
+        arrival: {
+          icao: 'KLAX',
+          iata: 'LAX',
+          name: 'LAX',
+          city: 'Los Angeles',
+          lat: 33.9425,
+          lon: -118.408,
+        },
+        status: 'active',
+        source: 'aviationstack',
+        mock: false,
+      })),
+    };
+
+    await lookupFlight('AA123', { providers: [provider], includeLivePosition: false });
+    await lookupFlight('AA123', {
+      providers: [provider],
+      includeLivePosition: false,
+      bypassCache: true,
+    });
+
+    expect(provider.lookupFlight).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('fetchLivePosition (OpenSky)', () => {
+  // jsdom's Response polyfill mishandles our payloads; use a plain mock with
+  // the fields the service actually reads (ok, json()).
+  function mockResponse(body: unknown, status = 200) {
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => body,
+    };
+  }
+
+  test('parses a matching state vector into a LivePosition', async () => {
+    const fetchImpl = jest.fn(async () =>
+      mockResponse({
+        time: 1_700_000_000,
+        states: [
+          [
+            'a1b2c3', // icao24
+            'AAL123  ', // callsign (padded)
+            'United States',
+            1_700_000_000,
+            1_700_000_000,
+            -73.7781, // lon
+            40.6413, // lat
+            10000, // baro_altitude (meters)
+            false, // on_ground
+            250, // velocity m/s
+            90, // heading
+            0,
+            null,
+            10500, // geo_altitude (meters)
+          ],
+        ],
+      }),
+    );
+
+    const pos = await fetchLivePosition(
+      'AAL',
+      '123',
+      fetchImpl as unknown as typeof fetch,
+    );
+
+    expect(pos).not.toBeNull();
+    expect(pos?.lat).toBeCloseTo(40.6413);
+    expect(pos?.lon).toBeCloseTo(-73.7781);
+    // 10500 m * 3.28084 ft/m ≈ 34449 ft
+    expect(pos?.altitudeFt).toBeGreaterThan(34000);
+    expect(pos?.altitudeFt).toBeLessThan(35000);
+    // 250 m/s * 1.94384 ≈ 486 kt
+    expect(pos?.velocityKt).toBeGreaterThan(480);
+    expect(pos?.onGround).toBe(false);
+  });
+
+  test('returns null when no callsign matches', async () => {
+    const fetchImpl = jest.fn(async () =>
+      mockResponse({
+        time: 1_700_000_000,
+        states: [
+          [
+            'aaaaaa',
+            'OTHER789',
+            'US',
+            1,
+            1,
+            0,
+            0,
+            0,
+            false,
+            0,
+            0,
+            0,
+            null,
+            0,
+          ],
+        ],
+      }),
+    );
+
+    const pos = await fetchLivePosition(
+      'AAL',
+      '123',
+      fetchImpl as unknown as typeof fetch,
+    );
+    expect(pos).toBeNull();
+  });
+
+  test('returns null and does not throw on HTTP failure', async () => {
+    const fetchImpl = jest.fn(async () => mockResponse('nope', 503));
+    const pos = await fetchLivePosition(
+      'AAL',
+      '123',
+      fetchImpl as unknown as typeof fetch,
+    );
+    expect(pos).toBeNull();
+  });
+});
+
+describe('lookupFlight - default providers integration', () => {
+  test('without AVIATIONSTACK_API_KEY, mock provider answers and result is labeled mock', async () => {
+    // Default providers, no env keys set.
+    const out = await lookupFlight('AA123', { includeLivePosition: false });
+    expect(out.ok).toBe(true);
+    if (out.ok) {
+      expect(out.result.source).toBe('mock');
+      expect(out.result.mock).toBe(true);
+      expect(out.result.flightNumber).toBe('AA123');
+      expect(out.result.departure.iata).toBe('LAX');
+      expect(out.result.arrival.iata).toBe('JFK');
+    }
+  });
+});
+
+describe('lookupFlight - forceMock option', () => {
+  test('skips live providers and returns mock data when forceMock=true', async () => {
+    const live: FlightProvider = {
+      name: 'aviationstack',
+      isAvailable: () => true,
+      lookupFlight: jest.fn(),
+    };
+    const mockProv: FlightProvider = {
+      name: 'mock',
+      isAvailable: () => true,
+      lookupFlight: jest.fn(async (): Promise<FlightLookupResult> => ({
+        flightNumber: 'AA123',
+        airline: { name: 'American Airlines', iata: 'AA', icao: 'AAL' },
+        departure: {
+          icao: 'KJFK',
+          iata: 'JFK',
+          name: 'JFK',
+          city: 'New York',
+          lat: 40.6413,
+          lon: -73.7781,
+        },
+        arrival: {
+          icao: 'KLAX',
+          iata: 'LAX',
+          name: 'LAX',
+          city: 'Los Angeles',
+          lat: 33.9425,
+          lon: -118.408,
+        },
+        status: 'scheduled',
+        source: 'mock',
+        mock: true,
+      })),
+    };
+
+    const out = await lookupFlight('AA123', {
+      providers: [live, mockProv],
+      forceMock: true,
+      includeLivePosition: false,
+    });
+
+    expect(out.ok).toBe(true);
+    if (out.ok) {
+      expect(out.result.mock).toBe(true);
+      expect(out.result.source).toBe('mock');
+    }
+    expect(live.lookupFlight).not.toHaveBeenCalled();
+    expect(mockProv.lookupFlight).toHaveBeenCalledTimes(1);
+  });
+
+  test('forceMock requests bypass the schedule cache', async () => {
+    const liveResult: FlightLookupResult = {
+      flightNumber: 'AA123',
+      airline: { name: 'American Airlines', iata: 'AA', icao: 'AAL' },
+      departure: {
+        icao: 'KJFK',
+        iata: 'JFK',
+        name: 'JFK',
+        city: 'New York',
+        lat: 40.6413,
+        lon: -73.7781,
+      },
+      arrival: {
+        icao: 'KLAX',
+        iata: 'LAX',
+        name: 'LAX',
+        city: 'Los Angeles',
+        lat: 33.9425,
+        lon: -118.408,
+      },
+      status: 'active',
+      source: 'aviationstack',
+      mock: false,
+    };
+    const live: FlightProvider = {
+      name: 'aviationstack',
+      isAvailable: () => true,
+      lookupFlight: jest.fn(async () => liveResult),
+    };
+    const mockProv: FlightProvider = {
+      name: 'mock',
+      isAvailable: () => true,
+      lookupFlight: jest.fn(async (): Promise<FlightLookupResult> => ({
+        ...liveResult,
+        source: 'mock',
+        mock: true,
+      })),
+    };
+
+    // Prime the cache with a live result.
+    const first = await lookupFlight('AA123', {
+      providers: [live, mockProv],
+      includeLivePosition: false,
+    });
+    expect(first.ok && first.result.mock).toBe(false);
+
+    // forceMock should ignore the cached live result and call the mock provider.
+    const second = await lookupFlight('AA123', {
+      providers: [live, mockProv],
+      forceMock: true,
+      includeLivePosition: false,
+    });
+    expect(second.ok && second.result.mock).toBe(true);
+    expect(mockProv.lookupFlight).toHaveBeenCalledTimes(1);
+
+    // Subsequent non-mock lookup should still hit the cache (live result is preserved).
+    const third = await lookupFlight('AA123', {
+      providers: [live, mockProv],
+      includeLivePosition: false,
+    });
+    expect(third.ok && third.result.mock).toBe(false);
+    // Live provider was only called once during the priming call.
+    expect(live.lookupFlight).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/api/aviation/flight-lookup/route.ts
+++ b/app/api/aviation/flight-lookup/route.ts
@@ -4,30 +4,20 @@
  * Copyright (C) 2025 16-Bit Weather
  * Licensed under Fair Source License, Version 0.9
  *
- * Looks up flight routes by flight number (e.g., AA123)
- * Returns departure/arrival airport data for turbulence lookup
+ * Looks up flight routes by flight number (e.g., AA123) using a provider
+ * abstraction (AviationStack with mock fallback). See
+ * lib/services/flight-lookup-service.ts for fallback chain semantics.
  */
 
 import { NextRequest, NextResponse } from 'next/server';
+import {
+  lookupFlight,
+  type AirlineData,
+  type AirportData,
+  type FlightStatus,
+  type LivePosition,
+} from '@/lib/services/flight-lookup-service';
 
-// Airline data interface
-interface AirlineData {
-  name: string;
-  iata: string;
-  icao: string;
-}
-
-// Airport data interface
-interface AirportData {
-  icao: string;
-  iata: string;
-  name: string;
-  city: string;
-  lat: number;
-  lon: number;
-}
-
-// Flight lookup response interface
 export interface FlightLookupResponse {
   success: boolean;
   data?: {
@@ -35,143 +25,20 @@ export interface FlightLookupResponse {
     airline: AirlineData;
     departure: AirportData;
     arrival: AirportData;
-    status: 'scheduled' | 'active' | 'landed' | 'cancelled' | 'diverted';
+    status: FlightStatus;
+    livePosition?: LivePosition;
+    /** True when route data is synthesized rather than from a live provider. */
+    mock?: boolean;
+    /** Which provider answered the request. */
+    source?: 'aviationstack' | 'mock';
   };
   error?: string;
-  errorCode?: 'INVALID_FLIGHT_NUMBER' | 'FLIGHT_NOT_FOUND' | 'RATE_LIMITED' | 'API_ERROR';
-}
-
-// Airline code mapping
-const AIRLINES: Record<string, AirlineData> = {
-  AA: { name: 'American Airlines', iata: 'AA', icao: 'AAL' },
-  UA: { name: 'United Airlines', iata: 'UA', icao: 'UAL' },
-  DL: { name: 'Delta Air Lines', iata: 'DL', icao: 'DAL' },
-  WN: { name: 'Southwest Airlines', iata: 'WN', icao: 'SWA' },
-  B6: { name: 'JetBlue Airways', iata: 'B6', icao: 'JBU' },
-  AS: { name: 'Alaska Airlines', iata: 'AS', icao: 'ASA' },
-  NK: { name: 'Spirit Airlines', iata: 'NK', icao: 'NKS' },
-  F9: { name: 'Frontier Airlines', iata: 'F9', icao: 'FFT' },
-  G4: { name: 'Allegiant Air', iata: 'G4', icao: 'AAY' },
-  HA: { name: 'Hawaiian Airlines', iata: 'HA', icao: 'HAL' },
-};
-
-// Airport data for popular airports
-const AIRPORTS: Record<string, AirportData> = {
-  LAX: { icao: 'KLAX', iata: 'LAX', name: 'Los Angeles International', city: 'Los Angeles', lat: 33.9425, lon: -118.408 },
-  JFK: { icao: 'KJFK', iata: 'JFK', name: 'John F Kennedy International', city: 'New York', lat: 40.6413, lon: -73.7781 },
-  ORD: { icao: 'KORD', iata: 'ORD', name: "O'Hare International", city: 'Chicago', lat: 41.9742, lon: -87.9073 },
-  SFO: { icao: 'KSFO', iata: 'SFO', name: 'San Francisco International', city: 'San Francisco', lat: 37.6213, lon: -122.379 },
-  DFW: { icao: 'KDFW', iata: 'DFW', name: 'Dallas/Fort Worth International', city: 'Dallas', lat: 32.8998, lon: -97.0403 },
-  DEN: { icao: 'KDEN', iata: 'DEN', name: 'Denver International', city: 'Denver', lat: 39.8561, lon: -104.6737 },
-  ATL: { icao: 'KATL', iata: 'ATL', name: 'Hartsfield-Jackson Atlanta International', city: 'Atlanta', lat: 33.6407, lon: -84.4277 },
-  SEA: { icao: 'KSEA', iata: 'SEA', name: 'Seattle-Tacoma International', city: 'Seattle', lat: 47.4502, lon: -122.3088 },
-  MIA: { icao: 'KMIA', iata: 'MIA', name: 'Miami International', city: 'Miami', lat: 25.7959, lon: -80.2870 },
-  BOS: { icao: 'KBOS', iata: 'BOS', name: 'Logan International', city: 'Boston', lat: 42.3656, lon: -71.0096 },
-  PHX: { icao: 'KPHX', iata: 'PHX', name: 'Phoenix Sky Harbor International', city: 'Phoenix', lat: 33.4373, lon: -112.0078 },
-  LAS: { icao: 'KLAS', iata: 'LAS', name: 'Harry Reid International', city: 'Las Vegas', lat: 36.0840, lon: -115.1537 },
-  MSP: { icao: 'KMSP', iata: 'MSP', name: 'Minneapolis-Saint Paul International', city: 'Minneapolis', lat: 44.8848, lon: -93.2223 },
-  DTW: { icao: 'KDTW', iata: 'DTW', name: 'Detroit Metropolitan Wayne County', city: 'Detroit', lat: 42.2162, lon: -83.3554 },
-  EWR: { icao: 'KEWR', iata: 'EWR', name: 'Newark Liberty International', city: 'Newark', lat: 40.6895, lon: -74.1745 },
-  IAH: { icao: 'KIAH', iata: 'IAH', name: 'George Bush Intercontinental', city: 'Houston', lat: 29.9902, lon: -95.3368 },
-  SAN: { icao: 'KSAN', iata: 'SAN', name: 'San Diego International', city: 'San Diego', lat: 32.7338, lon: -117.1933 },
-  HNL: { icao: 'PHNL', iata: 'HNL', name: 'Daniel K. Inouye International', city: 'Honolulu', lat: 21.3187, lon: -157.9225 },
-  MCO: { icao: 'KMCO', iata: 'MCO', name: 'Orlando International', city: 'Orlando', lat: 28.4312, lon: -81.3081 },
-  CLT: { icao: 'KCLT', iata: 'CLT', name: 'Charlotte Douglas International', city: 'Charlotte', lat: 35.2144, lon: -80.9473 },
-};
-
-// Mock flight routes for demo purposes
-// Maps flight number patterns to routes
-interface MockRoute {
-  departure: string;
-  arrival: string;
-}
-
-const MOCK_ROUTES: Record<string, MockRoute> = {
-  // American Airlines
-  'AA1': { departure: 'JFK', arrival: 'LAX' },
-  'AA100': { departure: 'JFK', arrival: 'LAX' },
-  'AA123': { departure: 'LAX', arrival: 'JFK' },
-  'AA175': { departure: 'DFW', arrival: 'ORD' },
-  'AA200': { departure: 'MIA', arrival: 'JFK' },
-  'AA234': { departure: 'ORD', arrival: 'DFW' },
-  'AA300': { departure: 'LAX', arrival: 'MIA' },
-  'AA456': { departure: 'DFW', arrival: 'LAX' },
-  'AA500': { departure: 'JFK', arrival: 'MIA' },
-  'AA789': { departure: 'PHX', arrival: 'DFW' },
-  // United Airlines
-  'UA1': { departure: 'SFO', arrival: 'EWR' },
-  'UA100': { departure: 'EWR', arrival: 'SFO' },
-  'UA123': { departure: 'ORD', arrival: 'DEN' },
-  'UA234': { departure: 'SFO', arrival: 'ORD' },
-  'UA456': { departure: 'SFO', arrival: 'ORD' },
-  'UA500': { departure: 'DEN', arrival: 'SFO' },
-  'UA789': { departure: 'IAH', arrival: 'DEN' },
-  // Delta Air Lines
-  'DL1': { departure: 'JFK', arrival: 'LAX' },
-  'DL100': { departure: 'ATL', arrival: 'LAX' },
-  'DL123': { departure: 'JFK', arrival: 'ATL' },
-  'DL234': { departure: 'ATL', arrival: 'JFK' },
-  'DL456': { departure: 'MSP', arrival: 'ATL' },
-  'DL500': { departure: 'DTW', arrival: 'ATL' },
-  'DL789': { departure: 'SEA', arrival: 'ATL' },
-  // Southwest Airlines
-  'WN1': { departure: 'LAS', arrival: 'PHX' },
-  'WN100': { departure: 'DEN', arrival: 'LAS' },
-  'WN123': { departure: 'LAX', arrival: 'LAS' },
-  'WN456': { departure: 'PHX', arrival: 'DEN' },
-  'WN789': { departure: 'ORD', arrival: 'DEN' },
-  // JetBlue Airways
-  'B6100': { departure: 'JFK', arrival: 'BOS' },
-  'B6123': { departure: 'BOS', arrival: 'JFK' },
-  'B6456': { departure: 'JFK', arrival: 'MCO' },
-  'B6789': { departure: 'BOS', arrival: 'MCO' },
-  // Alaska Airlines
-  'AS100': { departure: 'SEA', arrival: 'LAX' },
-  'AS123': { departure: 'SEA', arrival: 'SFO' },
-  'AS456': { departure: 'LAX', arrival: 'SEA' },
-  // Hawaiian Airlines
-  'HA100': { departure: 'HNL', arrival: 'LAX' },
-  'HA123': { departure: 'HNL', arrival: 'SFO' },
-  'HA456': { departure: 'LAX', arrival: 'HNL' },
-};
-
-// Parse flight number into airline code and number
-function parseFlightNumber(input: string): { airlineCode: string; flightNum: string } | null {
-  // Remove spaces and convert to uppercase
-  const cleaned = input.replace(/\s+/g, '').toUpperCase();
-
-  // Match pattern: 2 letters followed by 1-4 digits
-  const match = cleaned.match(/^([A-Z]{2})(\d{1,4})$/);
-
-  if (!match) {
-    return null;
-  }
-
-  return {
-    airlineCode: match[1],
-    flightNum: match[2],
-  };
-}
-
-// Generate a mock route for unknown flight numbers
-function generateMockRoute(airlineCode: string, flightNum: string): MockRoute {
-  // Use the flight number to deterministically select airports
-  const num = parseInt(flightNum, 10);
-  const airportKeys = Object.keys(AIRPORTS);
-
-  // Create a pseudo-random but deterministic selection
-  const depIndex = num % airportKeys.length;
-  let arrIndex = (num * 7 + 3) % airportKeys.length;
-
-  // Ensure different airports
-  if (arrIndex === depIndex) {
-    arrIndex = (arrIndex + 1) % airportKeys.length;
-  }
-
-  return {
-    departure: airportKeys[depIndex],
-    arrival: airportKeys[arrIndex],
-  };
+  errorCode?:
+    | 'INVALID_FLIGHT_NUMBER'
+    | 'FLIGHT_NOT_FOUND'
+    | 'UNKNOWN_AIRLINE'
+    | 'RATE_LIMITED'
+    | 'API_ERROR';
 }
 
 export async function GET(request: NextRequest) {
@@ -179,7 +46,6 @@ export async function GET(request: NextRequest) {
     const { searchParams } = new URL(request.url);
     const flightParam = searchParams.get('flight');
 
-    // Validate flight parameter
     if (!flightParam) {
       return NextResponse.json<FlightLookupResponse>(
         {
@@ -187,83 +53,53 @@ export async function GET(request: NextRequest) {
           error: 'Flight number is required. Example: AA123, UA456',
           errorCode: 'INVALID_FLIGHT_NUMBER',
         },
-        { status: 400 }
+        { status: 400 },
       );
     }
 
-    // Parse the flight number
-    const parsed = parseFlightNumber(flightParam);
+    const forceMock = searchParams.get('mock') === '1';
+    const outcome = await lookupFlight(flightParam, { forceMock });
 
-    if (!parsed) {
+    if (!outcome.ok) {
+      const status =
+        outcome.error.code === 'INVALID_FLIGHT_NUMBER' ? 400 : 404;
       return NextResponse.json<FlightLookupResponse>(
         {
           success: false,
-          error: 'Invalid flight number format. Use airline code + number (e.g., AA123, UA456)',
-          errorCode: 'INVALID_FLIGHT_NUMBER',
+          error: outcome.error.message,
+          errorCode: outcome.error.code,
         },
-        { status: 400 }
+        { status },
       );
     }
 
-    const { airlineCode, flightNum } = parsed;
-
-    // Check if airline is known
-    const airline = AIRLINES[airlineCode];
-
-    if (!airline) {
-      return NextResponse.json<FlightLookupResponse>(
-        {
-          success: false,
-          error: `Unknown airline code: ${airlineCode}. Supported airlines: ${Object.keys(AIRLINES).join(', ')}`,
-          errorCode: 'FLIGHT_NOT_FOUND',
+    const { result } = outcome;
+    return NextResponse.json<FlightLookupResponse>(
+      {
+        success: true,
+        data: {
+          flightNumber: result.flightNumber,
+          airline: result.airline,
+          departure: result.departure,
+          arrival: result.arrival,
+          status: result.status,
+          livePosition: result.livePosition,
+          mock: result.mock,
+          source: result.source,
         },
-        { status: 404 }
-      );
-    }
-
-    // Format flight number for lookup
-    const formattedFlight = `${airlineCode}${flightNum}`;
-
-    // Try to find a known mock route first
-    let route = MOCK_ROUTES[formattedFlight];
-
-    // If not found, generate a deterministic mock route
-    if (!route) {
-      route = generateMockRoute(airlineCode, flightNum);
-    }
-
-    // Get airport data
-    const departure = AIRPORTS[route.departure];
-    const arrival = AIRPORTS[route.arrival];
-
-    if (!departure || !arrival) {
-      return NextResponse.json<FlightLookupResponse>(
-        {
-          success: false,
-          error: 'Flight not found. Check the flight number and try again.',
-          errorCode: 'FLIGHT_NOT_FOUND',
-        },
-        { status: 404 }
-      );
-    }
-
-    // Return successful response
-    const response: FlightLookupResponse = {
-      success: true,
-      data: {
-        flightNumber: formattedFlight,
-        airline,
-        departure,
-        arrival,
-        status: 'scheduled',
       },
-    };
-
-    return NextResponse.json(response, {
-      headers: {
-        'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=7200',
+      {
+        headers: {
+          // Schedule data is fairly stable; let CDN cache as well — but only
+          // for live-provider responses. Forced-mock responses are
+          // user-driven and shouldn't be served from a shared cache.
+          'Cache-Control': forceMock
+            ? 'no-store'
+            : 'public, s-maxage=600, stale-while-revalidate=1200',
+          'X-Flight-Source': result.source,
+        },
       },
-    });
+    );
   } catch (error) {
     console.error('[API] Flight lookup error:', error);
     return NextResponse.json<FlightLookupResponse>(
@@ -272,7 +108,7 @@ export async function GET(request: NextRequest) {
         error: 'Internal server error',
         errorCode: 'API_ERROR',
       },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }

--- a/app/api/aviation/turbulence/route.ts
+++ b/app/api/aviation/turbulence/route.ts
@@ -4,249 +4,223 @@
  * Copyright (C) 2025 16-Bit Weather
  * Licensed under Fair Source License, Version 0.9
  *
- * Fetches Graphical Turbulence Guidance (GTG) data from NOAA Aviation Weather Center
+ * Fetches real Graphical AIRMET (G-AIRMET) turbulence forecasts from
+ * NOAA AWC. CONUS + Alaska/Hawaii coverage. Returns GeoJSON-style polygons
+ * normalized for client consumption.
+ *
+ * Endpoint reference: https://aviationweather.gov/api/data/gairmet?type=turb&format=json
  */
 
 import { NextRequest, NextResponse } from 'next/server';
 
-interface GTGDataPoint {
-  lat: number;
-  lon: number;
-  severity: 'smooth' | 'light' | 'moderate' | 'severe' | 'extreme';
-  edr: number;
+export type TurbulenceSeverity =
+  | 'smooth'
+  | 'light'
+  | 'moderate'
+  | 'severe'
+  | 'extreme';
+
+export interface TurbulencePolygon {
+  /** Stable id for keyed React rendering. */
+  id: string;
+  /** GeoJSON-style coordinate ring(s). Outer ring first. */
+  coordinates: number[][][];
+  severity: TurbulenceSeverity;
+  /** Raw severity string from AWC (e.g., "MOD-SEV"). */
+  rawSeverity: string;
+  /** Hazard label (always "TURB" for this endpoint). */
+  hazard: string;
+  /** Forecast hour offset (0, 3, 6, 9, ...). */
+  forecastHour: number;
+  /** ISO timestamp the forecast becomes valid. */
+  validFrom: string;
+  /** ISO timestamp the forecast expires. */
+  validTo: string;
+  /** Top of layer (hundreds of feet). null when omitted. */
+  topFt: number | null;
+  /** Base of layer (hundreds of feet). null when omitted. */
+  baseFt: number | null;
 }
 
-interface GTGResponse {
+export interface TurbulenceResponse {
   success: boolean;
   data: {
-    validTime: string;
-    altitude: string;
-    forecastHour: number;
-    turbulence: GTGDataPoint[];
-    bounds: {
-      north: number;
-      south: number;
-      east: number;
-      west: number;
-    };
+    polygons: TurbulencePolygon[];
+    fetchedAt: string;
+    source: 'NOAA AWC G-AIRMET';
+    coverage: 'CONUS+AK+HI';
   };
-  source: string;
-  cached: boolean;
+  error?: string;
 }
 
-// Map EDR values to severity levels
-function edrToSeverity(edr: number): GTGDataPoint['severity'] {
-  if (edr >= 0.6) return 'extreme';
-  if (edr >= 0.4) return 'severe';
-  if (edr >= 0.2) return 'moderate';
-  if (edr >= 0.1) return 'light';
+const AWC_GAIRMET_URL =
+  'https://aviationweather.gov/api/data/gairmet?type=turb&format=json';
+
+const FETCH_TIMEOUT_MS = 8000;
+
+function mapSeverity(raw: string | undefined | null): TurbulenceSeverity {
+  if (!raw) return 'smooth';
+  const upper = raw.toUpperCase();
+  if (upper.includes('EXTRM') || upper.includes('EXTREME')) return 'extreme';
+  if (upper.includes('SEV')) return 'severe';
+  if (upper.includes('MOD')) return 'moderate';
+  if (upper.includes('LGT') || upper.includes('LIGHT')) return 'light';
   return 'smooth';
 }
 
-// Seeded pseudo-random number generator for deterministic results
-// Uses simple linear congruential generator (LCG) for reproducibility
-function seededRandom(seed: number): () => number {
-  let state = seed;
-  return () => {
-    state = (state * 1664525 + 1013904223) % 4294967296;
-    return state / 4294967296;
+interface RawGairmetFeature {
+  geometry?: {
+    type?: string;
+    coordinates?: unknown;
+  };
+  properties?: {
+    hazard?: string;
+    severity?: string;
+    fcstHr?: number | string;
+    validTime?: string;
+    forecast?: string;
+    expireTime?: string;
+    top?: number | string;
+    base?: number | string;
+    icao?: string;
   };
 }
 
-// Create a deterministic seed from parameters (ensures same input = same output)
-function createSeed(altitude: string, forecastHour: number, lat: number, lon: number): number {
-  const altNum = parseInt(altitude.replace('FL', ''), 10) || 350;
-  // Round to 6-hour cycle for time-based stability
-  const hourCycle = Math.floor(Date.now() / (6 * 60 * 60 * 1000));
-  return (altNum * 1000 + forecastHour * 100 + Math.abs(lat * 10) + Math.abs(lon) + hourCycle) % 4294967296;
+function asFiniteNumber(v: unknown): number | null {
+  if (typeof v === 'number' && Number.isFinite(v)) return v;
+  if (typeof v === 'string') {
+    const parsed = Number(v);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
 }
 
-// Generate simulated turbulence data based on altitude and forecast
-// This simulates the NOAA GTG data structure while they expose a public API
-// Uses deterministic seeding to ensure consistent results for same parameters
-function generateTurbulenceData(altitude: string, forecastHour: number): GTGDataPoint[] {
-  const turbulencePoints: GTGDataPoint[] = [];
+/** Coerce AWC's polygon coordinates into [[[lon,lat], ...]] form. */
+function normalizeCoordinates(raw: unknown): number[][][] | null {
+  if (!Array.isArray(raw)) return null;
 
-  // Extract flight level number (e.g., FL350 -> 350)
-  const flLevel = parseInt(altitude.replace('FL', ''), 10) || 350;
+  // Polygon: [[[lon,lat], ...], (holes...)]
+  // MultiPolygon: [[[[lon,lat], ...]], ...]
+  // Sometimes AWC returns a flat ring [[lon,lat], ...] for older payloads.
+  if (raw.length === 0) return null;
 
-  // Turbulence is more common at certain flight levels (jet stream altitudes)
-  const jetStreamAltitudes = [300, 350, 400];
-  const isJetStreamAlt = jetStreamAltitudes.some(fl => Math.abs(flLevel - fl) <= 50);
-  const baseProbability = isJetStreamAlt ? 0.3 : 0.15;
-
-  // Known turbulence-prone areas in CONUS (mountain ranges, jet stream)
-  const turbulenceZones = [
-    // Rocky Mountains
-    { lat: 40, lon: -105, radius: 4, intensity: 0.4 },
-    { lat: 38, lon: -107, radius: 3, intensity: 0.35 },
-    { lat: 45, lon: -110, radius: 3, intensity: 0.3 },
-    // Sierra Nevada
-    { lat: 38, lon: -120, radius: 2, intensity: 0.35 },
-    // Jet stream corridor
-    { lat: 35, lon: -95, radius: 5, intensity: 0.3 },
-    { lat: 38, lon: -85, radius: 4, intensity: 0.25 },
-    { lat: 42, lon: -75, radius: 3, intensity: 0.25 },
-    // Appalachians
-    { lat: 37, lon: -80, radius: 2, intensity: 0.2 },
-    // Great Lakes
-    { lat: 44, lon: -87, radius: 3, intensity: 0.2 },
-  ];
-
-  // Adjust intensity based on forecast hour (more uncertainty further out)
-  const forecastMultiplier = 1 + (forecastHour / 24);
-
-  // Generate grid points across CONUS
-  for (let lat = 25; lat <= 50; lat += 2) {
-    for (let lon = -125; lon <= -65; lon += 2) {
-      let edr = 0;
-
-      // Check if point is in any turbulence zone
-      for (const zone of turbulenceZones) {
-        const distance = Math.sqrt(
-          Math.pow(lat - zone.lat, 2) + Math.pow(lon - zone.lon, 2)
-        );
-
-        if (distance < zone.radius) {
-          // EDR decreases with distance from center
-          const zoneEdr = zone.intensity * (1 - distance / zone.radius) * forecastMultiplier;
-          edr = Math.max(edr, zoneEdr);
-        }
-      }
-
-      // Add deterministic variation based on location (seeded random for consistency)
-      const random = seededRandom(createSeed(altitude, forecastHour, lat, lon));
-      if (random() < baseProbability) {
-        edr = Math.max(edr, random() * 0.3);
-      }
-
-      // Only include points with some turbulence (EDR > 0.05)
-      if (edr > 0.05) {
-        // Cap EDR at realistic maximum and round to 2 decimal places
-        // Important: Round BEFORE calling edrToSeverity to avoid mismatch
-        // e.g., 0.095 rounds to 0.10 (light), so severity should also be light
-        const roundedEdr = Math.round(Math.min(edr, 0.8) * 100) / 100;
-
-        turbulencePoints.push({
-          lat,
-          lon,
-          edr: roundedEdr,
-          severity: edrToSeverity(roundedEdr)
-        });
-      }
+  const first = raw[0];
+  // Flat ring (number[][]) → wrap once
+  if (Array.isArray(first) && typeof first[0] === 'number') {
+    return [raw as number[][]];
+  }
+  // Polygon with rings (number[][][]) → use as-is
+  if (Array.isArray(first) && Array.isArray(first[0]) && typeof first[0][0] === 'number') {
+    return raw as number[][][];
+  }
+  // MultiPolygon → flatten to outer rings only
+  if (Array.isArray(first) && Array.isArray(first[0]) && Array.isArray(first[0][0])) {
+    const outerRings: number[][][] = [];
+    for (const polygon of raw as number[][][][]) {
+      if (polygon[0]) outerRings.push(polygon[0]);
     }
+    return outerRings.length > 0 ? outerRings : null;
   }
-
-  return turbulencePoints;
+  return null;
 }
 
-export async function GET(request: NextRequest) {
-  const { searchParams } = new URL(request.url);
-  const altitudeParam = searchParams.get('altitude');
-  const forecastParam = searchParams.get('forecast');
+function parseGairmetFeatures(raw: unknown): TurbulencePolygon[] {
+  const features = Array.isArray(raw) ? raw : [];
+  const polygons: TurbulencePolygon[] = [];
 
-  // Validate required parameters
-  if (!altitudeParam || !forecastParam) {
-    return NextResponse.json(
-      {
-        success: false,
-        error: `Missing required parameter: ${!altitudeParam ? 'altitude' : 'forecast'}`
-      },
-      { status: 400 }
-    );
-  }
+  features.forEach((feature: RawGairmetFeature, index) => {
+    const coords = normalizeCoordinates(feature.geometry?.coordinates);
+    if (!coords) return;
 
-  // Validate altitude format
-  const validAltitudes = ['FL200', 'FL250', 'FL300', 'FL350', 'FL400', 'FL450'];
-  const normalizedAltitude = altitudeParam.toUpperCase();
-  if (!validAltitudes.includes(normalizedAltitude)) {
-    return NextResponse.json(
-      {
-        success: false,
-        error: `Invalid altitude: ${altitudeParam}. Valid values: ${validAltitudes.join(', ')}`
-      },
-      { status: 400 }
-    );
-  }
+    const props = feature.properties ?? {};
+    const rawSeverity = props.severity ?? '';
+    const fcstHr = asFiniteNumber(props.fcstHr) ?? 0;
+    const validFrom = props.validTime ?? props.forecast ?? new Date().toISOString();
+    const validTo = props.expireTime ?? validFrom;
 
-  // Validate forecast hour
-  const validForecasts = [0, 6, 12, 18];
-  const forecast = parseInt(forecastParam, 10);
-  if (!Number.isFinite(forecast) || !validForecasts.includes(forecast)) {
-    return NextResponse.json(
-      {
-        success: false,
-        error: `Invalid forecast: ${forecastParam}. Valid values: ${validForecasts.join(', ')}`
-      },
-      { status: 400 }
-    );
-  }
-  const normalizedForecast = forecast;
+    polygons.push({
+      id: `gairmet-${fcstHr}-${index}`,
+      coordinates: coords,
+      severity: mapSeverity(rawSeverity),
+      rawSeverity,
+      hazard: props.hazard ?? 'TURB',
+      forecastHour: fcstHr,
+      validFrom,
+      validTo,
+      topFt: asFiniteNumber(props.top),
+      baseFt: asFiniteNumber(props.base),
+    });
+  });
 
+  return polygons;
+}
+
+async function fetchWithTimeout(url: string, timeoutMs: number): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    // Try to fetch from NOAA GTG API (currently returns 404, so we fall back to simulated data)
-    // The official NOAA GTG endpoint for reference:
-    // const gtgUrl = `https://aviationweather.gov/api/data/gtg?format=json&fl=${normalizedAltitude.replace('FL', '')}&fcst=${normalizedForecast}`;
+    return await fetch(url, {
+      signal: controller.signal,
+      next: { revalidate: 600 }, // 10-min CDN cache
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+}
 
-    // Generate turbulence data
-    const turbulenceData = generateTurbulenceData(normalizedAltitude, normalizedForecast);
+export async function GET(_request: NextRequest) {
+  try {
+    const res = await fetchWithTimeout(AWC_GAIRMET_URL, FETCH_TIMEOUT_MS);
 
-    // Calculate valid time based on forecast hour (use UTC for aviation synoptic times)
-    // Aviation uses standard UTC synoptic hours: 00Z, 06Z, 12Z, 18Z
-    const now = new Date();
-    const roundedUtc = new Date(Date.UTC(
-      now.getUTCFullYear(),
-      now.getUTCMonth(),
-      now.getUTCDate(),
-      Math.floor(now.getUTCHours() / 6) * 6,
-      0, 0, 0
-    ));
-    const validTime = new Date(roundedUtc.getTime() + normalizedForecast * 60 * 60 * 1000);
+    if (!res.ok) {
+      console.error(`[API] AWC G-AIRMET returned ${res.status}`);
+      return NextResponse.json<TurbulenceResponse>(
+        {
+          success: false,
+          data: {
+            polygons: [],
+            fetchedAt: new Date().toISOString(),
+            source: 'NOAA AWC G-AIRMET',
+            coverage: 'CONUS+AK+HI',
+          },
+          error: `Upstream NOAA AWC returned ${res.status}`,
+        },
+        { status: 502 },
+      );
+    }
 
-    const response: GTGResponse = {
+    const raw = await res.json();
+    const polygons = parseGairmetFeatures(raw);
+
+    const response: TurbulenceResponse = {
       success: true,
       data: {
-        validTime: validTime.toISOString(),
-        altitude: normalizedAltitude,
-        forecastHour: normalizedForecast,
-        turbulence: turbulenceData,
-        bounds: {
-          north: 50,
-          south: 25,
-          east: -65,
-          west: -125
-        }
+        polygons,
+        fetchedAt: new Date().toISOString(),
+        source: 'NOAA AWC G-AIRMET',
+        coverage: 'CONUS+AK+HI',
       },
-      source: 'NOAA GTG (Simulated)',
-      cached: false
     };
 
     return NextResponse.json(response, {
       headers: {
-        'Cache-Control': 'public, s-maxage=1800, stale-while-revalidate=3600'
-      }
-    });
-
-  } catch (error) {
-    console.error('Turbulence API error:', error);
-
-    return NextResponse.json({
-      success: false,
-      data: {
-        validTime: new Date().toISOString(),
-        altitude: normalizedAltitude,
-        forecastHour: normalizedForecast,
-        turbulence: [],
-        bounds: {
-          north: 50,
-          south: 25,
-          east: -65,
-          west: -125
-        }
+        'Cache-Control': 'public, s-maxage=600, stale-while-revalidate=1200',
       },
-      source: 'NOAA GTG',
-      cached: false,
-      error: 'Unable to fetch turbulence data. Please try again later.'
-    }, { status: 500 });
+    });
+  } catch (error) {
+    console.error('[API] Turbulence (G-AIRMET) error:', error);
+    return NextResponse.json<TurbulenceResponse>(
+      {
+        success: false,
+        data: {
+          polygons: [],
+          fetchedAt: new Date().toISOString(),
+          source: 'NOAA AWC G-AIRMET',
+          coverage: 'CONUS+AK+HI',
+        },
+        error: 'Unable to fetch turbulence data. Please try again later.',
+      },
+      { status: 500 },
+    );
   }
 }

--- a/app/aviation/page.tsx
+++ b/app/aviation/page.tsx
@@ -26,6 +26,7 @@ export default function AviationPage() {
   const [alerts, setAlerts] = useState<AviationAlert[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [alertsFetchedAt, setAlertsFetchedAt] = useState<number | null>(null);
 
   useEffect(() => {
     const fetchAlerts = async () => {
@@ -39,6 +40,7 @@ export default function AviationPage() {
 
         const data = await response.json();
         setAlerts(data.alerts || []);
+        setAlertsFetchedAt(Date.now());
         setError(null);
       } catch (err) {
         console.error('Error fetching aviation alerts:', err);
@@ -86,10 +88,16 @@ export default function AviationPage() {
 
         {/* Error Display */}
         {error && (
-          <div className={cn(
-            'mb-6 p-4 border-4 border-red-500 bg-red-500/10 font-mono text-sm',
-            'text-red-500'
-          )}>
+          <div
+            className="mb-6 p-4 border-4 font-mono text-sm"
+            style={{
+              color: 'var(--severity-extreme)',
+              backgroundColor: 'var(--severity-extreme-bg)',
+              borderColor: 'var(--severity-extreme)',
+            }}
+            role="alert"
+            aria-live="polite"
+          >
             {error}
           </div>
         )}
@@ -103,6 +111,7 @@ export default function AviationPage() {
           <FlightConditionsTerminal
             alerts={alerts}
             isLoading={isLoading}
+            alertsFetchedAt={alertsFetchedAt}
           />
         </Suspense>
       </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -20,6 +20,20 @@
     font-family: var(--font-body, var(--font-ui), ui-sans-serif, system-ui, sans-serif);
     font-weight: 400;
   }
+
+  /* Universal severity tokens — meaning is universal (red = danger),
+     not theme-dependent. Used by aviation, alerts, and any feature
+     that needs semantic severity color. */
+  :root {
+    --severity-light: hsl(142 71% 45%);
+    --severity-moderate: hsl(48 96% 53%);
+    --severity-severe: hsl(25 95% 53%);
+    --severity-extreme: hsl(0 84% 60%);
+    --severity-light-bg: hsl(142 71% 45% / 0.12);
+    --severity-moderate-bg: hsl(48 96% 53% / 0.12);
+    --severity-severe-bg: hsl(25 95% 53% / 0.12);
+    --severity-extreme-bg: hsl(0 84% 60% / 0.12);
+  }
 }
 
 /* ═══════════════════════════════════════════════════════════

--- a/components/aviation/AlertTicker.tsx
+++ b/components/aviation/AlertTicker.tsx
@@ -9,7 +9,7 @@
 
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, type CSSProperties } from 'react';
 import { AlertTriangle, Info, Plane } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useTheme } from '@/components/theme-provider';
@@ -23,27 +23,27 @@ interface AlertTickerProps {
   isLoading?: boolean;
 }
 
+const severityVar: Record<AviationAlert['severity'], string> = {
+  extreme: '--severity-extreme',
+  severe: '--severity-severe',
+  moderate: '--severity-moderate',
+  low: '--severity-light',
+};
+
+function severityStyle(severity: AviationAlert['severity']): CSSProperties {
+  const v = severityVar[severity] ?? severityVar.low;
+  return {
+    color: `var(${v})`,
+    backgroundColor: `var(${v}-bg)`,
+  };
+}
+
 export default function AlertTicker({ alerts, isLoading = false }: AlertTickerProps) {
   const { theme } = useTheme();
   const themeClasses = getComponentStyles((theme || 'nord') as ThemeType, 'weather');
   const [currentIndex, setCurrentIndex] = useState(0);
   const [displayText, setDisplayText] = useState('');
   const [isTyping, setIsTyping] = useState(true);
-
-  // Severity color mapping
-  const getSeverityColor = (severity: AviationAlert['severity']) => {
-    switch (severity) {
-      case 'extreme':
-        return 'text-red-500 bg-red-500/10';
-      case 'severe':
-        return 'text-orange-500 bg-orange-500/10';
-      case 'moderate':
-        return 'text-yellow-500 bg-yellow-500/10';
-      case 'low':
-      default:
-        return 'text-green-500 bg-green-500/10';
-    }
-  };
 
   const getAlertIcon = (type: AviationAlert['type']) => {
     switch (type) {
@@ -88,17 +88,25 @@ export default function AlertTicker({ alerts, isLoading = false }: AlertTickerPr
 
   if (isLoading) {
     return (
-      <div className={cn(
-        'border-4 p-3 font-mono',
-        themeClasses.borderColor,
-        themeClasses.background
-      )}>
+      <div
+        className={cn(
+          'border-4 p-3 font-mono',
+          themeClasses.borderColor,
+          themeClasses.background
+        )}
+        role="status"
+        aria-live="polite"
+      >
         <div className="flex items-center gap-2">
           <div className="animate-pulse flex items-center gap-2">
-            <AlertTriangle className="w-4 h-4 text-yellow-500" />
+            <AlertTriangle
+              className="w-4 h-4"
+              style={{ color: 'var(--severity-moderate)' }}
+              aria-hidden="true"
+            />
             <span className={cn('text-xs', themeClasses.text)}>LOADING AVIATION ALERTS...</span>
           </div>
-          <span className="animate-pulse text-yellow-500">_</span>
+          <span className="animate-pulse" style={{ color: 'var(--severity-moderate)' }} aria-hidden="true">_</span>
         </div>
       </div>
     );
@@ -106,14 +114,21 @@ export default function AlertTicker({ alerts, isLoading = false }: AlertTickerPr
 
   if (alerts.length === 0) {
     return (
-      <div className={cn(
-        'border-4 p-3 font-mono',
-        themeClasses.borderColor,
-        themeClasses.background
-      )}>
+      <div
+        className={cn(
+          'border-4 p-3 font-mono',
+          themeClasses.borderColor,
+          themeClasses.background
+        )}
+        role="status"
+      >
         <div className="flex items-center gap-2">
-          <Info className="w-4 h-4 text-green-500" />
-          <span className={cn('text-xs text-green-500')}>
+          <Info
+            className="w-4 h-4"
+            style={{ color: 'var(--severity-light)' }}
+            aria-hidden="true"
+          />
+          <span className="text-xs" style={{ color: 'var(--severity-light)' }}>
             NO ACTIVE AVIATION ALERTS - ALL CLEAR
           </span>
         </div>
@@ -122,43 +137,51 @@ export default function AlertTicker({ alerts, isLoading = false }: AlertTickerPr
   }
 
   const currentAlert = alerts[currentIndex];
+  const severityStyles = severityStyle(currentAlert.severity);
 
   return (
-    <div className={cn(
-      'border-4 p-3 font-mono overflow-hidden',
-      themeClasses.borderColor,
-      themeClasses.background
-    )}>
+    <div
+      className={cn(
+        'border-4 p-3 font-mono overflow-hidden',
+        themeClasses.borderColor,
+        themeClasses.background
+      )}
+      role="region"
+      aria-label="Aviation alerts ticker"
+    >
       {/* Header */}
       <div className="flex items-center justify-between mb-2">
         <div className="flex items-center gap-2">
-          <span className={cn(
-            'text-xs font-bold px-2 py-0.5 border-2',
-            getSeverityColor(currentAlert.severity),
-            themeClasses.borderColor
-          )}>
+          <span
+            className={cn(
+              'text-xs font-bold px-2 py-0.5 border-2 inline-flex items-center',
+              themeClasses.borderColor
+            )}
+            style={severityStyles}
+            aria-hidden="true"
+          >
             {getAlertIcon(currentAlert.type)}
           </span>
-          <span className={cn(
-            'text-xs font-bold uppercase',
-            getSeverityColor(currentAlert.severity)
-          )}>
+          <span
+            className="text-xs font-bold uppercase px-1"
+            style={severityStyles}
+          >
             {currentAlert.type}
           </span>
         </div>
-        <span className={cn('text-xs', themeClasses.text)}>
+        <span className={cn('text-xs', themeClasses.text)} aria-label={`Alert ${currentIndex + 1} of ${alerts.length}`}>
           {currentIndex + 1}/{alerts.length}
         </span>
       </div>
 
       {/* Ticker Display */}
-      <div className={cn('text-sm', getSeverityColor(currentAlert.severity))}>
+      <div className="text-sm" style={severityStyles} aria-live="polite">
         {displayText}
-        {isTyping && <span className="animate-pulse">_</span>}
+        {isTyping && <span className="animate-pulse" aria-hidden="true">_</span>}
       </div>
 
       {/* Alert Counter */}
-      <div className="flex gap-1 mt-2">
+      <div className="flex gap-1 mt-2" aria-hidden="true">
         {alerts.map((_, idx) => (
           <div
             key={idx}
@@ -166,7 +189,7 @@ export default function AlertTicker({ alerts, isLoading = false }: AlertTickerPr
               'h-1 flex-1 transition-all duration-300',
               idx === currentIndex
                 ? themeClasses.accentBg
-                : 'bg-gray-700'
+                : 'bg-muted'
             )}
           />
         ))}

--- a/components/aviation/FlightConditionsTerminal.tsx
+++ b/components/aviation/FlightConditionsTerminal.tsx
@@ -21,8 +21,8 @@ import dynamic from 'next/dynamic';
 // Lazy load TurbulenceMap to optimize performance
 const TurbulenceMap = dynamic(() => import('./TurbulenceMap'), {
   loading: () => (
-    <div className="h-[350px] flex items-center justify-center bg-gray-900 border-2 border-dashed border-gray-600 rounded">
-      <div className="text-center text-gray-400 font-mono text-sm">
+    <div className="h-[350px] flex items-center justify-center bg-card border-2 border-dashed border-border rounded">
+      <div className="text-center text-muted-foreground font-mono text-sm">
         <div className="animate-pulse">Loading Turbulence Map...</div>
       </div>
     </div>
@@ -33,8 +33,8 @@ const TurbulenceMap = dynamic(() => import('./TurbulenceMap'), {
 // Lazy load FlightRouteLookup
 const FlightRouteLookup = dynamic(() => import('./FlightRouteLookup'), {
   loading: () => (
-    <div className="h-[200px] flex items-center justify-center bg-gray-900 border-2 border-dashed border-gray-600 rounded">
-      <div className="text-center text-gray-400 font-mono text-sm">
+    <div className="h-[200px] flex items-center justify-center bg-card border-2 border-dashed border-border rounded">
+      <div className="text-center text-muted-foreground font-mono text-sm">
         <div className="animate-pulse">Loading Route Lookup...</div>
       </div>
     </div>
@@ -45,9 +45,21 @@ const FlightRouteLookup = dynamic(() => import('./FlightRouteLookup'), {
 interface FlightConditionsTerminalProps {
   alerts: AviationAlert[];
   isLoading?: boolean;
+  alertsFetchedAt?: number | null;
 }
 
-export default function FlightConditionsTerminal({ alerts, isLoading = false }: FlightConditionsTerminalProps) {
+function formatAlertsAge(fetchedAt: number | null | undefined, now: number): string | null {
+  if (!fetchedAt) return null;
+  const diffMs = now - fetchedAt;
+  if (diffMs < 0) return 'just now';
+  const minutes = Math.floor(diffMs / 60000);
+  if (minutes < 1) return 'just now';
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  return `${hours}h ${minutes % 60}m ago`;
+}
+
+export default function FlightConditionsTerminal({ alerts, isLoading = false, alertsFetchedAt = null }: FlightConditionsTerminalProps) {
   const { theme } = useTheme();
   const themeClasses = getComponentStyles((theme || 'nord') as ThemeType, 'weather');
   const [currentTime, setCurrentTime] = useState<Date | null>(null);
@@ -60,6 +72,8 @@ export default function FlightConditionsTerminal({ alerts, isLoading = false }: 
     const timer = setInterval(() => setCurrentTime(new Date()), 10000);
     return () => clearInterval(timer);
   }, []);
+
+  const alertsAge = currentTime ? formatAlertsAge(alertsFetchedAt, currentTime.getTime()) : null;
 
   const formatZuluTime = (date: Date | null) => {
     if (!date) return '--:--:--Z';
@@ -120,7 +134,10 @@ export default function FlightConditionsTerminal({ alerts, isLoading = false }: 
               </div>
             </div>
             <div className={'text-center p-2 container-nested'}>
-              <div className="text-2xl font-bold font-mono text-orange-500">
+              <div
+                className="text-2xl font-bold font-mono"
+                style={{ color: 'var(--severity-severe)' }}
+              >
                 {alertStats.sigmet}
               </div>
               <div className={cn('text-xs font-mono uppercase', themeClasses.text)}>
@@ -128,7 +145,10 @@ export default function FlightConditionsTerminal({ alerts, isLoading = false }: 
               </div>
             </div>
             <div className={'text-center p-2 container-nested'}>
-              <div className="text-2xl font-bold font-mono text-yellow-500">
+              <div
+                className="text-2xl font-bold font-mono"
+                style={{ color: 'var(--severity-moderate)' }}
+              >
                 {alertStats.airmet}
               </div>
               <div className={cn('text-xs font-mono uppercase', themeClasses.text)}>
@@ -136,10 +156,14 @@ export default function FlightConditionsTerminal({ alerts, isLoading = false }: 
               </div>
             </div>
             <div className={'text-center p-2 container-nested'}>
-              <div className={cn(
-                'text-2xl font-bold font-mono',
-                alertStats.severe > 0 ? 'text-red-500' : 'text-green-500'
-              )}>
+              <div
+                className="text-2xl font-bold font-mono"
+                style={{
+                  color: alertStats.severe > 0
+                    ? 'var(--severity-extreme)'
+                    : 'var(--severity-light)',
+                }}
+              >
                 {alertStats.severe > 0 ? alertStats.severe : 'OK'}
               </div>
               <div className={cn('text-xs font-mono uppercase', themeClasses.text)}>
@@ -154,22 +178,24 @@ export default function FlightConditionsTerminal({ alerts, isLoading = false }: 
       <Card className={cn('container-primary', themeClasses.background)}>
         <button
           onClick={() => toggleSection('turbulence')}
-          className={'w-full flex items-center justify-between p-3 border-b border-subtle hover:bg-gray-800/50 transition-colors'}
+          className="w-full flex items-center justify-between p-3 border-b border-subtle hover:bg-muted/50 transition-colors"
+          aria-expanded={expandedSection === 'turbulence'}
+          aria-controls="aviation-turbulence-panel"
         >
           <div className="flex items-center gap-2">
-            <MapIcon className="w-4 h-4 text-purple-500" />
+            <MapIcon className="w-4 h-4 text-primary" aria-hidden="true" />
             <span className={cn('text-sm font-mono font-bold uppercase', themeClasses.headerText)}>
               Turbulence Forecast Map
             </span>
           </div>
           {expandedSection === 'turbulence' ? (
-            <ChevronUp className="w-4 h-4" />
+            <ChevronUp className="w-4 h-4" aria-hidden="true" />
           ) : (
-            <ChevronDown className="w-4 h-4" />
+            <ChevronDown className="w-4 h-4" aria-hidden="true" />
           )}
         </button>
         {expandedSection === 'turbulence' && (
-          <CardContent className="p-4">
+          <CardContent className="p-4" id="aviation-turbulence-panel">
             <TurbulenceMap initialAltitude="all" initialHours={2} />
           </CardContent>
         )}
@@ -179,25 +205,27 @@ export default function FlightConditionsTerminal({ alerts, isLoading = false }: 
       <Card className={cn('container-primary', themeClasses.background)}>
         <button
           onClick={() => toggleSection('route')}
-          className={'w-full flex items-center justify-between p-3 border-b border-subtle hover:bg-gray-800/50 transition-colors'}
+          className="w-full flex items-center justify-between p-3 border-b border-subtle hover:bg-muted/50 transition-colors"
+          aria-expanded={expandedSection === 'route'}
+          aria-controls="aviation-route-panel"
         >
           <div className="flex items-center gap-2">
-            <Route className="w-4 h-4 text-cyan-500" />
+            <Route className="w-4 h-4 text-primary" aria-hidden="true" />
             <span className={cn('text-sm font-mono font-bold uppercase', themeClasses.headerText)}>
               Flight Route Lookup
             </span>
-            <span className="text-xs px-2 py-0.5 bg-cyan-500/20 text-cyan-500 rounded">
+            <span className="text-xs px-2 py-0.5 bg-primary/20 text-primary rounded">
               NEW
             </span>
           </div>
           {expandedSection === 'route' ? (
-            <ChevronUp className="w-4 h-4" />
+            <ChevronUp className="w-4 h-4" aria-hidden="true" />
           ) : (
-            <ChevronDown className="w-4 h-4" />
+            <ChevronDown className="w-4 h-4" aria-hidden="true" />
           )}
         </button>
         {expandedSection === 'route' && (
-          <CardContent className="p-4">
+          <CardContent className="p-4" id="aviation-route-panel">
             <FlightRouteLookup />
           </CardContent>
         )}
@@ -207,30 +235,50 @@ export default function FlightConditionsTerminal({ alerts, isLoading = false }: 
       <Card className={cn('container-primary', themeClasses.background)}>
         <button
           onClick={() => toggleSection('alerts')}
-          className={'w-full flex items-center justify-between p-3 border-b border-subtle hover:bg-gray-800/50 transition-colors'}
+          className="w-full flex items-center justify-between p-3 border-b border-subtle hover:bg-muted/50 transition-colors"
+          aria-expanded={expandedSection === 'alerts'}
+          aria-controls="aviation-alerts-panel"
         >
           <div className="flex items-center gap-2">
-            <AlertTriangle className="w-4 h-4 text-yellow-500" />
+            <AlertTriangle
+              className="w-4 h-4"
+              style={{ color: 'var(--severity-moderate)' }}
+              aria-hidden="true"
+            />
             <span className={cn('text-sm font-mono font-bold uppercase', themeClasses.headerText)}>
               Aviation Alerts Feed
             </span>
             {alertStats.total > 0 && (
-              <span className={cn('text-xs px-2 py-0.5 rounded',
-                alertStats.severe > 0 ? 'bg-red-500/20 text-red-500' : 'bg-yellow-500/20 text-yellow-500'
-              )}>
+              <span
+                className="text-xs px-2 py-0.5 rounded font-mono"
+                style={{
+                  color: alertStats.severe > 0
+                    ? 'var(--severity-extreme)'
+                    : 'var(--severity-moderate)',
+                  backgroundColor: alertStats.severe > 0
+                    ? 'var(--severity-extreme-bg)'
+                    : 'var(--severity-moderate-bg)',
+                }}
+              >
                 {alertStats.total} ACTIVE
               </span>
             )}
           </div>
           {expandedSection === 'alerts' ? (
-            <ChevronUp className="w-4 h-4" />
+            <ChevronUp className="w-4 h-4" aria-hidden="true" />
           ) : (
-            <ChevronDown className="w-4 h-4" />
+            <ChevronDown className="w-4 h-4" aria-hidden="true" />
           )}
         </button>
         {expandedSection === 'alerts' && (
-          <CardContent className="p-0">
+          <CardContent className="p-0" id="aviation-alerts-panel">
             <AlertTicker alerts={alerts} isLoading={isLoading} />
+            {alertsAge && (
+              <div className={cn('flex items-center gap-2 px-3 py-2 text-xs font-mono opacity-60', themeClasses.text)}>
+                <Clock className="w-3 h-3" aria-hidden="true" />
+                <span>Alerts updated {alertsAge}</span>
+              </div>
+            )}
           </CardContent>
         )}
       </Card>
@@ -239,38 +287,48 @@ export default function FlightConditionsTerminal({ alerts, isLoading = false }: 
       <Card className={cn('container-primary', themeClasses.background)}>
         <button
           onClick={() => toggleSection('info')}
-          className={'w-full flex items-center justify-between p-3 border-b border-subtle hover:bg-gray-800/50 transition-colors'}
+          className="w-full flex items-center justify-between p-3 border-b border-subtle hover:bg-muted/50 transition-colors"
+          aria-expanded={expandedSection === 'info'}
+          aria-controls="aviation-info-panel"
         >
           <div className="flex items-center gap-2">
-            <Radio className="w-4 h-4 text-green-500" />
+            <Radio
+              className="w-4 h-4"
+              style={{ color: 'var(--severity-light)' }}
+              aria-hidden="true"
+            />
             <span className={cn('text-sm font-mono font-bold uppercase', themeClasses.headerText)}>
               Data Sources & Turbulence Guide
             </span>
           </div>
           {expandedSection === 'info' ? (
-            <ChevronUp className="w-4 h-4" />
+            <ChevronUp className="w-4 h-4" aria-hidden="true" />
           ) : (
-            <ChevronDown className="w-4 h-4" />
+            <ChevronDown className="w-4 h-4" aria-hidden="true" />
           )}
         </button>
         {expandedSection === 'info' && (
-          <CardContent className="p-4 space-y-4">
+          <CardContent className="p-4 space-y-4" id="aviation-info-panel">
             {/* Data Sources */}
             <div>
               <div className={cn('text-xs font-mono font-bold mb-2 flex items-center gap-2', themeClasses.headerText)}>
-                <Radio className="w-3 h-3 text-green-500" />
+                <Radio
+                  className="w-3 h-3"
+                  style={{ color: 'var(--severity-light)' }}
+                  aria-hidden="true"
+                />
                 DATA SOURCES
               </div>
               <div className="grid grid-cols-1 md:grid-cols-2 gap-3 font-mono text-xs">
                 <div className={'p-3 card-inner'}>
                   <div className={cn('font-bold mb-1', themeClasses.accentText)}>NOAA AWC</div>
                   <div className={cn(themeClasses.text)}>Aviation Weather Center</div>
-                  <div className="text-green-500 mt-1">STATUS: ONLINE</div>
+                  <div className="mt-1" style={{ color: 'var(--severity-light)' }}>STATUS: ONLINE</div>
                 </div>
                 <div className={'p-3 card-inner'}>
                   <div className={cn('font-bold mb-1', themeClasses.accentText)}>NOAA GFS</div>
                   <div className={cn(themeClasses.text)}>Global Forecast System</div>
-                  <div className="text-green-500 mt-1">STATUS: ONLINE</div>
+                  <div className="mt-1" style={{ color: 'var(--severity-light)' }}>STATUS: ONLINE</div>
                 </div>
               </div>
             </div>
@@ -278,41 +336,60 @@ export default function FlightConditionsTerminal({ alerts, isLoading = false }: 
             {/* Turbulence Guide */}
             <div className={cn('pt-4 border-t', themeClasses.borderColor)}>
               <div className={cn('text-xs font-mono font-bold mb-2 flex items-center gap-2', themeClasses.headerText)}>
-                <Wind className="w-3 h-3 text-cyan-500" />
+                <Wind
+                  className="w-3 h-3 text-primary"
+                  aria-hidden="true"
+                />
                 TURBULENCE INTENSITY GUIDE
               </div>
-              <div className="space-y-2 font-mono text-xs">
-                <div className={'flex items-center gap-3 p-2 card-inner'}>
-                  <div className="w-4 h-4 bg-green-500 rounded" />
+              <div className="space-y-2 font-mono text-xs" role="list">
+                <div className="flex items-center gap-3 p-2 card-inner" role="listitem">
+                  <div
+                    className="w-4 h-4 rounded"
+                    style={{ backgroundColor: 'var(--severity-light)' }}
+                    aria-hidden="true"
+                  />
                   <div>
-                    <span className="text-green-500 font-bold">LIGHT</span>
+                    <span className="font-bold" style={{ color: 'var(--severity-light)' }}>LIGHT</span>
                     <span className={cn('ml-2', themeClasses.text)}>
                       Minor turbulence. Seat belt recommended.
                     </span>
                   </div>
                 </div>
-                <div className={'flex items-center gap-3 p-2 card-inner'}>
-                  <div className="w-4 h-4 bg-yellow-500 rounded" />
+                <div className="flex items-center gap-3 p-2 card-inner" role="listitem">
+                  <div
+                    className="w-4 h-4 rounded"
+                    style={{ backgroundColor: 'var(--severity-moderate)' }}
+                    aria-hidden="true"
+                  />
                   <div>
-                    <span className="text-yellow-500 font-bold">MODERATE</span>
+                    <span className="font-bold" style={{ color: 'var(--severity-moderate)' }}>MODERATE</span>
                     <span className={cn('ml-2', themeClasses.text)}>
                       Definite strains against seat belt. Unsecured objects may move.
                     </span>
                   </div>
                 </div>
-                <div className={'flex items-center gap-3 p-2 card-inner'}>
-                  <div className="w-4 h-4 bg-orange-500 rounded" />
+                <div className="flex items-center gap-3 p-2 card-inner" role="listitem">
+                  <div
+                    className="w-4 h-4 rounded"
+                    style={{ backgroundColor: 'var(--severity-severe)' }}
+                    aria-hidden="true"
+                  />
                   <div>
-                    <span className="text-orange-500 font-bold">SEVERE</span>
+                    <span className="font-bold" style={{ color: 'var(--severity-severe)' }}>SEVERE</span>
                     <span className={cn('ml-2', themeClasses.text)}>
                       Abrupt changes in altitude/attitude. Aircraft may be momentarily out of control.
                     </span>
                   </div>
                 </div>
-                <div className={'flex items-center gap-3 p-2 card-inner'}>
-                  <div className="w-4 h-4 bg-red-500 rounded" />
+                <div className="flex items-center gap-3 p-2 card-inner" role="listitem">
+                  <div
+                    className="w-4 h-4 rounded"
+                    style={{ backgroundColor: 'var(--severity-extreme)' }}
+                    aria-hidden="true"
+                  />
                   <div>
-                    <span className="text-red-500 font-bold">EXTREME</span>
+                    <span className="font-bold" style={{ color: 'var(--severity-extreme)' }}>EXTREME</span>
                     <span className={cn('ml-2', themeClasses.text)}>
                       Aircraft violently tossed. Practically impossible to control. May cause structural damage.
                     </span>

--- a/components/aviation/FlightNumberInput.tsx
+++ b/components/aviation/FlightNumberInput.tsx
@@ -16,6 +16,7 @@ import { LoadingSpinner } from '@/components/ui/loading-state';
 import { cn } from '@/lib/utils';
 import { useTheme } from '@/components/theme-provider';
 import { getComponentStyles, type ThemeType } from '@/lib/theme-utils';
+import { useDemoMode } from '@/hooks/useDemoMode';
 
 // Flight data interface matching the API response
 export interface FlightData {
@@ -42,6 +43,8 @@ export interface FlightData {
     lon: number;
   };
   status: string;
+  /** Set when the route was synthesized rather than fetched from a live provider. */
+  mock?: boolean;
 }
 
 interface FlightNumberInputProps {
@@ -57,6 +60,7 @@ export default function FlightNumberInput({
 }: FlightNumberInputProps) {
   const { theme } = useTheme();
   const themeClasses = getComponentStyles((theme || 'nord') as ThemeType, 'weather');
+  const [demoMode, setDemoMode] = useDemoMode();
 
   const [flightNumber, setFlightNumber] = useState('');
   const [isSearching, setIsSearching] = useState(false);
@@ -77,7 +81,9 @@ export default function FlightNumberInput({
     setError(null);
 
     try {
-      const response = await fetch(`/api/aviation/flight-lookup?flight=${encodeURIComponent(trimmed)}`);
+      const params = new URLSearchParams({ flight: trimmed });
+      if (demoMode) params.set('mock', '1');
+      const response = await fetch(`/api/aviation/flight-lookup?${params.toString()}`);
       const result = await response.json();
 
       if (!response.ok || !result.success) {
@@ -98,7 +104,7 @@ export default function FlightNumberInput({
     } finally {
       setIsSearching(false);
     }
-  }, [flightNumber, onFlightFound, onError]);
+  }, [flightNumber, demoMode, onFlightFound, onError]);
 
   // Handle form submission
   const handleSubmit = (e: React.FormEvent) => {
@@ -134,11 +140,11 @@ export default function FlightNumberInput({
             maxLength={10}
             disabled={isSearching}
             className={cn(
-              'w-full pl-10 pr-3 py-2 font-mono text-sm border-2 rounded bg-gray-900',
+              'w-full pl-10 pr-3 py-2 font-mono text-sm border-2 rounded bg-card',
               themeClasses.borderColor,
               themeClasses.text,
-              'focus:outline-none focus:ring-2 focus:ring-cyan-500',
-              'placeholder:text-gray-500',
+              'focus:outline-none focus:ring-2 focus:ring-primary',
+              'placeholder:text-muted-foreground',
               isSearching && 'opacity-50 cursor-not-allowed'
             )}
             data-testid="flight-number-input"
@@ -154,8 +160,8 @@ export default function FlightNumberInput({
             'flex items-center justify-center gap-2 px-4 py-2 font-mono text-sm font-bold border-2 rounded transition-colors min-w-[100px]',
             themeClasses.borderColor,
             isSearching || !flightNumber.trim()
-              ? 'opacity-50 cursor-not-allowed bg-gray-800'
-              : 'bg-cyan-500/20 hover:bg-cyan-500/30 text-cyan-400'
+              ? 'opacity-50 cursor-not-allowed bg-muted'
+              : 'bg-primary/20 hover:bg-primary/30 text-primary'
           )}
           data-testid="flight-search-button"
           aria-label="Search flight"
@@ -177,21 +183,60 @@ export default function FlightNumberInput({
       {/* Error Display */}
       {error && (
         <div
-          className={cn(
-            'flex items-center gap-2 p-2 text-xs font-mono rounded',
-            'bg-red-500/10 text-red-400 border border-red-500/30'
-          )}
+          className="flex items-center gap-2 p-2 text-xs font-mono rounded border"
+          style={{
+            color: 'var(--severity-extreme)',
+            backgroundColor: 'var(--severity-extreme-bg)',
+            borderColor: 'var(--severity-extreme)',
+          }}
           data-testid="flight-search-error"
           role="alert"
+          aria-live="polite"
         >
-          <AlertTriangle className="w-3 h-3 flex-shrink-0" />
+          <AlertTriangle className="w-3 h-3 flex-shrink-0" aria-hidden="true" />
           <span>{error}</span>
         </div>
       )}
 
+      {/* Demo Mode Toggle */}
+      <label
+        className={cn(
+          'flex items-center justify-between gap-2 px-2 py-1 text-xs font-mono cursor-pointer select-none rounded border',
+          themeClasses.borderColor,
+          themeClasses.text,
+        )}
+        title="When on, flight searches return synthesized routes for screenshots and offline demos."
+      >
+        <span className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={demoMode}
+            onChange={(e) => setDemoMode(e.target.checked)}
+            className="accent-primary"
+            data-testid="aviation-demo-mode-toggle"
+            aria-label="Force demo data for flight lookups"
+          />
+          <span className="uppercase tracking-wider">Demo mode</span>
+          {demoMode && (
+            <span
+              className="text-[10px] font-bold px-1.5 py-0.5 rounded uppercase"
+              style={{
+                color: 'var(--severity-moderate)',
+                backgroundColor: 'var(--severity-moderate-bg)',
+              }}
+            >
+              ON
+            </span>
+          )}
+        </span>
+        <span className="opacity-60 text-[10px]">
+          {demoMode ? 'Forcing mock data' : 'Use real data when available'}
+        </span>
+      </label>
+
       {/* Help Text */}
       <div className={cn('text-xs font-mono opacity-50', themeClasses.text)}>
-        Supported airlines: AA, UA, DL, WN, B6, AS, NK, F9, G4, HA
+        Supported airlines: AA, UA, DL, WN, B6, AS, NK, F9, G4, HA. Without an AviationStack key configured, all routes are synthesized for demonstration.
       </div>
     </div>
   );

--- a/components/aviation/FlightRouteLookup.tsx
+++ b/components/aviation/FlightRouteLookup.tsx
@@ -21,8 +21,8 @@ import dynamic from 'next/dynamic';
 // Lazy load FlightNumberInput for performance
 const FlightNumberInput = dynamic(() => import('./FlightNumberInput'), {
   loading: () => (
-    <div className="h-[60px] flex items-center justify-center bg-gray-900 border-2 border-dashed border-gray-600 rounded">
-      <div className="text-center text-gray-400 font-mono text-xs">
+    <div className="h-[60px] flex items-center justify-center bg-card border-2 border-dashed border-border rounded">
+      <div className="text-center text-muted-foreground font-mono text-xs">
         <div className="animate-pulse">Loading Flight Input...</div>
       </div>
     </div>
@@ -55,6 +55,8 @@ export interface FlightData {
     lon: number;
   };
   status: string;
+  /** Set when route data is synthesized rather than from a live provider. */
+  mock?: boolean;
 }
 
 // PIREP data for route display
@@ -125,14 +127,14 @@ function isPointNearRoute(
   return Math.abs(crossTrack) <= corridorWidth;
 }
 
-// Get turbulence color
-function getTurbulenceColor(intensity: string | null): string {
-  if (!intensity) return 'text-green-500';
+// Get turbulence severity CSS variable for the given intensity
+function getTurbulenceSeverityVar(intensity: string | null): string {
+  if (!intensity) return '--severity-light';
   const upper = intensity.toUpperCase();
-  if (upper.includes('EXTRM') || upper.includes('EXTREME')) return 'text-red-500';
-  if (upper.includes('SEV')) return 'text-orange-500';
-  if (upper.includes('MOD')) return 'text-yellow-500';
-  return 'text-green-500';
+  if (upper.includes('EXTRM') || upper.includes('EXTREME')) return '--severity-extreme';
+  if (upper.includes('SEV')) return '--severity-severe';
+  if (upper.includes('MOD')) return '--severity-moderate';
+  return '--severity-light';
 }
 
 export default function FlightRouteLookup({ initialFlight, onRouteSearch }: FlightRouteLookupProps) {
@@ -297,7 +299,7 @@ export default function FlightRouteLookup({ initialFlight, onRouteSearch }: Flig
       {/* Flight Number Lookup Section */}
       <div className={cn('p-4 border-2 rounded', themeClasses.borderColor)}>
         <div className={cn('flex items-center gap-2 mb-3', themeClasses.headerText)}>
-          <Plane className="w-4 h-4 text-cyan-500" />
+          <Plane className="w-4 h-4 text-primary" aria-hidden="true" />
           <span className="text-sm font-mono font-bold uppercase">Search by Flight Number</span>
         </div>
         <FlightNumberInput
@@ -308,37 +310,63 @@ export default function FlightRouteLookup({ initialFlight, onRouteSearch }: Flig
 
       {/* Flight Info Display */}
       {flightData && (
-        <div className={cn('p-4 border-2 rounded bg-cyan-500/10', themeClasses.borderColor)}>
-          <div className="flex items-center justify-between mb-2">
-            <div className="flex items-center gap-2">
-              <Plane className="w-4 h-4 text-cyan-500" />
+        <div
+          className={cn('p-4 border-2 rounded bg-primary/10', themeClasses.borderColor)}
+          aria-label={`Flight ${flightData.flightNumber} from ${flightData.departure.city} to ${flightData.arrival.city}`}
+        >
+          <div className="flex items-center justify-between mb-2 flex-wrap gap-2">
+            <div className="flex items-center gap-2 flex-wrap">
+              <Plane className="w-4 h-4 text-primary" aria-hidden="true" />
               <span className={cn('text-sm font-mono font-bold', themeClasses.accentText)}>
                 {flightData.flightNumber}
               </span>
               <span className={cn('text-xs font-mono opacity-70', themeClasses.text)}>
                 {flightData.airline.name}
               </span>
+              {flightData.mock && (
+                <span
+                  className="text-[10px] font-mono font-bold px-2 py-0.5 rounded uppercase tracking-wider"
+                  style={{
+                    color: 'var(--severity-moderate)',
+                    backgroundColor: 'var(--severity-moderate-bg)',
+                    border: '1px solid var(--severity-moderate)',
+                  }}
+                  title="Route data is synthesized for demonstration. Live provider integration is coming soon."
+                  aria-label="Demo data: route is synthesized, not from a live provider"
+                >
+                  Demo data
+                </span>
+              )}
             </div>
             <button
               onClick={handleClear}
               className={cn(
-                'p-1 text-xs font-mono border rounded hover:bg-gray-700 transition-colors',
+                'p-1 text-xs font-mono border rounded hover:bg-muted transition-colors',
                 themeClasses.borderColor,
                 themeClasses.text
               )}
+              aria-label="Clear flight selection"
             >
               Clear
             </button>
           </div>
-          <div className="flex items-center gap-3 font-mono text-sm">
+          <div className="flex items-center gap-3 font-mono text-sm flex-wrap">
             <div className="flex items-center gap-1">
-              <MapPin className="w-3 h-3 text-green-500" />
+              <MapPin
+                className="w-3 h-3"
+                style={{ color: 'var(--severity-light)' }}
+                aria-hidden="true"
+              />
               <span className={themeClasses.text}>{flightData.departure.iata}</span>
               <span className={cn('text-xs opacity-60', themeClasses.text)}>{flightData.departure.city}</span>
             </div>
-            <ArrowRight className="w-4 h-4 text-gray-500" />
+            <ArrowRight className="w-4 h-4 text-muted-foreground" aria-hidden="true" />
             <div className="flex items-center gap-1">
-              <MapPin className="w-3 h-3 text-red-500" />
+              <MapPin
+                className="w-3 h-3"
+                style={{ color: 'var(--severity-extreme)' }}
+                aria-hidden="true"
+              />
               <span className={themeClasses.text}>{flightData.arrival.iata}</span>
               <span className={cn('text-xs opacity-60', themeClasses.text)}>{flightData.arrival.city}</span>
             </div>
@@ -349,7 +377,7 @@ export default function FlightRouteLookup({ initialFlight, onRouteSearch }: Flig
       {/* Manual Route Entry */}
       <div className={cn('p-4 border-2 rounded', themeClasses.borderColor)}>
         <div className={cn('flex items-center gap-2 mb-3', themeClasses.headerText)}>
-          <Route className="w-4 h-4 text-purple-500" />
+          <Route className="w-4 h-4 text-primary" aria-hidden="true" />
           <span className="text-sm font-mono font-bold uppercase">Manual Route Entry</span>
         </div>
         <form onSubmit={handleSubmit} className="space-y-3">
@@ -367,17 +395,17 @@ export default function FlightRouteLookup({ initialFlight, onRouteSearch }: Flig
                 placeholder="e.g. KLAX"
                 maxLength={4}
                 className={cn(
-                  'w-full px-3 py-2 font-mono text-sm border-2 rounded bg-gray-900 uppercase',
+                  'w-full px-3 py-2 font-mono text-sm border-2 rounded bg-card uppercase',
                   themeClasses.borderColor,
                   themeClasses.text,
-                  'focus:outline-none focus:ring-2 focus:ring-cyan-500'
+                  'focus:outline-none focus:ring-2 focus:ring-primary'
                 )}
                 data-testid="departure-input"
               />
             </div>
 
             <div className="hidden sm:flex items-end pb-2">
-              <ArrowRight className="w-5 h-5 text-gray-500" />
+              <ArrowRight className="w-5 h-5 text-muted-foreground" aria-hidden="true" />
             </div>
 
             {/* Arrival Input */}
@@ -393,10 +421,10 @@ export default function FlightRouteLookup({ initialFlight, onRouteSearch }: Flig
                 placeholder="e.g. KJFK"
                 maxLength={4}
                 className={cn(
-                  'w-full px-3 py-2 font-mono text-sm border-2 rounded bg-gray-900 uppercase',
+                  'w-full px-3 py-2 font-mono text-sm border-2 rounded bg-card uppercase',
                   themeClasses.borderColor,
                   themeClasses.text,
-                  'focus:outline-none focus:ring-2 focus:ring-cyan-500'
+                  'focus:outline-none focus:ring-2 focus:ring-primary'
                 )}
                 data-testid="arrival-input"
               />
@@ -411,8 +439,8 @@ export default function FlightRouteLookup({ initialFlight, onRouteSearch }: Flig
               'w-full flex items-center justify-center gap-2 px-4 py-2 font-mono text-sm font-bold border-2 rounded transition-colors',
               themeClasses.borderColor,
               isSearching || !departureCode || !arrivalCode
-                ? 'opacity-50 cursor-not-allowed bg-gray-800'
-                : 'bg-cyan-500/20 hover:bg-cyan-500/30 text-cyan-400'
+                ? 'opacity-50 cursor-not-allowed bg-muted'
+                : 'bg-primary/20 hover:bg-primary/30 text-primary'
             )}
             data-testid="search-route-button"
           >
@@ -433,9 +461,20 @@ export default function FlightRouteLookup({ initialFlight, onRouteSearch }: Flig
 
       {/* Error Display */}
       {searchError && (
-        <div className={cn('p-3 border-2 border-red-500/50 bg-red-500/10 rounded', themeClasses.borderColor)}>
-          <div className="flex items-center gap-2 text-red-500 font-mono text-sm">
-            <AlertTriangle className="w-4 h-4" />
+        <div
+          className={cn('p-3 border-2 rounded', themeClasses.borderColor)}
+          style={{
+            backgroundColor: 'var(--severity-extreme-bg)',
+            borderColor: 'var(--severity-extreme)',
+          }}
+          role="alert"
+          aria-live="polite"
+        >
+          <div
+            className="flex items-center gap-2 font-mono text-sm"
+            style={{ color: 'var(--severity-extreme)' }}
+          >
+            <AlertTriangle className="w-4 h-4" aria-hidden="true" />
             {searchError}
           </div>
         </div>
@@ -446,7 +485,11 @@ export default function FlightRouteLookup({ initialFlight, onRouteSearch }: Flig
         <div className={cn('p-4 border-2 rounded', themeClasses.borderColor)}>
           <div className="flex items-center justify-between mb-3">
             <div className={cn('flex items-center gap-2', themeClasses.headerText)}>
-              <AlertTriangle className="w-4 h-4 text-yellow-500" />
+              <AlertTriangle
+                className="w-4 h-4"
+                style={{ color: 'var(--severity-moderate)' }}
+                aria-hidden="true"
+              />
               <span className="text-sm font-mono font-bold uppercase">
                 Turbulence Reports Along Route
               </span>
@@ -455,19 +498,27 @@ export default function FlightRouteLookup({ initialFlight, onRouteSearch }: Flig
               onClick={() => handleRouteSearch(departureCode, arrivalCode, flightData)}
               disabled={isSearching}
               className={cn(
-                'p-1.5 border-2 rounded hover:bg-gray-700 transition-colors',
+                'p-1.5 border-2 rounded hover:bg-muted transition-colors',
                 themeClasses.borderColor,
                 isSearching && 'opacity-50 cursor-not-allowed'
               )}
               aria-label="Refresh route data"
             >
-              <RefreshCw className={cn('w-4 h-4', isSearching && 'animate-spin')} />
+              <RefreshCw className={cn('w-4 h-4', isSearching && 'animate-spin')} aria-hidden="true" />
             </button>
           </div>
 
           {routePireps.length === 0 ? (
-            <div className={cn('flex items-center gap-2 p-3 bg-green-500/10 rounded', themeClasses.text)}>
-              <Info className="w-4 h-4 text-green-500" />
+            <div
+              className={cn('flex items-center gap-2 p-3 rounded', themeClasses.text)}
+              style={{ backgroundColor: 'var(--severity-light-bg)' }}
+              role="status"
+            >
+              <Info
+                className="w-4 h-4"
+                style={{ color: 'var(--severity-light)' }}
+                aria-hidden="true"
+              />
               <span className="font-mono text-sm">
                 No significant turbulence reported along this route in the last 4 hours.
               </span>
@@ -477,19 +528,23 @@ export default function FlightRouteLookup({ initialFlight, onRouteSearch }: Flig
               <div className={cn('text-xs font-mono mb-2', themeClasses.text)}>
                 <span className={themeClasses.accentText}>{routePireps.length}</span> PIREPs found within 150nm of route
               </div>
-              <div className="max-h-[300px] overflow-y-auto space-y-2">
+              <div
+                className="max-h-[300px] overflow-y-auto space-y-2"
+                role="list"
+                aria-label="Turbulence reports along route"
+              >
                 {routePireps.map((pirep) => (
                   <div
                     key={pirep.id}
                     className={cn(
-                      'p-3 border-2 rounded font-mono text-xs',
-                      themeClasses.borderColor,
-                      'bg-gray-900/50'
+                      'p-3 border-2 rounded font-mono text-xs bg-card/50',
+                      themeClasses.borderColor
                     )}
+                    role="listitem"
                   >
-                    <div className="flex items-center justify-between mb-1">
+                    <div className="flex items-center justify-between mb-1 flex-wrap gap-1">
                       <div className="flex items-center gap-2">
-                        <span className={getTurbulenceColor(pirep.turbulenceIntensity)}>
+                        <span style={{ color: `var(${getTurbulenceSeverityVar(pirep.turbulenceIntensity)})` }}>
                           {pirep.turbulenceIntensity || 'SMOOTH'}
                         </span>
                         {pirep.turbulenceType && (
@@ -498,7 +553,7 @@ export default function FlightRouteLookup({ initialFlight, onRouteSearch }: Flig
                       </div>
                       <span className="opacity-60">{mounted ? formatTimeAgo(pirep.observationTime) : '...'}</span>
                     </div>
-                    <div className="flex items-center gap-4 opacity-70">
+                    <div className="flex items-center gap-4 opacity-70 flex-wrap">
                       <span>{formatAltitude(pirep.altitudeFt)}</span>
                       <span>
                         {Math.abs(pirep.latitude).toFixed(2)}{pirep.latitude >= 0 ? 'N' : 'S'}, {Math.abs(pirep.longitude).toFixed(2)}{pirep.longitude >= 0 ? 'E' : 'W'}

--- a/components/aviation/TurbulenceMap.tsx
+++ b/components/aviation/TurbulenceMap.tsx
@@ -4,8 +4,12 @@
  * Copyright (C) 2025 16-Bit Weather
  * Licensed under Fair Source License, Version 0.9
  *
- * Real PIREP (Pilot Report) turbulence map using OpenLayers
- * Shows actual pilot-reported turbulence observations across CONUS
+ * OpenLayers-based map showing real PIREP turbulence reports (point markers)
+ * overlaid with NOAA AWC G-AIRMET turbulence forecasts (polygons).
+ *
+ * Data wiring lives in `useTurbulenceData`; controls + legend are split
+ * into sibling components. This file owns OL initialization, layer
+ * lifecycle, and the PIREP detail popup.
  */
 
 'use client';
@@ -14,8 +18,14 @@ import React, { useEffect, useState, useCallback, useRef, useMemo } from 'react'
 import { cn } from '@/lib/utils';
 import { useTheme } from '@/components/theme-provider';
 import { getComponentStyles, type ThemeType } from '@/lib/theme-utils';
-import { RefreshCw, Plane, AlertTriangle, Clock, Mountain, X } from 'lucide-react';
-import { safeStorage } from '@/lib/safe-storage';
+import { Plane, AlertTriangle, Clock, Mountain, X } from 'lucide-react';
+import {
+  useTurbulenceData,
+  type PIREPData,
+} from '@/hooks/useTurbulenceData';
+import type { TurbulencePolygon, TurbulenceSeverity } from '@/app/api/aviation/turbulence/route';
+import TurbulenceLegend from './turbulence/TurbulenceLegend';
+import TurbulenceControls, { type AltitudeFilter } from './turbulence/TurbulenceControls';
 
 // OpenLayers imports
 import 'ol/ol.css';
@@ -26,90 +36,75 @@ import XYZ from 'ol/source/XYZ';
 import { fromLonLat } from 'ol/proj';
 import Feature from 'ol/Feature';
 import Point from 'ol/geom/Point';
+import Polygon from 'ol/geom/Polygon';
 import VectorLayer from 'ol/layer/Vector';
 import VectorSource from 'ol/source/Vector';
 import { Style, Circle as CircleStyle, Fill, Stroke } from 'ol/style';
 import Overlay from 'ol/Overlay';
 
-// PIREP data interface (matches API response)
-interface PIREPData {
-  id: string;
-  receiptTime: string;
-  observationTime: string;
-  aircraftRef: string;
-  latitude: number;
-  longitude: number;
-  altitudeFt: number;
-  turbulenceType: string | null;
-  turbulenceIntensity: string | null;
-  turbulenceBaseFt: number | null;
-  turbulenceTopFt: number | null;
-  icingType: string | null;
-  icingIntensity: string | null;
-  icingBaseFt: number | null;
-  icingTopFt: number | null;
-  tempC: number | null;
-  windDir: number | null;
-  windSpeedKt: number | null;
-  reportType: string;
-  rawText: string;
-}
-
 interface TurbulenceMapProps {
-  initialAltitude?: string;
+  initialAltitude?: AltitudeFilter;
   initialHours?: number;
 }
 
-// Turbulence intensity colors - 4-level scale
-const TURBULENCE_COLORS: Record<string, string> = {
-  NEG: '#22c55e',      // Green - Negative/Smooth
-  'NEG-LGT': '#22c55e', // Green - Light
-  LGT: '#22c55e',      // Green - Light
-  'LGT-MOD': '#eab308', // Yellow - Light-Moderate
-  MOD: '#eab308',      // Yellow - Moderate
-  'MOD-SEV': '#f97316', // Orange - Moderate-Severe
-  SEV: '#f97316',      // Orange - Severe
-  'SEV-EXTRM': '#ef4444', // Red - Severe-Extreme
-  EXTRM: '#ef4444',    // Red - Extreme
+// Severity hex values must match --severity-* CSS tokens (canvas can't read CSS vars).
+const SEVERITY_HEX: Record<TurbulenceSeverity, string> = {
+  smooth: '#22c55e',
+  light: '#22c55e',
+  moderate: '#eab308',
+  severe: '#f97316',
+  extreme: '#ef4444',
 };
 
-// Map turbulence intensity to severity level
-function getSeverityLevel(intensity: string | null): 'smooth' | 'light' | 'moderate' | 'severe' | 'extreme' {
+const TURBULENCE_COLORS: Record<string, string> = {
+  NEG: SEVERITY_HEX.light,
+  'NEG-LGT': SEVERITY_HEX.light,
+  LGT: SEVERITY_HEX.light,
+  'LGT-MOD': SEVERITY_HEX.moderate,
+  MOD: SEVERITY_HEX.moderate,
+  'MOD-SEV': SEVERITY_HEX.severe,
+  SEV: SEVERITY_HEX.severe,
+  'SEV-EXTRM': SEVERITY_HEX.extreme,
+  EXTRM: SEVERITY_HEX.extreme,
+};
+
+function getPirepSeverity(intensity: string | null): TurbulenceSeverity {
   if (!intensity) return 'smooth';
   const upper = intensity.toUpperCase();
   if (upper === 'NEG' || upper === 'SMOOTH') return 'smooth';
-  if (upper.includes('LGT') && !upper.includes('MOD')) return 'light';
-  if (upper.includes('MOD') && !upper.includes('SEV')) return 'moderate';
-  if (upper.includes('SEV') && !upper.includes('EXTRM')) return 'severe';
   if (upper.includes('EXTRM') || upper.includes('EXTREME')) return 'extreme';
+  if (upper.includes('SEV') && !upper.includes('EXTRM')) return 'severe';
+  if (upper.includes('MOD') && !upper.includes('SEV')) return 'moderate';
+  if (upper.includes('LGT') && !upper.includes('MOD')) return 'light';
   return 'light';
 }
 
-// Get color for turbulence intensity - uses same matching logic as getSeverityLevel
-function getTurbulenceColor(intensity: string | null): string {
+function getPirepColor(intensity: string | null): string {
   if (!intensity) return TURBULENCE_COLORS.NEG;
   const upper = intensity.toUpperCase();
-  // First try exact match
   if (TURBULENCE_COLORS[upper]) return TURBULENCE_COLORS[upper];
-  // Fall back to substring matching for non-standard values
-  if (upper === 'SMOOTH') return TURBULENCE_COLORS.NEG;
-  if (upper.includes('EXTRM') || upper.includes('EXTREME')) return TURBULENCE_COLORS.EXTRM;
-  if (upper.includes('SEV') && !upper.includes('EXTRM')) return TURBULENCE_COLORS.SEV;
-  if (upper.includes('MOD') && !upper.includes('SEV')) return TURBULENCE_COLORS.MOD;
-  if (upper.includes('LGT') && !upper.includes('MOD')) return TURBULENCE_COLORS.LGT;
-  return TURBULENCE_COLORS.NEG;
+  return SEVERITY_HEX[getPirepSeverity(intensity)];
 }
 
-// CartoDB Dark Matter base map
 const CARTO_DARK_URL = 'https://{a-d}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png';
-
-// Cache configuration
-const PIREP_CACHE_KEY = 'bitweather_pirep_cache';
-const PIREP_CACHE_TTL = 5 * 60 * 1000; // 5 minutes
-
-// CONUS bounds
 const CONUS_CENTER = [-98.5795, 39.8283];
 const CONUS_ZOOM = 4;
+
+function formatTimeAgo(isoString: string): string {
+  if (!isoString) return 'Unknown';
+  const date = new Date(isoString);
+  if (isNaN(date.getTime())) return 'Unknown';
+  const diff = Date.now() - date.getTime();
+  const minutes = Math.floor(diff / 60000);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  return `${hours}h ${minutes % 60}m ago`;
+}
+
+function formatAltitude(ft: number): string {
+  if (ft >= 18000) return `FL${Math.round(ft / 100)}`;
+  return `${ft.toLocaleString()} ft`;
+}
 
 export default function TurbulenceMap({
   initialAltitude = 'all',
@@ -120,141 +115,33 @@ export default function TurbulenceMap({
 
   const mapRef = useRef<HTMLDivElement>(null);
   const mapInstanceRef = useRef<OLMap | null>(null);
-  const vectorLayerRef = useRef<VectorLayer<VectorSource> | null>(null);
+  const pirepLayerRef = useRef<VectorLayer<VectorSource> | null>(null);
+  const polygonLayerRef = useRef<VectorLayer<VectorSource> | null>(null);
   const popupRef = useRef<HTMLDivElement>(null);
   const popupOverlayRef = useRef<Overlay | null>(null);
-  const abortControllerRef = useRef<AbortController | null>(null);
 
-  const [pireps, setPireps] = useState<PIREPData[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
   const [selectedPirep, setSelectedPirep] = useState<PIREPData | null>(null);
-  const [fetchedAt, setFetchedAt] = useState<string | null>(null);
-  const [currentTime, setCurrentTime] = useState(Date.now()); // For keeping age filter fresh
-
-  // Filters
   const [hoursBack, setHoursBack] = useState(initialHours);
-  const [altitudeFilter, setAltitudeFilter] = useState(initialAltitude);
+  const [altitudeFilter, setAltitudeFilter] = useState<AltitudeFilter>(initialAltitude);
 
-  const altitudeOptions = [
-    { value: 'all', label: 'All Altitudes' },
-    { value: 'low', label: 'Below FL180' },
-    { value: 'mid', label: 'FL180-FL350' },
-    { value: 'high', label: 'Above FL350' },
-  ];
+  const {
+    pireps,
+    polygons,
+    fetchedAt,
+    isLoading,
+    error,
+    refresh,
+    currentTime,
+  } = useTurbulenceData();
 
-  const hoursOptions = [
-    { value: 1, label: '1 Hour' },
-    { value: 2, label: '2 Hours' },
-    { value: 4, label: '4 Hours' },
-    { value: 6, label: '6 Hours' },
-  ];
-
-  // Cache helpers
-  const getCachedData = useCallback((): { pireps: PIREPData[]; fetchedAt: string } | null => {
-    try {
-      const cached = safeStorage.getItem(PIREP_CACHE_KEY);
-      if (cached) {
-        const parsed = JSON.parse(cached);
-        if (Date.now() < parsed.expiresAt) {
-          return { pireps: parsed.pireps, fetchedAt: parsed.fetchedAt };
-        }
-        safeStorage.removeItem(PIREP_CACHE_KEY);
-      }
-    } catch (err) {
-      console.warn('Cache read error:', err);
-    }
-    return null;
-  }, []);
-
-  const setCachedData = useCallback((pirepData: PIREPData[], fetchTime: string) => {
-    try {
-      const cacheEntry = {
-        pireps: pirepData,
-        fetchedAt: fetchTime,
-        expiresAt: Date.now() + PIREP_CACHE_TTL,
-      };
-      safeStorage.setItem(PIREP_CACHE_KEY, JSON.stringify(cacheEntry));
-    } catch (err) {
-      console.warn('Cache write error:', err);
-    }
-  }, []);
-
-  // Fetch PIREP data
-  const fetchPirepData = useCallback(async (forceRefresh = false) => {
-    if (!forceRefresh) {
-      const cached = getCachedData();
-      if (cached) {
-        setPireps(cached.pireps);
-        setFetchedAt(cached.fetchedAt);
-        setIsLoading(false);
-        setError(null);
-        return;
-      }
-    }
-
-    // Cancel any in-flight request to prevent race conditions
-    if (abortControllerRef.current) {
-      abortControllerRef.current.abort();
-    }
-    const controller = new AbortController();
-    abortControllerRef.current = controller;
-
-    setIsLoading(true);
-    setError(null);
-
-    try {
-      const response = await fetch(`/api/aviation/pireps?hours=6&turbulenceOnly=false`, {
-        signal: controller.signal,
-      });
-      if (!response.ok) {
-        throw new Error('Failed to fetch PIREP data');
-      }
-
-      const result = await response.json();
-
-      // Check if request was aborted before updating state
-      if (controller.signal.aborted) return;
-
-      if (result.success) {
-        setPireps(result.data.pireps);
-        setFetchedAt(result.data.fetchedAt);
-        setCachedData(result.data.pireps, result.data.fetchedAt);
-      } else {
-        throw new Error(result.error || 'Unknown error');
-      }
-    } catch (err) {
-      // Don't update state if request was aborted
-      if (err instanceof Error && err.name === 'AbortError') return;
-      console.error('PIREP fetch error:', err);
-      setError('Unable to load PIREP data');
-    } finally {
-      // Only update loading state if this is still the current request
-      if (!controller.signal.aborted) {
-        setIsLoading(false);
-      }
-    }
-  }, [getCachedData, setCachedData]);
-
-  // Update current time every minute to keep age filter fresh
-  useEffect(() => {
-    const interval = setInterval(() => {
-      setCurrentTime(Date.now());
-    }, 60000); // Update every minute
-    return () => clearInterval(interval);
-  }, []);
-
-  // Filter PIREPs based on user selections
+  // Filter PIREPs by age + altitude
   const filteredPireps = useMemo(() => {
-    const cutoffTime = new Date(currentTime - hoursBack * 60 * 60 * 1000);
-
+    const cutoff = currentTime - hoursBack * 60 * 60 * 1000;
     return pireps.filter((pirep) => {
-      // Time filter - skip PIREPs with missing or invalid observation times
       if (!pirep.observationTime) return false;
-      const obsTime = new Date(pirep.observationTime);
-      if (isNaN(obsTime.getTime()) || obsTime < cutoffTime) return false;
+      const obs = new Date(pirep.observationTime).getTime();
+      if (!Number.isFinite(obs) || obs < cutoff) return false;
 
-      // Altitude filter
       const alt = pirep.altitudeFt || 0;
       switch (altitudeFilter) {
         case 'low':
@@ -269,22 +156,10 @@ export default function TurbulenceMap({
     });
   }, [pireps, hoursBack, altitudeFilter, currentTime]);
 
-  // Initial fetch with cleanup on unmount
-  useEffect(() => {
-    fetchPirepData();
-    return () => {
-      // Abort any in-flight request on unmount
-      if (abortControllerRef.current) {
-        abortControllerRef.current.abort();
-      }
-    };
-  }, [fetchPirepData]);
-
-  // Initialize map
+  // Initialize map once
   useEffect(() => {
     if (!mapRef.current || mapInstanceRef.current) return;
 
-    // Create base layer
     const baseLayer = new TileLayer({
       source: new XYZ({
         url: CARTO_DARK_URL,
@@ -294,7 +169,6 @@ export default function TurbulenceMap({
       opacity: 0.9,
     });
 
-    // Create map
     const map = new OLMap({
       target: mapRef.current,
       layers: [baseLayer],
@@ -303,16 +177,12 @@ export default function TurbulenceMap({
         zoom: CONUS_ZOOM,
       }),
     });
-
     mapInstanceRef.current = map;
 
-    // Create popup overlay
     if (popupRef.current) {
       const overlay = new Overlay({
         element: popupRef.current,
-        autoPan: {
-          animation: { duration: 250 },
-        },
+        autoPan: { animation: { duration: 250 } },
         positioning: 'bottom-center',
         offset: [0, -10],
       });
@@ -320,258 +190,220 @@ export default function TurbulenceMap({
       popupOverlayRef.current = overlay;
     }
 
-    // Handle map click
     map.on('click', (evt) => {
-      const feature = map.forEachFeatureAtPixel(evt.pixel, (f) => f);
+      const feature = map.forEachFeatureAtPixel(evt.pixel, (f) => {
+        const pirep = f.get('pirep') as PIREPData | undefined;
+        return pirep ? f : undefined;
+      });
       if (feature) {
         const pirep = feature.get('pirep') as PIREPData;
-        if (pirep) {
-          setSelectedPirep(pirep);
-          popupOverlayRef.current?.setPosition(evt.coordinate);
-        }
+        setSelectedPirep(pirep);
+        popupOverlayRef.current?.setPosition(evt.coordinate);
       } else {
         setSelectedPirep(null);
         popupOverlayRef.current?.setPosition(undefined);
       }
     });
 
-    // Change cursor on hover
     map.on('pointermove', (evt) => {
-      const hit = map.forEachFeatureAtPixel(evt.pixel, () => true);
+      const hit = map.forEachFeatureAtPixel(evt.pixel, (f) =>
+        f.get('pirep') ? true : undefined,
+      );
       map.getTargetElement().style.cursor = hit ? 'pointer' : '';
     });
 
-    // Handle resize
     const updateMapSize = () => mapInstanceRef.current?.updateSize();
     setTimeout(updateMapSize, 0);
     setTimeout(updateMapSize, 100);
     setTimeout(updateMapSize, 500);
 
     const resizeObserver = new ResizeObserver(updateMapSize);
-    if (mapRef.current) {
-      resizeObserver.observe(mapRef.current);
-    }
+    if (mapRef.current) resizeObserver.observe(mapRef.current);
 
     return () => {
       resizeObserver.disconnect();
       map.setTarget(undefined);
-      map.dispose(); // Properly release OpenLayers resources to prevent memory leaks
+      map.dispose();
       mapInstanceRef.current = null;
     };
   }, []);
 
-  // Close popup if selected PIREP is filtered out
+  // Close popup if its PIREP is filtered out
   useEffect(() => {
-    if (selectedPirep && !filteredPireps.some(p => p.id === selectedPirep.id)) {
+    if (selectedPirep && !filteredPireps.some((p) => p.id === selectedPirep.id)) {
       setSelectedPirep(null);
       popupOverlayRef.current?.setPosition(undefined);
     }
   }, [filteredPireps, selectedPirep]);
 
-  // Update markers when filtered data changes
+  // PIREP point layer
   useEffect(() => {
-    if (!mapInstanceRef.current) return;
-
     const map = mapInstanceRef.current;
+    if (!map) return;
 
-    // Remove existing vector layer
-    if (vectorLayerRef.current) {
-      map.removeLayer(vectorLayerRef.current);
+    if (pirepLayerRef.current) {
+      map.removeLayer(pirepLayerRef.current);
     }
 
-    // Create features from PIREPs
     const features = filteredPireps.map((pirep) => {
       const feature = new Feature({
         geometry: new Point(fromLonLat([pirep.longitude, pirep.latitude])),
         pirep,
       });
-
-      const color = getTurbulenceColor(pirep.turbulenceIntensity);
-      const severity = getSeverityLevel(pirep.turbulenceIntensity);
-      const size = severity === 'smooth' ? 6 : severity === 'light' ? 8 : severity === 'moderate' ? 10 : severity === 'severe' ? 12 : 14;
+      const color = getPirepColor(pirep.turbulenceIntensity);
+      const severity = getPirepSeverity(pirep.turbulenceIntensity);
+      const size =
+        severity === 'smooth' ? 6 : severity === 'light' ? 8 : severity === 'moderate' ? 10 : severity === 'severe' ? 12 : 14;
 
       feature.setStyle(
         new Style({
           image: new CircleStyle({
             radius: size,
-            fill: new Fill({ color: color + 'cc' }), // Semi-transparent
+            fill: new Fill({ color: color + 'cc' }),
             stroke: new Stroke({ color: '#ffffff', width: 1.5 }),
           }),
-        })
+        }),
       );
-
       return feature;
     });
 
-    // Create new vector layer
-    const vectorSource = new VectorSource({ features });
-    const vectorLayer = new VectorLayer({
-      source: vectorSource,
+    const layer = new VectorLayer({
+      source: new VectorSource({ features }),
       zIndex: 100,
     });
-
-    map.addLayer(vectorLayer);
-    vectorLayerRef.current = vectorLayer;
+    map.addLayer(layer);
+    pirepLayerRef.current = layer;
   }, [filteredPireps]);
 
-  // Close popup
+  // G-AIRMET polygon layer
+  useEffect(() => {
+    const map = mapInstanceRef.current;
+    if (!map) return;
+
+    if (polygonLayerRef.current) {
+      map.removeLayer(polygonLayerRef.current);
+    }
+
+    if (polygons.length === 0) {
+      polygonLayerRef.current = null;
+      return;
+    }
+
+    const features: Feature[] = [];
+    for (const poly of polygons) {
+      // Show only the most relevant near-term forecast (≤6 hr) to avoid stacking.
+      if (poly.forecastHour > 6) continue;
+      const rings = poly.coordinates
+        .map((ring) => ring.map(([lon, lat]) => fromLonLat([lon, lat])));
+      if (rings.length === 0 || rings[0].length < 3) continue;
+
+      const feature = new Feature({
+        geometry: new Polygon(rings),
+        gairmet: poly,
+      });
+      const color = SEVERITY_HEX[poly.severity];
+      feature.setStyle(
+        new Style({
+          fill: new Fill({ color: color + '33' }), // ~20% alpha
+          stroke: new Stroke({ color, width: 1.5 }),
+        }),
+      );
+      features.push(feature);
+    }
+
+    const layer = new VectorLayer({
+      source: new VectorSource({ features }),
+      zIndex: 50, // below PIREPs
+    });
+    map.addLayer(layer);
+    polygonLayerRef.current = layer;
+  }, [polygons]);
+
   const closePopup = useCallback(() => {
     setSelectedPirep(null);
     popupOverlayRef.current?.setPosition(undefined);
   }, []);
 
-  // Format time ago
-  const formatTimeAgo = (isoString: string): string => {
-    if (!isoString) return 'Unknown';
-    const date = new Date(isoString);
-    if (isNaN(date.getTime())) return 'Unknown';
-    const diff = Date.now() - date.getTime();
-    const minutes = Math.floor(diff / 60000);
-    if (minutes < 60) return `${minutes}m ago`;
-    const hours = Math.floor(minutes / 60);
-    return `${hours}h ${minutes % 60}m ago`;
-  };
-
-  // Format altitude
-  const formatAltitude = (ft: number): string => {
-    if (ft >= 18000) {
-      return `FL${Math.round(ft / 100)}`;
-    }
-    return `${ft.toLocaleString()} ft`;
-  };
-
   return (
     <div className={cn('space-y-3', themeClasses.background)}>
-      {/* Controls Row */}
-      <div className="flex flex-wrap items-center gap-3">
-        {/* Hours Filter */}
-        <div className="flex items-center gap-2">
-          <Clock className={cn('w-4 h-4', themeClasses.accentText)} />
-          <label htmlFor="hours-select" className={cn('text-xs font-mono uppercase', themeClasses.text)}>
-            Age:
-          </label>
-          <select
-            id="hours-select"
-            value={hoursBack}
-            onChange={(e) => setHoursBack(parseInt(e.target.value, 10))}
-            className={cn(
-              'px-2 py-1 text-xs font-mono border-2 rounded bg-gray-900',
-              themeClasses.borderColor,
-              themeClasses.text
-            )}
-          >
-            {hoursOptions.map((opt) => (
-              <option key={opt.value} value={opt.value}>
-                {opt.label}
-              </option>
-            ))}
-          </select>
-        </div>
+      <TurbulenceControls
+        hoursBack={hoursBack}
+        altitudeFilter={altitudeFilter}
+        pirepCount={filteredPireps.length}
+        isLoading={isLoading}
+        onHoursChange={setHoursBack}
+        onAltitudeChange={setAltitudeFilter}
+        onRefresh={refresh}
+      />
 
-        {/* Altitude Filter */}
-        <div className="flex items-center gap-2">
-          <Mountain className={cn('w-4 h-4', themeClasses.accentText)} />
-          <label htmlFor="altitude-filter" className={cn('text-xs font-mono uppercase', themeClasses.text)}>
-            Altitude:
-          </label>
-          <select
-            id="altitude-filter"
-            value={altitudeFilter}
-            onChange={(e) => setAltitudeFilter(e.target.value)}
-            className={cn(
-              'px-2 py-1 text-xs font-mono border-2 rounded bg-gray-900',
-              themeClasses.borderColor,
-              themeClasses.text
-            )}
-          >
-            {altitudeOptions.map((opt) => (
-              <option key={opt.value} value={opt.value}>
-                {opt.label}
-              </option>
-            ))}
-          </select>
-        </div>
-
-        {/* Refresh Button */}
-        <button
-          onClick={() => fetchPirepData(true)}
-          disabled={isLoading}
-          className={cn(
-            'p-1.5 border-2 rounded hover:bg-gray-700 transition-colors',
-            themeClasses.borderColor,
-            isLoading && 'opacity-50 cursor-not-allowed'
-          )}
-          aria-label="Refresh PIREP data"
-        >
-          <RefreshCw className={cn('w-4 h-4', isLoading && 'animate-spin')} />
-        </button>
-
-        {/* PIREP Count */}
-        <div className={cn('text-xs font-mono ml-auto', themeClasses.text)}>
-          <span className={cn('font-bold', themeClasses.accentText)}>{filteredPireps.length}</span> PIREPs
-        </div>
-      </div>
-
-      {/* Map Container */}
       <div
         className={cn(
-          'relative border-4 rounded-lg overflow-hidden bg-gray-900',
-          themeClasses.borderColor
+          'relative border-4 rounded-lg overflow-hidden bg-card h-[300px] sm:h-[400px] md:h-[480px]',
+          themeClasses.borderColor,
         )}
-        style={{ height: '400px' }}
+        role="region"
+        aria-label="Turbulence pilot reports map for the contiguous United States"
       >
         {isLoading && !pireps.length ? (
-          <div className="absolute inset-0 flex items-center justify-center bg-gray-900 z-10">
+          <div
+            className="absolute inset-0 flex items-center justify-center bg-card z-10"
+            role="status"
+            aria-live="polite"
+          >
             <div className="text-center">
-              <Plane className={cn('w-8 h-8 mx-auto mb-2 animate-bounce', themeClasses.accentText)} />
+              <Plane className={cn('w-8 h-8 mx-auto mb-2 animate-bounce', themeClasses.accentText)} aria-hidden="true" />
               <div className={cn('text-xs font-mono', themeClasses.text)}>
-                Loading PIREP Data...
+                Loading turbulence data...
               </div>
             </div>
           </div>
         ) : error && !pireps.length ? (
-          <div className="absolute inset-0 flex items-center justify-center bg-gray-900 z-10">
-            <div className="text-center text-red-500">
-              <AlertTriangle className="w-8 h-8 mx-auto mb-2" />
+          <div
+            className="absolute inset-0 flex items-center justify-center bg-card z-10"
+            role="alert"
+          >
+            <div className="text-center" style={{ color: 'var(--severity-extreme)' }}>
+              <AlertTriangle className="w-8 h-8 mx-auto mb-2" aria-hidden="true" />
               <div className="text-xs font-mono">{error}</div>
             </div>
           </div>
         ) : null}
 
-        {/* OpenLayers Map */}
         <div ref={mapRef} className="w-full h-full" />
 
-        {/* Popup */}
         <div ref={popupRef} className="absolute z-50">
           {selectedPirep && (
-            <div className={cn(
-              'bg-gray-900/95 border-2 rounded-lg p-3 min-w-[280px] max-w-[350px] shadow-xl backdrop-blur-sm',
-              themeClasses.borderColor
-            )}>
-              {/* Header */}
+            <div
+              className={cn(
+                'bg-card/95 border-2 rounded-lg p-3 min-w-[260px] max-w-[90vw] sm:max-w-[350px] shadow-xl backdrop-blur-sm',
+                themeClasses.borderColor,
+              )}
+              role="dialog"
+              aria-label={`PIREP details for ${selectedPirep.aircraftRef || 'unknown aircraft'}`}
+            >
               <div className="flex items-center justify-between mb-2">
                 <div className="flex items-center gap-2">
-                  <Plane className={cn('w-4 h-4', themeClasses.accentText)} />
+                  <Plane className={cn('w-4 h-4', themeClasses.accentText)} aria-hidden="true" />
                   <span className={cn('font-mono text-sm font-bold', themeClasses.text)}>
                     {selectedPirep.aircraftRef || 'Unknown Aircraft'}
                   </span>
                 </div>
                 <button
                   onClick={closePopup}
-                  className="p-1 hover:bg-gray-700 rounded transition-colors"
+                  className="p-1 hover:bg-muted rounded transition-colors"
+                  aria-label="Close PIREP details"
                 >
-                  <X className="w-4 h-4 text-gray-400" />
+                  <X className="w-4 h-4 text-muted-foreground" aria-hidden="true" />
                 </button>
               </div>
 
-              {/* Content */}
               <div className={cn('space-y-1 text-xs font-mono', themeClasses.text)}>
-                {/* Turbulence */}
                 {selectedPirep.turbulenceIntensity && (
                   <div className="flex items-center gap-2">
                     <span
                       className="w-3 h-3 rounded-full"
-                      style={{ backgroundColor: getTurbulenceColor(selectedPirep.turbulenceIntensity) }}
+                      style={{ backgroundColor: getPirepColor(selectedPirep.turbulenceIntensity) }}
+                      aria-hidden="true"
                     />
                     <span className="font-bold">Turbulence:</span>
                     <span>{selectedPirep.turbulenceIntensity}</span>
@@ -581,9 +413,8 @@ export default function TurbulenceMap({
                   </div>
                 )}
 
-                {/* Altitude */}
                 <div className="flex items-center gap-2">
-                  <Mountain className="w-3 h-3" />
+                  <Mountain className="w-3 h-3" aria-hidden="true" />
                   <span className="font-bold">Altitude:</span>
                   <span>{formatAltitude(selectedPirep.altitudeFt)}</span>
                   {selectedPirep.turbulenceBaseFt !== null && selectedPirep.turbulenceTopFt !== null && (
@@ -593,10 +424,9 @@ export default function TurbulenceMap({
                   )}
                 </div>
 
-                {/* Icing */}
                 {selectedPirep.icingIntensity && (
                   <div className="flex items-center gap-2">
-                    <span className="text-terminal-weather-cold">❄</span>
+                    <span aria-hidden="true">❄</span>
                     <span className="font-bold">Icing:</span>
                     <span>{selectedPirep.icingIntensity}</span>
                     {selectedPirep.icingType && (
@@ -605,34 +435,30 @@ export default function TurbulenceMap({
                   </div>
                 )}
 
-                {/* Temperature */}
                 {selectedPirep.tempC !== null && (
                   <div className="flex items-center gap-2">
-                    <span>🌡</span>
+                    <span aria-hidden="true">🌡</span>
                     <span className="font-bold">Temp:</span>
                     <span>{selectedPirep.tempC}°C</span>
                   </div>
                 )}
 
-                {/* Wind */}
                 {selectedPirep.windDir !== null && selectedPirep.windSpeedKt !== null && (
                   <div className="flex items-center gap-2">
-                    <span>💨</span>
+                    <span aria-hidden="true">💨</span>
                     <span className="font-bold">Wind:</span>
                     <span>{selectedPirep.windDir}° / {selectedPirep.windSpeedKt} kt</span>
                   </div>
                 )}
 
-                {/* Time */}
-                <div className="flex items-center gap-2 pt-1 border-t border-gray-700">
-                  <Clock className="w-3 h-3" />
+                <div className="flex items-center gap-2 pt-1 border-t border-border">
+                  <Clock className="w-3 h-3" aria-hidden="true" />
                   <span className="font-bold">Observed:</span>
                   <span>{formatTimeAgo(selectedPirep.observationTime)}</span>
                 </div>
 
-                {/* Raw text (truncated) */}
                 {selectedPirep.rawText && (
-                  <div className="pt-1 border-t border-gray-700">
+                  <div className="pt-1 border-t border-border">
                     <div className="opacity-60 text-[10px] break-all">
                       {selectedPirep.rawText.slice(0, 150)}
                       {selectedPirep.rawText.length > 150 && '...'}
@@ -644,40 +470,21 @@ export default function TurbulenceMap({
           )}
         </div>
 
-        {/* Map Attribution */}
-        <div className="absolute bottom-2 left-2 bg-gray-900/80 px-2 py-1 rounded text-[10px] font-mono text-gray-400 z-20">
-          PIREP Data: NOAA AWC
+        <div className="absolute bottom-2 left-2 bg-card/80 px-2 py-1 rounded text-[10px] font-mono text-muted-foreground z-20">
+          PIREPs + G-AIRMET: NOAA AWC
         </div>
       </div>
 
-      {/* Legend */}
-      <div className={cn('flex flex-wrap items-center gap-4 text-xs font-mono', themeClasses.text)}>
-        <span className="uppercase font-bold">Turbulence Intensity:</span>
-        <div className="flex items-center gap-1">
-          <span className="w-3 h-3 rounded-full" style={{ backgroundColor: '#22c55e' }} />
-          <span>None/Light</span>
-        </div>
-        <div className="flex items-center gap-1">
-          <span className="w-3 h-3 rounded-full" style={{ backgroundColor: '#eab308' }} />
-          <span>Moderate</span>
-        </div>
-        <div className="flex items-center gap-1">
-          <span className="w-3 h-3 rounded-full" style={{ backgroundColor: '#f97316' }} />
-          <span>Severe</span>
-        </div>
-        <div className="flex items-center gap-1">
-          <span className="w-3 h-3 rounded-full" style={{ backgroundColor: '#ef4444' }} />
-          <span>Extreme</span>
-        </div>
-      </div>
+      <TurbulenceLegend />
 
-      {/* Data freshness */}
-      <div className={cn('flex items-center gap-2 text-xs font-mono opacity-60', themeClasses.text)}>
-        <Clock className="w-3 h-3" />
+      <div className={cn('flex flex-wrap items-center gap-2 text-xs font-mono opacity-60', themeClasses.text)}>
+        <Clock className="w-3 h-3" aria-hidden="true" />
         <span>
-          Data updated: {fetchedAt ? new Date(fetchedAt).toLocaleTimeString() : 'Loading...'}
+          PIREPs updated: {fetchedAt ? new Date(fetchedAt).toLocaleTimeString() : 'Loading...'}
         </span>
-        <span className="mx-2">|</span>
+        <span className="mx-2 hidden sm:inline" aria-hidden="true">|</span>
+        <span>{polygons.length} G-AIRMET zones</span>
+        <span className="mx-2 hidden sm:inline" aria-hidden="true">|</span>
         <span>Click markers for details</span>
       </div>
     </div>

--- a/components/aviation/turbulence/TurbulenceControls.tsx
+++ b/components/aviation/turbulence/TurbulenceControls.tsx
@@ -1,0 +1,126 @@
+/**
+ * 16-Bit Weather Platform - Turbulence Map Controls
+ *
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ */
+
+'use client';
+
+import React from 'react';
+import { Clock, Mountain, RefreshCw } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { useTheme } from '@/components/theme-provider';
+import { getComponentStyles, type ThemeType } from '@/lib/theme-utils';
+
+export type AltitudeFilter = 'all' | 'low' | 'mid' | 'high';
+
+interface TurbulenceControlsProps {
+  hoursBack: number;
+  altitudeFilter: AltitudeFilter;
+  pirepCount: number;
+  isLoading: boolean;
+  onHoursChange: (hours: number) => void;
+  onAltitudeChange: (filter: AltitudeFilter) => void;
+  onRefresh: () => void;
+}
+
+const HOUR_OPTIONS = [
+  { value: 1, label: '1 Hour' },
+  { value: 2, label: '2 Hours' },
+  { value: 4, label: '4 Hours' },
+  { value: 6, label: '6 Hours' },
+];
+
+const ALTITUDE_OPTIONS: Array<{ value: AltitudeFilter; label: string }> = [
+  { value: 'all', label: 'All Altitudes' },
+  { value: 'low', label: 'Below FL180' },
+  { value: 'mid', label: 'FL180-FL350' },
+  { value: 'high', label: 'Above FL350' },
+];
+
+export default function TurbulenceControls({
+  hoursBack,
+  altitudeFilter,
+  pirepCount,
+  isLoading,
+  onHoursChange,
+  onAltitudeChange,
+  onRefresh,
+}: TurbulenceControlsProps) {
+  const { theme } = useTheme();
+  const themeClasses = getComponentStyles((theme || 'nord') as ThemeType, 'weather');
+
+  return (
+    <div className="flex flex-wrap items-center gap-3">
+      <div className="flex items-center gap-2">
+        <Clock className={cn('w-4 h-4', themeClasses.accentText)} aria-hidden="true" />
+        <label
+          htmlFor="hours-select"
+          className={cn('text-xs font-mono uppercase', themeClasses.text)}
+        >
+          Age:
+        </label>
+        <select
+          id="hours-select"
+          value={hoursBack}
+          onChange={(e) => onHoursChange(parseInt(e.target.value, 10))}
+          className={cn(
+            'px-2 py-1 text-xs font-mono border-2 rounded bg-card',
+            themeClasses.borderColor,
+            themeClasses.text,
+          )}
+        >
+          {HOUR_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Mountain className={cn('w-4 h-4', themeClasses.accentText)} aria-hidden="true" />
+        <label
+          htmlFor="altitude-filter"
+          className={cn('text-xs font-mono uppercase', themeClasses.text)}
+        >
+          Altitude:
+        </label>
+        <select
+          id="altitude-filter"
+          value={altitudeFilter}
+          onChange={(e) => onAltitudeChange(e.target.value as AltitudeFilter)}
+          className={cn(
+            'px-2 py-1 text-xs font-mono border-2 rounded bg-card',
+            themeClasses.borderColor,
+            themeClasses.text,
+          )}
+        >
+          {ALTITUDE_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <button
+        onClick={onRefresh}
+        disabled={isLoading}
+        className={cn(
+          'p-1.5 border-2 rounded hover:bg-muted transition-colors',
+          themeClasses.borderColor,
+          isLoading && 'opacity-50 cursor-not-allowed',
+        )}
+        aria-label="Refresh turbulence data"
+      >
+        <RefreshCw className={cn('w-4 h-4', isLoading && 'animate-spin')} aria-hidden="true" />
+      </button>
+
+      <div className={cn('text-xs font-mono ml-auto', themeClasses.text)}>
+        <span className={cn('font-bold', themeClasses.accentText)}>{pirepCount}</span> PIREPs
+      </div>
+    </div>
+  );
+}

--- a/components/aviation/turbulence/TurbulenceLegend.tsx
+++ b/components/aviation/turbulence/TurbulenceLegend.tsx
@@ -1,0 +1,50 @@
+/**
+ * 16-Bit Weather Platform - Turbulence Map Legend
+ *
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ */
+
+'use client';
+
+import React from 'react';
+import { cn } from '@/lib/utils';
+import { useTheme } from '@/components/theme-provider';
+import { getComponentStyles, type ThemeType } from '@/lib/theme-utils';
+
+interface LegendItem {
+  label: string;
+  cssVar: string;
+}
+
+const ITEMS: LegendItem[] = [
+  { label: 'None/Light', cssVar: '--severity-light' },
+  { label: 'Moderate', cssVar: '--severity-moderate' },
+  { label: 'Severe', cssVar: '--severity-severe' },
+  { label: 'Extreme', cssVar: '--severity-extreme' },
+];
+
+export default function TurbulenceLegend() {
+  const { theme } = useTheme();
+  const themeClasses = getComponentStyles((theme || 'nord') as ThemeType, 'weather');
+
+  return (
+    <div
+      className={cn('flex flex-wrap items-center gap-x-4 gap-y-1 text-xs font-mono', themeClasses.text)}
+      role="list"
+      aria-label="Turbulence intensity legend"
+    >
+      <span className="uppercase font-bold">Turbulence Intensity:</span>
+      {ITEMS.map((item) => (
+        <div key={item.cssVar} className="flex items-center gap-1" role="listitem">
+          <span
+            className="w-3 h-3 rounded-full"
+            style={{ backgroundColor: `var(${item.cssVar})` }}
+            aria-hidden="true"
+          />
+          <span>{item.label}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/hooks/useDemoMode.ts
+++ b/hooks/useDemoMode.ts
@@ -1,0 +1,58 @@
+/**
+ * 16-Bit Weather Platform - Aviation Demo Mode Hook
+ *
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ *
+ * Persistent user preference for forcing the aviation flight-lookup API to
+ * return synthesized mock data even when real providers are configured.
+ * Useful for screenshots and offline demos. State is shared across all
+ * mounted consumers via a custom event so flipping the toggle in one
+ * component instantly updates the rest.
+ */
+
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { safeStorage } from '@/lib/safe-storage';
+
+export const DEMO_MODE_STORAGE_KEY = 'bitweather_aviation_demo_mode';
+const DEMO_MODE_EVENT = 'bitweather:aviation-demo-mode-change';
+
+function readStored(): boolean {
+  return safeStorage.getItem(DEMO_MODE_STORAGE_KEY) === 'true';
+}
+
+export function useDemoMode(): readonly [boolean, (next: boolean) => void] {
+  const [enabled, setEnabled] = useState<boolean>(false);
+
+  // Hydrate from storage after mount to avoid SSR mismatch.
+  useEffect(() => {
+    setEnabled(readStored());
+  }, []);
+
+  // Sync across tabs (storage event) and within the same tab (custom event).
+  useEffect(() => {
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === DEMO_MODE_STORAGE_KEY) {
+        setEnabled(e.newValue === 'true');
+      }
+    };
+    const onLocalChange = () => setEnabled(readStored());
+
+    window.addEventListener('storage', onStorage);
+    window.addEventListener(DEMO_MODE_EVENT, onLocalChange);
+    return () => {
+      window.removeEventListener('storage', onStorage);
+      window.removeEventListener(DEMO_MODE_EVENT, onLocalChange);
+    };
+  }, []);
+
+  const setMode = useCallback((next: boolean) => {
+    safeStorage.setItem(DEMO_MODE_STORAGE_KEY, String(next));
+    setEnabled(next);
+    window.dispatchEvent(new Event(DEMO_MODE_EVENT));
+  }, []);
+
+  return [enabled, setMode] as const;
+}

--- a/hooks/useTurbulenceData.ts
+++ b/hooks/useTurbulenceData.ts
@@ -1,0 +1,192 @@
+/**
+ * 16-Bit Weather Platform - Turbulence Data Hook
+ *
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ *
+ * Fetches both real PIREP turbulence reports and G-AIRMET forecast polygons
+ * for the aviation TurbulenceMap. Handles client-side caching, request
+ * cancellation on unmount/refresh, and a 1-minute "now" tick used by the
+ * age-based filter on the consumer side.
+ */
+
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { safeStorage } from '@/lib/safe-storage';
+import type { TurbulencePolygon } from '@/app/api/aviation/turbulence/route';
+
+export interface PIREPData {
+  id: string;
+  receiptTime: string;
+  observationTime: string;
+  aircraftRef: string;
+  latitude: number;
+  longitude: number;
+  altitudeFt: number;
+  turbulenceType: string | null;
+  turbulenceIntensity: string | null;
+  turbulenceBaseFt: number | null;
+  turbulenceTopFt: number | null;
+  icingType: string | null;
+  icingIntensity: string | null;
+  icingBaseFt: number | null;
+  icingTopFt: number | null;
+  tempC: number | null;
+  windDir: number | null;
+  windSpeedKt: number | null;
+  reportType: string;
+  rawText: string;
+}
+
+export interface UseTurbulenceDataResult {
+  pireps: PIREPData[];
+  polygons: TurbulencePolygon[];
+  fetchedAt: string | null;
+  isLoading: boolean;
+  error: string | null;
+  /** Re-fetch from the server, bypassing client cache. */
+  refresh: () => void;
+  /** Now() tick that updates each minute — used to keep the age filter fresh. */
+  currentTime: number;
+}
+
+const PIREP_CACHE_KEY = 'bitweather_pirep_cache';
+const PIREP_CACHE_TTL = 5 * 60 * 1000;
+const TIME_TICK_MS = 60_000;
+
+interface PirepCacheEntry {
+  pireps: PIREPData[];
+  fetchedAt: string;
+  expiresAt: number;
+}
+
+function readCache(): PirepCacheEntry | null {
+  try {
+    const raw = safeStorage.getItem(PIREP_CACHE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as PirepCacheEntry;
+    if (Date.now() < parsed.expiresAt) return parsed;
+    safeStorage.removeItem(PIREP_CACHE_KEY);
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function writeCache(pireps: PIREPData[], fetchedAt: string): void {
+  try {
+    safeStorage.setItem(
+      PIREP_CACHE_KEY,
+      JSON.stringify({
+        pireps,
+        fetchedAt,
+        expiresAt: Date.now() + PIREP_CACHE_TTL,
+      } satisfies PirepCacheEntry),
+    );
+  } catch {
+    // Ignore quota errors — cache is best-effort.
+  }
+}
+
+export function useTurbulenceData(): UseTurbulenceDataResult {
+  const [pireps, setPireps] = useState<PIREPData[]>([]);
+  const [polygons, setPolygons] = useState<TurbulencePolygon[]>([]);
+  const [fetchedAt, setFetchedAt] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [currentTime, setCurrentTime] = useState(Date.now());
+
+  const abortRef = useRef<AbortController | null>(null);
+
+  const load = useCallback(async (forceRefresh: boolean) => {
+    // Try cache for PIREPs (only) — G-AIRMET is server-cached and cheap to refetch.
+    if (!forceRefresh) {
+      const cached = readCache();
+      if (cached) {
+        setPireps(cached.pireps);
+        setFetchedAt(cached.fetchedAt);
+        setIsLoading(false);
+        setError(null);
+      }
+    }
+
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const [pirepRes, turbRes] = await Promise.all([
+        fetch('/api/aviation/pireps?hours=6&turbulenceOnly=false', {
+          signal: controller.signal,
+        }),
+        fetch('/api/aviation/turbulence', {
+          signal: controller.signal,
+        }),
+      ]);
+
+      if (controller.signal.aborted) return;
+
+      if (!pirepRes.ok) throw new Error(`PIREPs returned ${pirepRes.status}`);
+      const pirepJson = await pirepRes.json();
+      if (!pirepJson.success) throw new Error(pirepJson.error || 'PIREP fetch failed');
+
+      const nextPireps = (pirepJson.data?.pireps ?? []) as PIREPData[];
+      const nextFetchedAt = (pirepJson.data?.fetchedAt as string) ?? new Date().toISOString();
+      setPireps(nextPireps);
+      setFetchedAt(nextFetchedAt);
+      writeCache(nextPireps, nextFetchedAt);
+
+      // G-AIRMET is best-effort: if it fails, still show PIREPs.
+      if (turbRes.ok) {
+        const turbJson = await turbRes.json();
+        if (turbJson.success && Array.isArray(turbJson.data?.polygons)) {
+          setPolygons(turbJson.data.polygons as TurbulencePolygon[]);
+        } else {
+          setPolygons([]);
+        }
+      } else {
+        setPolygons([]);
+      }
+    } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') return;
+      console.error('[useTurbulenceData] fetch failed:', err);
+      setError('Unable to load turbulence data');
+    } finally {
+      if (!controller.signal.aborted) {
+        setIsLoading(false);
+      }
+    }
+  }, []);
+
+  // Initial load + cleanup
+  useEffect(() => {
+    load(false);
+    return () => {
+      abortRef.current?.abort();
+    };
+  }, [load]);
+
+  // Time tick for the consumer-side age filter
+  useEffect(() => {
+    const timer = setInterval(() => setCurrentTime(Date.now()), TIME_TICK_MS);
+    return () => clearInterval(timer);
+  }, []);
+
+  const refresh = useCallback(() => {
+    load(true);
+  }, [load]);
+
+  return {
+    pireps,
+    polygons,
+    fetchedAt,
+    isLoading,
+    error,
+    refresh,
+    currentTime,
+  };
+}

--- a/lib/env-validation.ts
+++ b/lib/env-validation.ts
@@ -49,6 +49,18 @@ const envConfig: EnvConfig = {
       name: 'SENTRY_PROJECT',
       description: 'Sentry project (optional - defaults to "javascript-nextjs")',
     },
+    AVIATIONSTACK_API_KEY: {
+      name: 'AVIATIONSTACK_API_KEY',
+      description: 'AviationStack API key (optional - enables real flight schedule data on /aviation; without it, the service returns labeled mock routes). Free tier: 100 req/month.',
+    },
+    OPENSKY_USERNAME: {
+      name: 'OPENSKY_USERNAME',
+      description: 'OpenSky Network username (optional - raises rate limits for live position lookups on /aviation; anonymous works for low-traffic dev).',
+    },
+    OPENSKY_PASSWORD: {
+      name: 'OPENSKY_PASSWORD',
+      description: 'OpenSky Network password (optional - paired with OPENSKY_USERNAME).',
+    },
   },
 };
 

--- a/lib/services/flight-lookup-service.ts
+++ b/lib/services/flight-lookup-service.ts
@@ -1,0 +1,615 @@
+/**
+ * 16-Bit Weather Platform - Flight Lookup Service
+ *
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ *
+ * Provider-agnostic flight schedule + live position lookup.
+ *
+ * Fallback chain:
+ *   1. AviationStack (real schedule data, free tier 100 req/month)
+ *   2. OpenSky Network (live position by callsign — enrichment only, not gating)
+ *   3. Mock (synthesized routes — last resort, response carries `mock: true`)
+ *
+ * Server-side cache keeps us under provider quotas. The cache lives in-process,
+ * so warm Vercel functions share it; cold starts repopulate.
+ */
+
+export interface AirlineData {
+  name: string;
+  iata: string;
+  icao: string;
+}
+
+export interface AirportData {
+  icao: string;
+  iata: string;
+  name: string;
+  city: string;
+  lat: number;
+  lon: number;
+}
+
+export type FlightStatus =
+  | 'scheduled'
+  | 'active'
+  | 'landed'
+  | 'cancelled'
+  | 'diverted';
+
+export interface LivePosition {
+  lat: number;
+  lon: number;
+  altitudeFt: number | null;
+  velocityKt: number | null;
+  headingDeg: number | null;
+  onGround: boolean;
+  fetchedAt: number;
+}
+
+export interface FlightLookupResult {
+  flightNumber: string;
+  airline: AirlineData;
+  departure: AirportData;
+  arrival: AirportData;
+  status: FlightStatus;
+  livePosition?: LivePosition;
+  /** Which provider returned the schedule data. */
+  source: 'aviationstack' | 'mock';
+  /** True when route data is synthesized rather than from a live provider. */
+  mock: boolean;
+}
+
+export interface FlightProvider {
+  readonly name: 'aviationstack' | 'mock';
+  isAvailable(): boolean;
+  lookupFlight(
+    airlineCode: string,
+    flightNum: string,
+  ): Promise<FlightLookupResult | null>;
+}
+
+// ───────────────────────────────────────────────────────────────
+// Reference data (airlines + airports)
+// ───────────────────────────────────────────────────────────────
+
+export const AIRLINES: Record<string, AirlineData> = {
+  AA: { name: 'American Airlines', iata: 'AA', icao: 'AAL' },
+  UA: { name: 'United Airlines', iata: 'UA', icao: 'UAL' },
+  DL: { name: 'Delta Air Lines', iata: 'DL', icao: 'DAL' },
+  WN: { name: 'Southwest Airlines', iata: 'WN', icao: 'SWA' },
+  B6: { name: 'JetBlue Airways', iata: 'B6', icao: 'JBU' },
+  AS: { name: 'Alaska Airlines', iata: 'AS', icao: 'ASA' },
+  NK: { name: 'Spirit Airlines', iata: 'NK', icao: 'NKS' },
+  F9: { name: 'Frontier Airlines', iata: 'F9', icao: 'FFT' },
+  G4: { name: 'Allegiant Air', iata: 'G4', icao: 'AAY' },
+  HA: { name: 'Hawaiian Airlines', iata: 'HA', icao: 'HAL' },
+};
+
+export const AIRPORTS: Record<string, AirportData> = {
+  LAX: { icao: 'KLAX', iata: 'LAX', name: 'Los Angeles International', city: 'Los Angeles', lat: 33.9425, lon: -118.408 },
+  JFK: { icao: 'KJFK', iata: 'JFK', name: 'John F Kennedy International', city: 'New York', lat: 40.6413, lon: -73.7781 },
+  ORD: { icao: 'KORD', iata: 'ORD', name: "O'Hare International", city: 'Chicago', lat: 41.9742, lon: -87.9073 },
+  SFO: { icao: 'KSFO', iata: 'SFO', name: 'San Francisco International', city: 'San Francisco', lat: 37.6213, lon: -122.379 },
+  DFW: { icao: 'KDFW', iata: 'DFW', name: 'Dallas/Fort Worth International', city: 'Dallas', lat: 32.8998, lon: -97.0403 },
+  DEN: { icao: 'KDEN', iata: 'DEN', name: 'Denver International', city: 'Denver', lat: 39.8561, lon: -104.6737 },
+  ATL: { icao: 'KATL', iata: 'ATL', name: 'Hartsfield-Jackson Atlanta International', city: 'Atlanta', lat: 33.6407, lon: -84.4277 },
+  SEA: { icao: 'KSEA', iata: 'SEA', name: 'Seattle-Tacoma International', city: 'Seattle', lat: 47.4502, lon: -122.3088 },
+  MIA: { icao: 'KMIA', iata: 'MIA', name: 'Miami International', city: 'Miami', lat: 25.7959, lon: -80.2870 },
+  BOS: { icao: 'KBOS', iata: 'BOS', name: 'Logan International', city: 'Boston', lat: 42.3656, lon: -71.0096 },
+  PHX: { icao: 'KPHX', iata: 'PHX', name: 'Phoenix Sky Harbor International', city: 'Phoenix', lat: 33.4373, lon: -112.0078 },
+  LAS: { icao: 'KLAS', iata: 'LAS', name: 'Harry Reid International', city: 'Las Vegas', lat: 36.0840, lon: -115.1537 },
+  MSP: { icao: 'KMSP', iata: 'MSP', name: 'Minneapolis-Saint Paul International', city: 'Minneapolis', lat: 44.8848, lon: -93.2223 },
+  DTW: { icao: 'KDTW', iata: 'DTW', name: 'Detroit Metropolitan Wayne County', city: 'Detroit', lat: 42.2162, lon: -83.3554 },
+  EWR: { icao: 'KEWR', iata: 'EWR', name: 'Newark Liberty International', city: 'Newark', lat: 40.6895, lon: -74.1745 },
+  IAH: { icao: 'KIAH', iata: 'IAH', name: 'George Bush Intercontinental', city: 'Houston', lat: 29.9902, lon: -95.3368 },
+  SAN: { icao: 'KSAN', iata: 'SAN', name: 'San Diego International', city: 'San Diego', lat: 32.7338, lon: -117.1933 },
+  HNL: { icao: 'PHNL', iata: 'HNL', name: 'Daniel K. Inouye International', city: 'Honolulu', lat: 21.3187, lon: -157.9225 },
+  MCO: { icao: 'KMCO', iata: 'MCO', name: 'Orlando International', city: 'Orlando', lat: 28.4312, lon: -81.3081 },
+  CLT: { icao: 'KCLT', iata: 'CLT', name: 'Charlotte Douglas International', city: 'Charlotte', lat: 35.2144, lon: -80.9473 },
+};
+
+const AIRPORTS_BY_IATA = AIRPORTS;
+const AIRPORTS_BY_ICAO: Record<string, AirportData> = Object.fromEntries(
+  Object.values(AIRPORTS).map((a) => [a.icao, a]),
+);
+
+// ───────────────────────────────────────────────────────────────
+// Parsing helpers
+// ───────────────────────────────────────────────────────────────
+
+export interface ParsedFlightNumber {
+  airlineCode: string;
+  flightNum: string;
+}
+
+export function parseFlightNumber(input: string): ParsedFlightNumber | null {
+  const cleaned = input.replace(/\s+/g, '').toUpperCase();
+  const match = cleaned.match(/^([A-Z]{2})(\d{1,4})$/);
+  if (!match) return null;
+  return { airlineCode: match[1], flightNum: match[2] };
+}
+
+// ───────────────────────────────────────────────────────────────
+// In-process TTL cache
+// ───────────────────────────────────────────────────────────────
+
+interface CacheEntry<T> {
+  value: T;
+  expiresAt: number;
+}
+
+const SCHEDULE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+const POSITION_TTL_MS = 60 * 1000; // 1 minute
+
+const scheduleCache = new Map<string, CacheEntry<FlightLookupResult>>();
+const positionCache = new Map<string, CacheEntry<LivePosition>>();
+
+function cacheGet<T>(cache: Map<string, CacheEntry<T>>, key: string): T | null {
+  const entry = cache.get(key);
+  if (!entry) return null;
+  if (Date.now() > entry.expiresAt) {
+    cache.delete(key);
+    return null;
+  }
+  return entry.value;
+}
+
+function cacheSet<T>(
+  cache: Map<string, CacheEntry<T>>,
+  key: string,
+  value: T,
+  ttlMs: number,
+): void {
+  cache.set(key, { value, expiresAt: Date.now() + ttlMs });
+}
+
+/** Test helper — clears all cached state. */
+export function _resetCacheForTests(): void {
+  scheduleCache.clear();
+  positionCache.clear();
+}
+
+// ───────────────────────────────────────────────────────────────
+// AviationStack provider (real schedule data)
+// ───────────────────────────────────────────────────────────────
+
+interface AviationStackAirport {
+  airport?: string | null;
+  iata?: string | null;
+  icao?: string | null;
+  timezone?: string | null;
+}
+
+interface AviationStackAirline {
+  name?: string | null;
+  iata?: string | null;
+  icao?: string | null;
+}
+
+interface AviationStackFlight {
+  flight_status?: string | null;
+  departure?: AviationStackAirport | null;
+  arrival?: AviationStackAirport | null;
+  airline?: AviationStackAirline | null;
+  flight?: { iata?: string | null; icao?: string | null; number?: string | null } | null;
+}
+
+interface AviationStackResponse {
+  data?: AviationStackFlight[];
+  error?: { code?: string; message?: string };
+}
+
+const AVIATIONSTACK_BASE_URL = 'http://api.aviationstack.com/v1';
+
+function mapAviationStackStatus(raw: string | null | undefined): FlightStatus {
+  switch ((raw || '').toLowerCase()) {
+    case 'active':
+    case 'en-route':
+      return 'active';
+    case 'landed':
+      return 'landed';
+    case 'cancelled':
+      return 'cancelled';
+    case 'diverted':
+      return 'diverted';
+    case 'scheduled':
+    default:
+      return 'scheduled';
+  }
+}
+
+function airportFromAviationStack(
+  raw: AviationStackAirport | null | undefined,
+): AirportData | null {
+  if (!raw) return null;
+  const iata = raw.iata?.toUpperCase();
+  const icao = raw.icao?.toUpperCase();
+  if (iata && AIRPORTS_BY_IATA[iata]) return AIRPORTS_BY_IATA[iata];
+  if (icao && AIRPORTS_BY_ICAO[icao]) return AIRPORTS_BY_ICAO[icao];
+  // We don't have coords for unknown airports — caller decides whether to bail.
+  if (iata && icao && raw.airport) {
+    return {
+      iata,
+      icao,
+      name: raw.airport,
+      city: raw.airport,
+      lat: 0,
+      lon: 0,
+    };
+  }
+  return null;
+}
+
+class AviationStackProvider implements FlightProvider {
+  readonly name = 'aviationstack' as const;
+
+  constructor(
+    private readonly apiKey: string | undefined,
+    private readonly fetchImpl: typeof fetch = globalThis.fetch,
+  ) {}
+
+  isAvailable(): boolean {
+    return Boolean(this.apiKey);
+  }
+
+  async lookupFlight(
+    airlineCode: string,
+    flightNum: string,
+  ): Promise<FlightLookupResult | null> {
+    if (!this.apiKey) return null;
+
+    const flightIata = `${airlineCode}${flightNum}`;
+    const url = `${AVIATIONSTACK_BASE_URL}/flights?access_key=${encodeURIComponent(
+      this.apiKey,
+    )}&flight_iata=${encodeURIComponent(flightIata)}&limit=1`;
+
+    let json: AviationStackResponse;
+    try {
+      const res = await this.fetchImpl(url);
+      if (!res.ok) {
+        console.warn(
+          `[flight-lookup] AviationStack returned ${res.status} for ${flightIata}`,
+        );
+        return null;
+      }
+      json = (await res.json()) as AviationStackResponse;
+    } catch (err) {
+      console.warn(`[flight-lookup] AviationStack fetch failed:`, err);
+      return null;
+    }
+
+    if (json.error) {
+      console.warn(
+        `[flight-lookup] AviationStack error: ${json.error.code} ${json.error.message}`,
+      );
+      return null;
+    }
+
+    const flight = json.data?.[0];
+    if (!flight) return null;
+
+    const departure = airportFromAviationStack(flight.departure);
+    const arrival = airportFromAviationStack(flight.arrival);
+    if (!departure || !arrival) return null;
+    if (departure.lat === 0 && departure.lon === 0) return null;
+    if (arrival.lat === 0 && arrival.lon === 0) return null;
+
+    const airline: AirlineData = AIRLINES[airlineCode] ?? {
+      name: flight.airline?.name || airlineCode,
+      iata: flight.airline?.iata?.toUpperCase() || airlineCode,
+      icao: flight.airline?.icao?.toUpperCase() || airlineCode,
+    };
+
+    return {
+      flightNumber: flightIata,
+      airline,
+      departure,
+      arrival,
+      status: mapAviationStackStatus(flight.flight_status),
+      source: 'aviationstack',
+      mock: false,
+    };
+  }
+}
+
+// ───────────────────────────────────────────────────────────────
+// Mock provider (last-resort synthesized data)
+// ───────────────────────────────────────────────────────────────
+
+interface MockRoute {
+  departure: string;
+  arrival: string;
+}
+
+const MOCK_ROUTES: Record<string, MockRoute> = {
+  AA1: { departure: 'JFK', arrival: 'LAX' },
+  AA100: { departure: 'JFK', arrival: 'LAX' },
+  AA123: { departure: 'LAX', arrival: 'JFK' },
+  AA175: { departure: 'DFW', arrival: 'ORD' },
+  AA200: { departure: 'MIA', arrival: 'JFK' },
+  AA234: { departure: 'ORD', arrival: 'DFW' },
+  AA300: { departure: 'LAX', arrival: 'MIA' },
+  AA456: { departure: 'DFW', arrival: 'LAX' },
+  AA500: { departure: 'JFK', arrival: 'MIA' },
+  AA789: { departure: 'PHX', arrival: 'DFW' },
+  UA1: { departure: 'SFO', arrival: 'EWR' },
+  UA100: { departure: 'EWR', arrival: 'SFO' },
+  UA123: { departure: 'ORD', arrival: 'DEN' },
+  UA234: { departure: 'SFO', arrival: 'ORD' },
+  UA456: { departure: 'SFO', arrival: 'ORD' },
+  UA500: { departure: 'DEN', arrival: 'SFO' },
+  UA789: { departure: 'IAH', arrival: 'DEN' },
+  DL1: { departure: 'JFK', arrival: 'LAX' },
+  DL100: { departure: 'ATL', arrival: 'LAX' },
+  DL123: { departure: 'JFK', arrival: 'ATL' },
+  DL234: { departure: 'ATL', arrival: 'JFK' },
+  DL456: { departure: 'MSP', arrival: 'ATL' },
+  DL500: { departure: 'DTW', arrival: 'ATL' },
+  DL789: { departure: 'SEA', arrival: 'ATL' },
+  WN1: { departure: 'LAS', arrival: 'PHX' },
+  WN100: { departure: 'DEN', arrival: 'LAS' },
+  WN123: { departure: 'LAX', arrival: 'LAS' },
+  WN456: { departure: 'PHX', arrival: 'DEN' },
+  WN789: { departure: 'ORD', arrival: 'DEN' },
+  B6100: { departure: 'JFK', arrival: 'BOS' },
+  B6123: { departure: 'BOS', arrival: 'JFK' },
+  B6456: { departure: 'JFK', arrival: 'MCO' },
+  B6789: { departure: 'BOS', arrival: 'MCO' },
+  AS100: { departure: 'SEA', arrival: 'LAX' },
+  AS123: { departure: 'SEA', arrival: 'SFO' },
+  AS456: { departure: 'LAX', arrival: 'SEA' },
+  HA100: { departure: 'HNL', arrival: 'LAX' },
+  HA123: { departure: 'HNL', arrival: 'SFO' },
+  HA456: { departure: 'LAX', arrival: 'HNL' },
+};
+
+function generateMockRoute(flightNum: string): MockRoute {
+  const num = parseInt(flightNum, 10);
+  const keys = Object.keys(AIRPORTS_BY_IATA);
+  const depIndex = num % keys.length;
+  let arrIndex = (num * 7 + 3) % keys.length;
+  if (arrIndex === depIndex) arrIndex = (arrIndex + 1) % keys.length;
+  return { departure: keys[depIndex], arrival: keys[arrIndex] };
+}
+
+class MockProvider implements FlightProvider {
+  readonly name = 'mock' as const;
+
+  isAvailable(): boolean {
+    return true;
+  }
+
+  async lookupFlight(
+    airlineCode: string,
+    flightNum: string,
+  ): Promise<FlightLookupResult | null> {
+    const airline = AIRLINES[airlineCode];
+    if (!airline) return null;
+
+    const formatted = `${airlineCode}${flightNum}`;
+    const route = MOCK_ROUTES[formatted] ?? generateMockRoute(flightNum);
+    const departure = AIRPORTS_BY_IATA[route.departure];
+    const arrival = AIRPORTS_BY_IATA[route.arrival];
+    if (!departure || !arrival) return null;
+
+    return {
+      flightNumber: formatted,
+      airline,
+      departure,
+      arrival,
+      status: 'scheduled',
+      source: 'mock',
+      mock: true,
+    };
+  }
+}
+
+// ───────────────────────────────────────────────────────────────
+// OpenSky live position enrichment
+// ───────────────────────────────────────────────────────────────
+
+// State vector tuple per https://openskynetwork.github.io/opensky-api/rest.html
+// 0: icao24, 1: callsign, 2: origin_country, 3: time_position, 4: last_contact,
+// 5: longitude, 6: latitude, 7: baro_altitude, 8: on_ground, 9: velocity,
+// 10: true_track, 11: vertical_rate, 12: sensors, 13: geo_altitude
+type OpenSkyStateVector = readonly unknown[];
+
+interface OpenSkyResponse {
+  time: number;
+  states: OpenSkyStateVector[] | null;
+}
+
+const OPENSKY_BASE_URL = 'https://opensky-network.org/api/states/all';
+
+function asNumber(v: unknown): number | null {
+  return typeof v === 'number' && Number.isFinite(v) ? v : null;
+}
+
+function asString(v: unknown): string | null {
+  return typeof v === 'string' ? v : null;
+}
+
+export async function fetchLivePosition(
+  airlineIcao: string,
+  flightNum: string,
+  fetchImpl: typeof fetch = globalThis.fetch,
+): Promise<LivePosition | null> {
+  if (!fetchImpl) return null;
+
+  // Callsigns are typically ICAO airline + flight number, padded with spaces.
+  const callsignPrefix = `${airlineIcao}${flightNum}`.toUpperCase();
+  const cacheKey = `pos:${callsignPrefix}`;
+  const cached = cacheGet(positionCache, cacheKey);
+  if (cached) return cached;
+
+  const username = process.env.OPENSKY_USERNAME;
+  const password = process.env.OPENSKY_PASSWORD;
+  const headers: Record<string, string> = {};
+  if (username && password) {
+    headers.Authorization = `Basic ${Buffer.from(`${username}:${password}`).toString('base64')}`;
+  }
+
+  let json: OpenSkyResponse;
+  try {
+    const res = await fetchImpl(OPENSKY_BASE_URL, { headers });
+    if (!res.ok) return null;
+    json = (await res.json()) as OpenSkyResponse;
+  } catch (err) {
+    console.warn('[flight-lookup] OpenSky fetch failed:', err);
+    return null;
+  }
+
+  if (!json.states) return null;
+
+  const match = json.states.find((s) => {
+    const callsign = asString(s[1])?.trim().toUpperCase();
+    return callsign === callsignPrefix;
+  });
+  if (!match) return null;
+
+  const lon = asNumber(match[5]);
+  const lat = asNumber(match[6]);
+  if (lat === null || lon === null) return null;
+
+  const altMeters = asNumber(match[13]) ?? asNumber(match[7]);
+  const velocityMs = asNumber(match[9]);
+  const heading = asNumber(match[10]);
+  const onGround = Boolean(match[8]);
+
+  const position: LivePosition = {
+    lat,
+    lon,
+    altitudeFt: altMeters !== null ? Math.round(altMeters * 3.28084) : null,
+    velocityKt: velocityMs !== null ? Math.round(velocityMs * 1.94384) : null,
+    headingDeg: heading,
+    onGround,
+    fetchedAt: Date.now(),
+  };
+
+  cacheSet(positionCache, cacheKey, position, POSITION_TTL_MS);
+  return position;
+}
+
+// ───────────────────────────────────────────────────────────────
+// Public lookup entry point
+// ───────────────────────────────────────────────────────────────
+
+export interface LookupOptions {
+  /** When false, skip OpenSky live position enrichment. Default: true */
+  includeLivePosition?: boolean;
+  /** Override providers (test injection). */
+  providers?: FlightProvider[];
+  /** Override fetch (test injection). */
+  fetchImpl?: typeof fetch;
+  /** When true, ignore cache for this lookup. */
+  bypassCache?: boolean;
+  /**
+   * When true, skip real providers and return mock data directly. Used by the
+   * user-facing "Demo mode" toggle so screenshots/demos don't burn quota.
+   */
+  forceMock?: boolean;
+}
+
+export type LookupErrorCode =
+  | 'INVALID_FLIGHT_NUMBER'
+  | 'UNKNOWN_AIRLINE'
+  | 'FLIGHT_NOT_FOUND';
+
+export interface LookupError {
+  code: LookupErrorCode;
+  message: string;
+}
+
+export type LookupOutcome =
+  | { ok: true; result: FlightLookupResult }
+  | { ok: false; error: LookupError };
+
+function defaultProviders(fetchImpl: typeof fetch = globalThis.fetch): FlightProvider[] {
+  return [
+    new AviationStackProvider(process.env.AVIATIONSTACK_API_KEY, fetchImpl),
+    new MockProvider(),
+  ];
+}
+
+export async function lookupFlight(
+  rawFlightNumber: string,
+  options: LookupOptions = {},
+): Promise<LookupOutcome> {
+  const parsed = parseFlightNumber(rawFlightNumber);
+  if (!parsed) {
+    return {
+      ok: false,
+      error: {
+        code: 'INVALID_FLIGHT_NUMBER',
+        message:
+          'Invalid flight number format. Use airline code + number (e.g., AA123, UA456).',
+      },
+    };
+  }
+
+  const { airlineCode, flightNum } = parsed;
+  if (!AIRLINES[airlineCode]) {
+    return {
+      ok: false,
+      error: {
+        code: 'UNKNOWN_AIRLINE',
+        message: `Unknown airline code: ${airlineCode}. Supported airlines: ${Object.keys(AIRLINES).join(', ')}.`,
+      },
+    };
+  }
+
+  // Demo-mode lookups bypass cache entirely so toggling on/off shows the
+  // change immediately, and we never want a live result to satisfy a mock
+  // request (or vice versa).
+  const cacheKey = `flight:${airlineCode}${flightNum}`;
+  if (!options.bypassCache && !options.forceMock) {
+    const cached = cacheGet(scheduleCache, cacheKey);
+    if (cached) return { ok: true, result: cached };
+  }
+
+  const fetchImpl = options.fetchImpl ?? globalThis.fetch;
+  const allProviders = options.providers ?? defaultProviders(fetchImpl);
+  const providers = options.forceMock
+    ? allProviders.filter((p) => p.name === 'mock')
+    : allProviders;
+
+  for (const provider of providers) {
+    if (!provider.isAvailable()) continue;
+    try {
+      const result = await provider.lookupFlight(airlineCode, flightNum);
+      if (result) {
+        if (!options.forceMock) {
+          cacheSet(scheduleCache, cacheKey, result, SCHEDULE_TTL_MS);
+        }
+
+        if (options.includeLivePosition !== false && !result.mock) {
+          const livePosition = await fetchLivePosition(
+            result.airline.icao,
+            flightNum,
+            fetchImpl,
+          ).catch(() => null);
+          if (livePosition) {
+            const enriched = { ...result, livePosition };
+            if (!options.forceMock) {
+              cacheSet(scheduleCache, cacheKey, enriched, SCHEDULE_TTL_MS);
+            }
+            return { ok: true, result: enriched };
+          }
+        }
+
+        return { ok: true, result };
+      }
+    } catch (err) {
+      console.warn(`[flight-lookup] Provider ${provider.name} threw:`, err);
+    }
+  }
+
+  return {
+    ok: false,
+    error: {
+      code: 'FLIGHT_NOT_FOUND',
+      message: 'Flight not found. Check the flight number and try again.',
+    },
+  };
+}

--- a/planning/aviation-uplift.md
+++ b/planning/aviation-uplift.md
@@ -1,0 +1,126 @@
+# Aviation Uplift Plan
+
+Status: shipped, 2026-05-07
+Owner: justinelrod
+
+## Why now
+
+The aviation section ships behaviors that don't match what users expect:
+
+- `app/api/aviation/flight-lookup/route.ts` returns **fake routes** for any flight number — ~40 hardcoded routes, then a deterministic-random fallback. No "demo" disclaimer in the UI.
+- `app/api/aviation/turbulence/route.ts` generates **simulated GTG** with seeded random; comment admits it.
+- All 5 aviation components hardcode colors (`text-red-500`, `#22c55e`) and skip the theme tokens used everywhere else.
+- `components/aviation/TurbulenceMap.tsx` is 685 LOC with 25 hooks — the next change in there will hurt.
+- Zero tests across `app/api/aviation/**` and `components/aviation/**`.
+
+The retro-terminal aesthetic is good. The data and the plumbing aren't.
+
+## Non-goals
+
+- This is **not for operational flight planning** — disclaimer stays. The fix is making the educational/recreational use case honest, not turning into an EFB.
+- Not redesigning the page IA. Terminal layout stays.
+- Not touching `app/api/aviation/{alerts,metar,pireps}/route.ts` data sources — they hit real AWC/NOAA endpoints already.
+
+## Phasing
+
+Three lanes, ordered so each unblocks the next.
+
+### Phase 1 — Honesty + theme + a11y pass (1 session, low risk)
+
+Smallest blast radius, ships value immediately, doesn't depend on external API decisions.
+
+- Add a visible "Demo data" badge to flight-lookup results until Phase 2 lands. One line in `FlightRouteLookup.tsx`.
+- Migrate hardcoded colors to theme tokens across `AlertTicker`, `FlightConditionsTerminal`, `TurbulenceMap`, `FlightNumberInput`, `FlightRouteLookup`. Map severity → semantic CSS vars (`--danger`, `--warning`, `--success`) defined in `lib/theme-config.ts`. If those vars don't exist yet, add them once and reuse.
+- Replace inline `style={{ height: '400px' }}` and inline `backgroundColor` in `TurbulenceMap.tsx` with Tailwind classes + responsive breakpoints. Stack the 4-col status grid on `<md`.
+- Add aria labels and focus management on the PIREP popup, severity legends, and collapsible terminal sections. Target: ≥30 aria attributes across aviation surface.
+- Show "Updated X min ago" timestamp on `AlertTicker` and `TurbulenceMap` legends.
+
+Exit criteria: theme switcher visibly changes aviation colors; mobile viewport doesn't overflow; flight-lookup demo badge visible.
+
+### Phase 2 — Real flight data (1–2 sessions, medium risk)
+
+The lie is the worst thing on the page. Replace it.
+
+**Provider choice (decide before starting):**
+- **OpenSky Network** — free, no key for anonymous, rate-limited (~100/day anon, 4000/day registered). Live position + callsign, but flight-number → route mapping is awkward (callsigns aren't always IATA flight numbers).
+- **AviationStack** — free tier 100/month, real flight schedules with route data. Easier mapping. Caps low.
+- **FlightAware AeroAPI** — paid only, $0.005–0.02/req. Best data, but cost.
+
+Recommendation: start with **OpenSky for live tracking** (where is flight X right now) + **AviationStack for schedule lookup** (route for flight X) on a server-side cache to stay under quota. Fall back to current mock with explicit "schedule unavailable" UI when both miss.
+
+Implementation:
+- New `lib/services/flight-lookup-service.ts` with provider abstraction (so we can swap later).
+- Server-side cache via existing patterns (10-min TTL on schedules, 60s on positions).
+- Env vars: `AVIATIONSTACK_API_KEY`, `OPENSKY_USERNAME`, `OPENSKY_PASSWORD`. Add to `lib/env-validation.ts`.
+- Keep `MOCK_ROUTES` only as last-resort fallback, behind a `mock: true` flag in the response so the UI can label it.
+- Tests: `__tests__/flight-lookup-service.test.ts` covering parsing, provider fallback chain, cache behavior. Mock provider responses with MSW or fetch mock.
+
+Exit criteria: real flights resolve to real routes; rate-limit handling is graceful; mock fallback only fires when providers fail and is labeled in UI.
+
+### Phase 3 — TurbulenceMap rewrite + real GTG (2–3 sessions, higher risk)
+
+The big one. Don't start until Phase 1+2 ship.
+
+**Data:**
+- Real NOAA GTG isn't on a clean public REST endpoint. Two options:
+  1. AWC G-AIRMET turbulence polygons (`aviationweather.gov/api/data/gairmet?type=turb`) — already structured GeoJSON-ish, covers CONUS, free.
+  2. NOMADS GFS turbulence index — heavier (GRIB2), more accurate, more work.
+- Recommendation: **G-AIRMET first**, leave GFS hook for later. PIREPs already work and complement G-AIRMETs nicely.
+
+**Component split** (`TurbulenceMap.tsx` 685 → 4 files):
+- `TurbulenceMap.tsx` — container, OpenLayers init, ~150 LOC.
+- `useTurbulenceData.ts` — data fetching + caching hook.
+- `TurbulenceLegend.tsx` — severity legend, theme-aware.
+- `TurbulenceControls.tsx` — hours/altitude filter UI.
+- Move the seeded-random simulator out of `app/api/aviation/turbulence/route.ts`; route now proxies AWC G-AIRMET + caches.
+
+**Tests:**
+- E2E in `tests/e2e/aviation.spec.ts` covering: page loads, alerts render, flight lookup with real flight (mocked at network layer), turbulence map mounts, theme switcher cascades.
+
+Exit criteria: turbulence data is real; component is splittable without ceremony; one E2E spec green.
+
+## Risk register
+
+- **External API quotas** — both flight providers are tight. Mitigation: aggressive server-side cache, public `Cache-Control` headers, per-IP throttle if abuse shows up.
+- **AWC G-AIRMET coverage gaps** — non-CONUS may have less data. UI must handle empty results gracefully (don't show empty map as "smooth skies").
+- **Theme token migration could regress visuals** — Phase 1 should land behind a careful visual diff (Playwright screenshot per theme is overkill; manual check across 3 themes is enough).
+- **OpenLayers split could break map init order** — keep the rewrite mechanical: extract, don't redesign behavior in the same PR.
+
+## Decisions (locked 2026-05-07)
+
+1. **Provider tier**: OpenSky (free) + AviationStack free tier. Mock fallback stays, labeled clearly when active. Revisit paid tier only if quota becomes a real problem.
+2. **Demo mode**: persistent user-facing toggle. Survives Phase 2 — useful when providers are down or quota is hit, and for screenshots. Lives in the flight lookup UI; remembers preference in localStorage.
+3. **Turbulence scope**: CONUS + AK/HI only via AWC G-AIRMET. Outside that region, UI shows "No coverage for this area" rather than an empty smooth-skies map. No GFS GRIB2 work in this plan.
+
+## What's not in this plan
+
+- Aviation chat/AI integration (separate effort if wanted).
+- METAR/TAF parser hardening — regex in `metar/route.ts` is fragile but not currently failing. Park it.
+- Airport detail pages. Different feature.
+
+## What shipped (2026-05-07)
+
+### Phase 1
+- `app/globals.css` — universal `--severity-{light,moderate,severe,extreme}` tokens (with `*-bg` companions) in `:root`.
+- `app/aviation/page.tsx` — error banner uses severity tokens; threads `alertsFetchedAt` so the alerts feed shows "Updated Xm ago".
+- `components/aviation/{AlertTicker,FlightConditionsTerminal,FlightNumberInput,FlightRouteLookup,TurbulenceMap}.tsx` — severity colors via CSS vars, `bg-card`/`text-primary` instead of `bg-gray-900`/`text-cyan-500`, full aria treatment on collapsibles + map dialog + alerts ticker, mobile responsive (status grid stacks, map height `h-[300px] sm:h-[400px] md:h-[480px]`).
+- `app/api/aviation/flight-lookup/route.ts` — `mock: true` flag added to all responses.
+
+### Phase 2
+- `lib/services/flight-lookup-service.ts` — provider abstraction (`AviationStackProvider` + `MockProvider`), in-process schedule cache (10m TTL), live position cache (60s TTL), OpenSky enrichment when ICAO callsign matches, `forceMock` option for the demo toggle.
+- `app/api/aviation/flight-lookup/route.ts` — refactored to use the service. Honors `?mock=1` query param. Forced-mock responses are `Cache-Control: no-store`; live responses get `s-maxage=600, stale-while-revalidate=1200`.
+- `lib/env-validation.ts` — `AVIATIONSTACK_API_KEY`, `OPENSKY_USERNAME`, `OPENSKY_PASSWORD` registered as optional.
+- `__tests__/flight-lookup-service.test.ts` — 18 tests covering parsing, fallback chain (success/null/unavailable/throw/exhausted), schedule cache (hit + bypass), forceMock semantics, OpenSky parsing (match/no-match/HTTP failure), default-providers integration.
+- `hooks/useDemoMode.ts` + `components/aviation/FlightNumberInput.tsx` — persistent user-facing toggle (`localStorage` + cross-tab + same-tab event sync) that forces mock data when on. Visible in the flight lookup section.
+
+### Phase 3
+- `app/api/aviation/turbulence/route.ts` — replaced simulated GTG with real AWC G-AIRMET fetch (`aviationweather.gov/api/data/gairmet?type=turb&format=json`). Defensive coordinate normalization handles polygon, multipolygon, and legacy flat-ring shapes. CONUS + AK/HI coverage labeled in response.
+- `hooks/useTurbulenceData.ts` — extracted from TurbulenceMap. Owns dual-fetch (PIREPs + G-AIRMET), client cache, abort handling, 1-min time tick.
+- `components/aviation/turbulence/{TurbulenceLegend,TurbulenceControls}.tsx` — split sub-components, theme-aware.
+- `components/aviation/TurbulenceMap.tsx` — slimmed from 685 → ~380 LOC. Adds G-AIRMET polygon layer (zIndex 50, ≤6h forecast hours only) under the existing PIREP point layer (zIndex 100). Filters PIREP-only feature hits for the popup.
+- `tests/e2e/aviation.spec.ts` — header/alerts render, demo badge appears for mock provider, OpenLayers viewport mounts, theme tokens cascade.
+
+### Open follow-ups (deferred)
+- Surface `livePosition` in the UI (route map, ETA-style indicator). Plumbing exists; just unused.
+- E2E coverage of the demo-mode toggle (turning it on while a real provider is configured — currently we have no key in CI so this can't be exercised).
+- Per-IP throttle on `/api/aviation/flight-lookup` if abuse shows up. Not needed yet.

--- a/tests/e2e/aviation.spec.ts
+++ b/tests/e2e/aviation.spec.ts
@@ -1,0 +1,167 @@
+/**
+ * E2E spec for /aviation.
+ *
+ * Stubs the upstream NOAA endpoints so the test runs deterministically and
+ * doesn't depend on aviationweather.gov uptime. Verifies:
+ *   - Page loads with header + alerts feed
+ *   - Demo data badge appears for the mock flight provider
+ *   - Turbulence map mounts (OL canvas present)
+ *   - Theme switching cascades to aviation surface
+ */
+
+import { test, expect } from './fixtures';
+import { setTheme } from '../fixtures/utils';
+
+const SAMPLE_ALERTS = {
+  alerts: [
+    {
+      id: 'sigmet-1',
+      type: 'SIGMET',
+      severity: 'severe',
+      hazard: 'TURB',
+      region: 'CONUS-CENTRAL',
+      validFrom: '2026-05-07T12:00:00Z',
+      validTo: '2026-05-07T18:00:00Z',
+      text: 'Severe turbulence FL280-FL400 over central plains.',
+    },
+    {
+      id: 'airmet-1',
+      type: 'AIRMET',
+      severity: 'moderate',
+      hazard: 'TURB',
+      region: 'CONUS-WEST',
+      validFrom: '2026-05-07T10:00:00Z',
+      validTo: '2026-05-07T16:00:00Z',
+      text: 'Moderate turbulence below FL180.',
+    },
+  ],
+};
+
+const SAMPLE_PIREPS = {
+  success: true,
+  data: {
+    pireps: [
+      {
+        id: 'pirep-1',
+        receiptTime: '2026-05-07T14:30:00Z',
+        observationTime: '2026-05-07T14:25:00Z',
+        aircraftRef: 'B738',
+        latitude: 40.0,
+        longitude: -100.0,
+        altitudeFt: 35000,
+        turbulenceType: 'CAT',
+        turbulenceIntensity: 'MOD',
+        turbulenceBaseFt: 33000,
+        turbulenceTopFt: 37000,
+        icingType: null,
+        icingIntensity: null,
+        icingBaseFt: null,
+        icingTopFt: null,
+        tempC: -50,
+        windDir: 270,
+        windSpeedKt: 80,
+        reportType: 'PIREP',
+        rawText: 'B738 /OV BOI /TM 1425 /FL350 /TP B738 /TB MOD CAT',
+      },
+    ],
+    fetchedAt: '2026-05-07T14:30:00Z',
+  },
+};
+
+const SAMPLE_TURBULENCE = {
+  success: true,
+  data: {
+    polygons: [
+      {
+        id: 'gairmet-0-0',
+        coordinates: [[
+          [-110, 35],
+          [-95, 35],
+          [-95, 45],
+          [-110, 45],
+          [-110, 35],
+        ]],
+        severity: 'moderate',
+        rawSeverity: 'MOD',
+        hazard: 'TURB',
+        forecastHour: 0,
+        validFrom: '2026-05-07T12:00:00Z',
+        validTo: '2026-05-07T15:00:00Z',
+        topFt: 35000,
+        baseFt: 18000,
+      },
+    ],
+    fetchedAt: '2026-05-07T14:30:00Z',
+    source: 'NOAA AWC G-AIRMET',
+    coverage: 'CONUS+AK+HI',
+  },
+};
+
+test.describe('/aviation', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/api/aviation/alerts**', (route) =>
+      route.fulfill({ status: 200, body: JSON.stringify(SAMPLE_ALERTS) }),
+    );
+    await page.route('**/api/aviation/pireps**', (route) =>
+      route.fulfill({ status: 200, body: JSON.stringify(SAMPLE_PIREPS) }),
+    );
+    await page.route('**/api/aviation/turbulence**', (route) =>
+      route.fulfill({ status: 200, body: JSON.stringify(SAMPLE_TURBULENCE) }),
+    );
+  });
+
+  test('renders header and alerts statistics', async ({ page }) => {
+    await page.goto('/aviation', { waitUntil: 'domcontentloaded' });
+
+    await expect(page.getByRole('heading', { name: /AVIATION WEATHER/i })).toBeVisible();
+    // Status grid shows the SIGMET count
+    await expect(page.getByText(/SIGMETs/i).first()).toBeVisible();
+    await expect(page.getByText(/AIRMETs/i).first()).toBeVisible();
+  });
+
+  test('flight lookup surfaces Demo data badge for mock provider', async ({ page }) => {
+    await page.goto('/aviation', { waitUntil: 'domcontentloaded' });
+
+    // Open the route lookup section
+    await page.getByRole('button', { name: /Flight Route Lookup/i }).click();
+
+    const flightInput = page.getByTestId('flight-number-input');
+    await expect(flightInput).toBeVisible({ timeout: 10000 });
+
+    await flightInput.fill('AA123');
+    await page.getByTestId('flight-search-button').click();
+
+    // The badge is part of the flight info display once a result loads.
+    // We rely on the *real* flight-lookup route handler running locally —
+    // without env keys, it returns the mock provider with mock:true.
+    await expect(page.getByText(/Demo data/i)).toBeVisible({ timeout: 10000 });
+  });
+
+  test('turbulence map mounts with OpenLayers viewport', async ({ page }) => {
+    await page.goto('/aviation', { waitUntil: 'domcontentloaded' });
+    // Map section is expanded by default
+    const mapRegion = page.getByRole('region', {
+      name: /Turbulence pilot reports map/i,
+    });
+    await expect(mapRegion).toBeVisible({ timeout: 15000 });
+    // OpenLayers always renders an .ol-viewport canvas wrapper
+    await expect(mapRegion.locator('.ol-viewport')).toBeVisible({ timeout: 15000 });
+  });
+
+  test('theme tokens cascade to aviation surface', async ({ page }) => {
+    await page.goto('/aviation', { waitUntil: 'domcontentloaded' });
+    await setTheme(page, 'nord');
+
+    // Theme attribute reaches the document
+    const dataTheme = await page.locator('html').getAttribute('data-theme');
+    expect(dataTheme).toBe('nord');
+
+    // The severity token is defined and resolves to a non-empty value
+    const severityValue = await page.evaluate(() => {
+      return getComputedStyle(document.documentElement)
+        .getPropertyValue('--severity-extreme')
+        .trim();
+    });
+    expect(severityValue.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/e2e/aviation.spec.ts
+++ b/tests/e2e/aviation.spec.ts
@@ -122,19 +122,24 @@ test.describe('/aviation', () => {
   test('flight lookup surfaces Demo data badge for mock provider', async ({ page }) => {
     await page.goto('/aviation', { waitUntil: 'domcontentloaded' });
 
-    // Open the route lookup section
-    await page.getByRole('button', { name: /Flight Route Lookup/i }).click();
+    // Wait for the lazy-loaded terminal to finish hydrating before
+    // interacting. The route section sits inside three nested
+    // dynamic()/lazy() boundaries, so the route button only appears once
+    // FlightConditionsTerminal has resolved.
+    const routeButton = page.getByRole('button', { name: /Flight Route Lookup/i });
+    await routeButton.waitFor({ state: 'visible', timeout: 30000 });
+    await routeButton.click();
 
+    // FlightRouteLookup → FlightNumberInput is a second dynamic boundary.
     const flightInput = page.getByTestId('flight-number-input');
-    await expect(flightInput).toBeVisible({ timeout: 10000 });
+    await expect(flightInput).toBeVisible({ timeout: 30000 });
 
     await flightInput.fill('AA123');
     await page.getByTestId('flight-search-button').click();
 
-    // The badge is part of the flight info display once a result loads.
-    // We rely on the *real* flight-lookup route handler running locally —
-    // without env keys, it returns the mock provider with mock:true.
-    await expect(page.getByText(/Demo data/i)).toBeVisible({ timeout: 10000 });
+    // Without an AviationStack key configured, the route handler answers
+    // from the mock provider and the UI surfaces the Demo data badge.
+    await expect(page.getByText(/Demo data/i)).toBeVisible({ timeout: 15000 });
   });
 
   test('turbulence map mounts with OpenLayers viewport', async ({ page }) => {


### PR DESCRIPTION
## Summary

- Replaces synthesized flight routes (`flight-lookup`) and simulated GTG (`turbulence`) with provider-backed data (AviationStack, OpenSky, AWC G-AIRMET) behind a clean abstraction with mock fallback
- Migrates the entire aviation surface off hardcoded Tailwind colors onto theme + universal severity CSS tokens; adds aria coverage and responsive mobile layout
- Adds a persistent **Demo mode** user toggle so screenshots/offline demos don't burn provider quota

## What changed

### Flight lookup (Phase 2)
- `lib/services/flight-lookup-service.ts` — new provider abstraction. AviationStack provider (real schedule), Mock provider (last-resort), OpenSky live-position enrichment by callsign. In-process caches: 10-min schedule, 60s position. Honors `forceMock` to drive the demo toggle.
- `app/api/aviation/flight-lookup/route.ts` — refactored onto the service. Returns `source`, `mock`, optional `livePosition`. Honors `?mock=1`. Forced-mock responses are `Cache-Control: no-store`.
- `__tests__/flight-lookup-service.test.ts` — 18 tests: parsing, fallback chain (success/null/unavailable/throw/exhausted), schedule cache hit + bypass, `forceMock` semantics, OpenSky parsing (match/no-match/HTTP fail), default-providers integration.

### Turbulence (Phase 3)
- `app/api/aviation/turbulence/route.ts` — replaced seeded-random simulator with real AWC G-AIRMET fetch (`aviationweather.gov/api/data/gairmet?type=turb&format=json`). CONUS+AK+HI coverage. Defensive coordinate normalization handles polygon, multipolygon, and legacy ring shapes.
- `hooks/useTurbulenceData.ts` — extracted from `TurbulenceMap`. Owns dual-fetch (PIREPs + G-AIRMET), client cache, abort handling, 1-min time tick.
- `components/aviation/turbulence/{TurbulenceLegend,TurbulenceControls}.tsx` — split sub-components, theme-aware.
- `components/aviation/TurbulenceMap.tsx` — slimmed from **685 → ~380 LOC**. New G-AIRMET polygon layer (zIndex 50, ≤6h forecast) renders below the existing PIREP point layer (zIndex 100). Popup hit-test filters to PIREP features only.

### Theme + a11y + mobile (Phase 1)
- `app/globals.css` — universal `--severity-{light,moderate,severe,extreme}` tokens (+ `*-bg` companions) in `:root`. Severity meaning is universal, so these don't theme-shift.
- All 5 aviation components migrated:
  - Severity colors use `style={{ color: 'var(--severity-…)' }}`, never Tailwind `text-red-500`.
  - Decoration colors (`bg-gray-900`, `text-cyan-500`) replaced with theme tokens (`bg-card`, `text-primary`, `bg-muted`).
  - Collapsibles get `aria-expanded`/`aria-controls`, popup gets `role="dialog"`, legends get `role="list"`, error displays get `role="alert"` + `aria-live`.
  - Map container is responsive (`h-[300px] sm:h-[400px] md:h-[480px]`).
  - Status grid stacks on mobile, 4-col on `md+`.
- `app/aviation/page.tsx` — error banner uses severity tokens; threads `alertsFetchedAt` so the alerts feed shows "Updated Xm ago".

### Demo mode toggle
- `hooks/useDemoMode.ts` — persists in `localStorage`, syncs across tabs (storage event) and within tab (custom event).
- `components/aviation/FlightNumberInput.tsx` — toggle UI + appends `?mock=1` to fetches when on. Forced-mock responses still surface the existing "Demo data" badge.

### Env (all optional, registered in `lib/env-validation.ts`)
```
AVIATIONSTACK_API_KEY     # real flight schedule data
OPENSKY_USERNAME          # raises live-position rate limits
OPENSKY_PASSWORD
```
Without these, the route stays on labeled mock data — same behavior as today, but the response truthfully says `"mock": true` and the UI shows the badge.

### Planning doc
- `planning/aviation-uplift.md` — full plan + decisions + shipped manifest.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `eslint` clean across all touched files
- [x] `npm test -- flight-lookup-service.test.ts` — 18/18 pass
- [ ] `npx playwright test tests/e2e/aviation.spec.ts` against a live dev server
- [ ] Manual: load `/aviation` and verify Nord/Synthwave/Matrix theme switching cascades to severity colors, badges, and map controls
- [ ] Manual: enter `AA123`, confirm "Demo data" badge appears (no env keys configured)
- [ ] Manual: toggle "Demo mode", search again, verify badge appears even when keys are present (set `AVIATIONSTACK_API_KEY` locally to test)
- [ ] Manual: mobile viewport — confirm map height adapts and status grid stacks
- [ ] Manual: keyboard navigation through collapsible sections; screen reader spot-check on PIREP popup

## Notes

- Diff is large (~2.7k lines added, ~1k deleted) but most additions are the new service + tests + planning doc; the existing aviation files are net-smaller and clearer.
- `TURBULENCE_COLORS` hex constants stay in `TurbulenceMap.tsx` because OpenLayers renders to canvas, where CSS custom properties don't resolve. They mirror the `--severity-*` tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)