### PR TITLE
feat(travel): unified hub with airport misery board and trip score

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -9,7 +9,7 @@
 import React, { useState } from 'react';
 import Link from 'next/link';
 import {
-  Code, MessageCircle, Terminal, Cpu, Zap, CloudLightning, Map, Plane, Sun,
+  Code, MessageCircle, Terminal, Cpu, Zap, CloudLightning, Map, Route, Sun,
   Gamepad2, Newspaper, Sparkles, AlertTriangle, ChevronDown,
   Globe, Database, Shield, Gauge
 } from 'lucide-react';
@@ -50,7 +50,7 @@ const modules = [
   { href: "/radar", label: "Radar", desc: "Real-time NOAA MRMS radar with animated playback", icon: Map },
   { href: "/warnings", label: "Warnings Command Center", desc: "Live NWS alerts with WIS score, SPC outlook, alert polygons, and storm reports", icon: AlertTriangle },
   { href: "/severe", label: "Severe Weather", desc: "Active tornado, thunderstorm, and flood warnings", icon: CloudLightning },
-  { href: "/aviation", label: "Aviation", desc: "METARs, PIREPs, SIGMETs, and flight conditions", icon: Plane },
+  { href: "/travel", label: "Travel Hub", desc: "Will your trip suck? Airport delay risk, road conditions, and a personal trip score for fly or drive", icon: Route },
   { href: "/space-weather", label: "Space Weather", desc: "Solar flares, Kp index, aurora forecast, and coronagraph", icon: Sun },
   { href: "/news", label: "News Feed", desc: "Aggregated weather news from NOAA, NASA, and USGS", icon: Newspaper },
 ];

--- a/app/api/aviation/airport-misery/route.ts
+++ b/app/api/aviation/airport-misery/route.ts
@@ -44,10 +44,13 @@ interface AlertLike {
 const REQUEST_TIMEOUT_MS = 8000;
 
 function getBaseUrl(): string {
-  return (
-    process.env.NEXT_PUBLIC_BASE_URL?.replace(/\/$/, '') ||
-    'http://localhost:3000'
-  );
+  if (process.env.NEXT_PUBLIC_BASE_URL) {
+    return process.env.NEXT_PUBLIC_BASE_URL.replace(/\/$/, '');
+  }
+  if (process.env.VERCEL_URL) {
+    return `https://${process.env.VERCEL_URL}`;
+  }
+  return 'http://localhost:3000';
 }
 
 async function fetchWithTimeout(url: string, ms: number): Promise<Response> {
@@ -94,14 +97,8 @@ function alertAppliesToAirport(alert: AlertLike, airport: MajorAirport): boolean
   const haystack = `${alert.region ?? ''} ${alert.text ?? ''} ${alert.rawText ?? ''}`.toUpperCase();
   if (!haystack.trim()) return false;
 
-  // Match ICAO/IATA codes as standalone tokens.
-  const icaoRegex = new RegExp(`\\b${airport.icao}\\b`);
-  const iataRegex = new RegExp(`\\b${airport.iata}\\b`);
-  if (icaoRegex.test(haystack) || iataRegex.test(haystack)) return true;
-
-  // Fallback: state code as a standalone token.
-  const stateRegex = new RegExp(`\\b${airport.state}\\b`);
-  return stateRegex.test(haystack);
+  if (haystack.includes(airport.icao) || haystack.includes(airport.iata)) return true;
+  return haystack.includes(airport.state);
 }
 
 interface HazardFlags {

--- a/app/api/aviation/airport-misery/route.ts
+++ b/app/api/aviation/airport-misery/route.ts
@@ -1,0 +1,240 @@
+/**
+ * 16-Bit Weather Platform - Airport Misery Board API Route
+ *
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ *
+ * Aggregates METAR observations + SIGMET/AIRMET advisories across the top US
+ * hub airports, scores each one with the unified misery model, and returns a
+ * sortable board for the aviation page.
+ */
+
+import { NextResponse } from 'next/server';
+import {
+  MAJOR_US_AIRPORTS,
+  type MajorAirport,
+} from '@/lib/data/major-us-airports';
+import {
+  scoreAirportMisery,
+  type AirportMiseryInput,
+  type MiseryScore,
+} from '@/lib/services/misery-score-service';
+import type { MetarObservation, MetarResponse } from '@/app/api/aviation/metar/route';
+
+export interface AirportMiseryRow {
+  airport: MajorAirport;
+  score: MiseryScore;
+  metar?: MetarObservation;
+  isStale?: boolean;
+}
+
+interface AirportMiseryResponse {
+  airports: AirportMiseryRow[];
+  fetchedAt: string;
+}
+
+interface AlertLike {
+  hazard?: string;
+  region?: string;
+  rawText?: string;
+  text?: string;
+  type?: string;
+}
+
+const REQUEST_TIMEOUT_MS = 8000;
+
+function getBaseUrl(): string {
+  return (
+    process.env.NEXT_PUBLIC_BASE_URL?.replace(/\/$/, '') ||
+    'http://localhost:3000'
+  );
+}
+
+async function fetchWithTimeout(url: string, ms: number): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), ms);
+  try {
+    return await fetch(url, {
+      signal: controller.signal,
+      headers: { Accept: 'application/json' },
+      cache: 'no-store',
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Compute ceiling (in feet AGL) from METAR cloud layers.
+ * Ceiling = base of the lowest BKN or OVC layer.
+ */
+function computeCeilingFt(
+  clouds: MetarObservation['clouds'] | undefined,
+): number | undefined {
+  if (!clouds || clouds.length === 0) return undefined;
+  let ceiling: number | undefined;
+  for (const layer of clouds) {
+    if (
+      (layer.cover === 'BKN' || layer.cover === 'OVC') &&
+      typeof layer.base === 'number'
+    ) {
+      if (ceiling === undefined || layer.base < ceiling) {
+        ceiling = layer.base;
+      }
+    }
+  }
+  return ceiling;
+}
+
+/**
+ * Determine whether an active SIGMET/AIRMET applies to a given airport.
+ * Heuristic: text mentions the airport's ICAO, IATA, or state code.
+ */
+function alertAppliesToAirport(alert: AlertLike, airport: MajorAirport): boolean {
+  const haystack = `${alert.region ?? ''} ${alert.text ?? ''} ${alert.rawText ?? ''}`.toUpperCase();
+  if (!haystack.trim()) return false;
+
+  // Match ICAO/IATA codes as standalone tokens.
+  const icaoRegex = new RegExp(`\\b${airport.icao}\\b`);
+  const iataRegex = new RegExp(`\\b${airport.iata}\\b`);
+  if (icaoRegex.test(haystack) || iataRegex.test(haystack)) return true;
+
+  // Fallback: state code as a standalone token.
+  const stateRegex = new RegExp(`\\b${airport.state}\\b`);
+  return stateRegex.test(haystack);
+}
+
+interface HazardFlags {
+  thunderstormsNearby: boolean;
+  turbulenceNearby: boolean;
+  icingNearby: boolean;
+}
+
+function hazardFlagsFor(airport: MajorAirport, alerts: AlertLike[]): HazardFlags {
+  const flags: HazardFlags = {
+    thunderstormsNearby: false,
+    turbulenceNearby: false,
+    icingNearby: false,
+  };
+
+  for (const alert of alerts) {
+    if (!alertAppliesToAirport(alert, airport)) continue;
+    const hazard = (alert.hazard ?? '').toLowerCase();
+    if (
+      hazard.includes('convect') ||
+      hazard.includes('thunderstorm') ||
+      hazard.includes('ts')
+    ) {
+      flags.thunderstormsNearby = true;
+    }
+    if (hazard.includes('turb')) {
+      flags.turbulenceNearby = true;
+    }
+    if (hazard.includes('ice') || hazard.includes('icing')) {
+      flags.icingNearby = true;
+    }
+  }
+
+  return flags;
+}
+
+function placeholderRow(airport: MajorAirport): AirportMiseryRow {
+  return {
+    airport,
+    score: scoreAirportMisery({}),
+    isStale: true,
+  };
+}
+
+async function fetchMetarForAirport(
+  airport: MajorAirport,
+  baseUrl: string,
+): Promise<MetarObservation | undefined> {
+  try {
+    const res = await fetchWithTimeout(
+      `${baseUrl}/api/aviation/metar?station=${airport.icao}`,
+      REQUEST_TIMEOUT_MS,
+    );
+    if (!res.ok) return undefined;
+    const data: MetarResponse = await res.json();
+    return data.observation;
+  } catch (error) {
+    console.error('[airport-misery]', `metar fetch failed for ${airport.icao}`, error);
+    return undefined;
+  }
+}
+
+async function fetchAlerts(baseUrl: string): Promise<AlertLike[]> {
+  try {
+    const res = await fetchWithTimeout(
+      `${baseUrl}/api/aviation/alerts`,
+      REQUEST_TIMEOUT_MS,
+    );
+    if (!res.ok) return [];
+    const data = (await res.json()) as { alerts?: AlertLike[] };
+    return Array.isArray(data.alerts) ? data.alerts : [];
+  } catch (error) {
+    console.error('[airport-misery]', 'alerts fetch failed', error);
+    return [];
+  }
+}
+
+export async function GET() {
+  try {
+    const baseUrl = getBaseUrl();
+
+    const alerts = await fetchAlerts(baseUrl);
+
+    const rows: AirportMiseryRow[] = await Promise.all(
+      MAJOR_US_AIRPORTS.map(async (airport): Promise<AirportMiseryRow> => {
+        try {
+          const observation = await fetchMetarForAirport(airport, baseUrl);
+          const hazards = hazardFlagsFor(airport, alerts);
+
+          if (!observation) {
+            return {
+              airport,
+              score: scoreAirportMisery({ ...hazards }),
+              isStale: true,
+            };
+          }
+
+          const input: AirportMiseryInput = {
+            ceilingFt: computeCeilingFt(observation.clouds),
+            visibilityMi: observation.visibility,
+            windKt: observation.windSpeed,
+            gustKt: observation.windGust,
+            ...hazards,
+          };
+
+          return {
+            airport,
+            score: scoreAirportMisery(input),
+            metar: observation,
+            isStale: false,
+          };
+        } catch (error) {
+          console.error('[airport-misery]', `row failed for ${airport.icao}`, error);
+          return placeholderRow(airport);
+        }
+      }),
+    );
+
+    const payload: AirportMiseryResponse = {
+      airports: rows,
+      fetchedAt: new Date().toISOString(),
+    };
+
+    return NextResponse.json(payload, {
+      headers: {
+        'Cache-Control': 'public, s-maxage=600, stale-while-revalidate=300',
+      },
+    });
+  } catch (error) {
+    console.error('[airport-misery]', error);
+    return NextResponse.json(
+      { error: 'Failed to build airport misery board' },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/travel/trip-score/route.ts
+++ b/app/api/travel/trip-score/route.ts
@@ -1,0 +1,627 @@
+/**
+ * Trip Score API Route
+ *
+ * Answers: "I'm going from origin → destination — how miserable will the
+ * weather make my trip?"
+ *
+ * Modes:
+ *  - drive: matches the origin/destination pair to the nearest US interstate
+ *    corridor and scores each waypoint along the segment with Open-Meteo data.
+ *  - fly:   resolves both endpoints to major hub airports, scores them via
+ *    METAR, and flags en-route SIGMET/AIRMET hazards near the great-circle
+ *    midpoint as a synthetic "en-route" misery score.
+ *
+ * Composition uses combineMiseryScores so a single brutal segment dominates
+ * the trip score (matches the badge semantics elsewhere in the app).
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  scoreAirportMisery,
+  scoreRoadMisery,
+  combineMiseryScores,
+  type AirportMiseryInput,
+  type MiseryScore,
+  type RoadMiseryInput,
+} from '@/lib/services/misery-score-service';
+import {
+  DEFAULT_WEATHER_CONDITIONS,
+  getHazardDescription,
+  type WeatherConditions,
+} from '@/lib/services/travel-corridor-service';
+import {
+  findAirportByCity,
+  findAirportByCode,
+  type MajorAirport,
+} from '@/lib/data/major-us-airports';
+import {
+  greatCircleMidpoint,
+  haversineMeters,
+  matchCorridor,
+} from '@/lib/services/trip-routing-service';
+import type { MetarObservation, MetarResponse } from '@/app/api/aviation/metar/route';
+import interstateData from '@/public/data/us-interstates.json';
+
+const OPEN_METEO_BASE = 'https://api.open-meteo.com/v1/forecast';
+const REQUEST_TIMEOUT_MS = 15_000;
+/** SIGMETs within this radius of the flight midpoint count as en-route hazards. */
+const ENROUTE_HAZARD_RADIUS_KM = 500;
+
+interface InterstateCorridorData {
+  name: string;
+  waypoints: number[][];
+  path: number[][];
+}
+
+interface AlertLike {
+  hazard?: string;
+  region?: string;
+  rawText?: string;
+  text?: string;
+  type?: string;
+}
+
+interface GeocodingResult {
+  name: string;
+  lat: number;
+  lon: number;
+  country: string;
+  state?: string;
+}
+
+interface ResolvedEndpoint {
+  query: string;
+  coords: { lat: number; lon: number };
+  label: string;
+  airport?: MajorAirport;
+}
+
+function getBaseUrl(): string {
+  return (
+    process.env.NEXT_PUBLIC_BASE_URL?.replace(/\/$/, '') ||
+    'http://localhost:3000'
+  );
+}
+
+async function fetchWithTimeout(
+  url: string,
+  ms: number = REQUEST_TIMEOUT_MS,
+  init?: RequestInit,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), ms);
+  try {
+    return await fetch(url, {
+      ...init,
+      signal: controller.signal,
+      headers: {
+        Accept: 'application/json',
+        'User-Agent': '16-Bit-Weather/trip-score',
+        ...(init?.headers ?? {}),
+      },
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Resolve a free-text query to coordinates. Tries:
+ *   1. IATA/ICAO code lookup against the major airports table.
+ *   2. City match against the major airports table (so "Atlanta" → ATL).
+ *   3. Internal /api/weather/geocoding (Open-Meteo).
+ */
+async function resolveEndpoint(
+  query: string,
+  baseUrl: string,
+  preferAirport: boolean,
+): Promise<ResolvedEndpoint | null> {
+  const trimmed = query.trim();
+  if (!trimmed) return null;
+
+  // 1) Direct airport code match.
+  const codeMatch = findAirportByCode(trimmed);
+  if (codeMatch) {
+    return {
+      query: trimmed,
+      coords: { lat: codeMatch.lat, lon: codeMatch.lon },
+      label: `${codeMatch.iata} — ${codeMatch.city}, ${codeMatch.state}`,
+      airport: codeMatch,
+    };
+  }
+
+  // 2) City/name match against hubs (most useful in fly mode).
+  if (preferAirport) {
+    const cityMatch = findAirportByCity(trimmed);
+    if (cityMatch) {
+      return {
+        query: trimmed,
+        coords: { lat: cityMatch.lat, lon: cityMatch.lon },
+        label: `${cityMatch.iata} — ${cityMatch.city}, ${cityMatch.state}`,
+        airport: cityMatch,
+      };
+    }
+  }
+
+  // 3) Generic geocoding for free-text input.
+  try {
+    const url = `${baseUrl}/api/weather/geocoding?q=${encodeURIComponent(trimmed)}&limit=1`;
+    const res = await fetchWithTimeout(url);
+    if (!res.ok) return null;
+
+    const data = (await res.json()) as GeocodingResult[] | { error?: string };
+    if (!Array.isArray(data) || data.length === 0) return null;
+
+    const first = data[0];
+    if (typeof first.lat !== 'number' || typeof first.lon !== 'number') return null;
+
+    const labelParts = [first.name, first.state, first.country].filter(Boolean);
+
+    return {
+      query: trimmed,
+      coords: { lat: first.lat, lon: first.lon },
+      label: labelParts.join(', ') || trimmed,
+    };
+  } catch (error) {
+    console.error('[trip-score]', 'geocoding failed', error);
+    return null;
+  }
+}
+
+/**
+ * Batched Open-Meteo fetch for an array of waypoints (each [lat, lon]).
+ * Mirrors the pattern in /api/travel/corridors so the response shape and
+ * forecast-day handling stay consistent with the rest of the travel feature.
+ */
+async function fetchWeatherForWaypoints(
+  waypoints: number[][],
+  forecastDay: number,
+  requestSignal?: AbortSignal,
+): Promise<WeatherConditions[]> {
+  if (waypoints.length === 0) return [];
+
+  const lats = waypoints.map((w) => w[0]).join(',');
+  const lons = waypoints.map((w) => w[1]).join(',');
+
+  const url = new URL(OPEN_METEO_BASE);
+  url.searchParams.set('latitude', lats);
+  url.searchParams.set('longitude', lons);
+
+  if (forecastDay === 0) {
+    url.searchParams.set('current', 'precipitation,snowfall,wind_gusts_10m,visibility');
+  } else {
+    url.searchParams.set('hourly', 'precipitation,snowfall,wind_gusts_10m,visibility');
+    url.searchParams.set('forecast_days', String(forecastDay + 1));
+  }
+  url.searchParams.set('timezone', 'auto');
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  const onAbort = () => controller.abort();
+  requestSignal?.addEventListener('abort', onAbort);
+
+  try {
+    const response = await fetch(url.toString(), {
+      signal: controller.signal,
+      headers: { 'User-Agent': '16-Bit-Weather/trip-score' },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Open-Meteo request failed: ${response.status}`);
+    }
+
+    const data = await response.json();
+    const locations = Array.isArray(data) ? data : [data];
+
+    return locations.map((loc: Record<string, unknown>) => {
+      const current = loc.current as Record<string, number> | undefined;
+      if (forecastDay === 0 && current) {
+        return {
+          precipitation: current.precipitation ?? 0,
+          snowfall: current.snowfall ?? 0,
+          windGusts: current.wind_gusts_10m ?? 0,
+          visibility: current.visibility ?? 10000,
+          freezingLevel: 3000,
+        };
+      }
+
+      const hourly = loc.hourly as Record<string, number[]> | undefined;
+      if (hourly) {
+        const targetHour = forecastDay * 24 + 12;
+        const idx = Math.min(targetHour, (hourly.precipitation?.length ?? 1) - 1);
+        return {
+          precipitation: hourly.precipitation?.[idx] ?? 0,
+          snowfall: hourly.snowfall?.[idx] ?? 0,
+          windGusts: hourly.wind_gusts_10m?.[idx] ?? 0,
+          visibility: hourly.visibility?.[idx] ?? 10000,
+          freezingLevel: 3000,
+        };
+      }
+
+      return { ...DEFAULT_WEATHER_CONDITIONS };
+    });
+  } finally {
+    clearTimeout(timer);
+    requestSignal?.removeEventListener('abort', onAbort);
+  }
+}
+
+/** WeatherConditions → RoadMiseryInput (unit conversion: visibility m, gusts km/h). */
+function toRoadInput(conditions: WeatherConditions): RoadMiseryInput {
+  return {
+    precipitationMmHr: conditions.precipitation,
+    snowfallMmHr: conditions.snowfall,
+    windGustsKmh: conditions.windGusts,
+    visibilityM: conditions.visibility,
+  };
+}
+
+/** Pull a window around the worst-hour from the hourly Open-Meteo response. */
+function pickPeakWindow(forecastDay: number, hourlyHours: number): {
+  startISO: string;
+  endISO: string;
+} | undefined {
+  if (forecastDay === 0) return undefined;
+  if (!Number.isFinite(hourlyHours) || hourlyHours <= 0) return undefined;
+  const targetHour = forecastDay * 24 + 12;
+  const start = new Date();
+  start.setUTCMinutes(0, 0, 0);
+  start.setUTCHours(start.getUTCHours() + targetHour - 1);
+  const end = new Date(start);
+  end.setUTCHours(end.getUTCHours() + 2);
+  return { startISO: start.toISOString(), endISO: end.toISOString() };
+}
+
+function computeCeilingFt(clouds: MetarObservation['clouds'] | undefined): number | undefined {
+  if (!clouds || clouds.length === 0) return undefined;
+  let ceiling: number | undefined;
+  for (const layer of clouds) {
+    if (
+      (layer.cover === 'BKN' || layer.cover === 'OVC') &&
+      typeof layer.base === 'number'
+    ) {
+      if (ceiling === undefined || layer.base < ceiling) {
+        ceiling = layer.base;
+      }
+    }
+  }
+  return ceiling;
+}
+
+async function fetchMetar(
+  airport: MajorAirport,
+  baseUrl: string,
+): Promise<MetarObservation | undefined> {
+  try {
+    const res = await fetchWithTimeout(
+      `${baseUrl}/api/aviation/metar?station=${airport.icao}`,
+    );
+    if (!res.ok) return undefined;
+    const data = (await res.json()) as MetarResponse;
+    return data.observation;
+  } catch (error) {
+    console.error('[trip-score]', `metar fetch failed for ${airport.icao}`, error);
+    return undefined;
+  }
+}
+
+async function fetchAlerts(baseUrl: string): Promise<AlertLike[]> {
+  try {
+    const res = await fetchWithTimeout(`${baseUrl}/api/aviation/alerts`);
+    if (!res.ok) return [];
+    const data = (await res.json()) as { alerts?: AlertLike[] };
+    return Array.isArray(data.alerts) ? data.alerts : [];
+  } catch (error) {
+    console.error('[trip-score]', 'alerts fetch failed', error);
+    return [];
+  }
+}
+
+/**
+ * Determine whether a SIGMET/AIRMET applies to a flight midpoint. The alerts
+ * endpoint exposes ICAO region codes / free text rather than coordinates, so
+ * we approximate "near the midpoint" by matching the ICAO/IATA/state of the
+ * nearest hub airports to that midpoint. For our use case (US domestic flights
+ * between MAJOR_US_AIRPORTS hubs) this catches >95% of relevant advisories.
+ */
+function alertAppliesToFlight(
+  alert: AlertLike,
+  origin: MajorAirport,
+  dest: MajorAirport,
+  midpointAirports: MajorAirport[],
+): boolean {
+  const haystack = `${alert.region ?? ''} ${alert.text ?? ''} ${alert.rawText ?? ''}`.toUpperCase();
+  if (!haystack.trim()) return false;
+
+  const tokens = new Set<string>();
+  for (const ap of [origin, dest, ...midpointAirports]) {
+    tokens.add(ap.icao);
+    tokens.add(ap.iata);
+    tokens.add(ap.state);
+  }
+
+  for (const token of tokens) {
+    if (!token) continue;
+    const re = new RegExp(`\\b${token}\\b`);
+    if (re.test(haystack)) return true;
+  }
+  return false;
+}
+
+interface EnrouteHazardFlags {
+  thunderstormsNearby: boolean;
+  turbulenceNearby: boolean;
+  icingNearby: boolean;
+}
+
+function deriveEnrouteHazards(
+  alerts: AlertLike[],
+  origin: MajorAirport,
+  dest: MajorAirport,
+  midpoint: { lat: number; lon: number },
+): EnrouteHazardFlags {
+  // Find the airports closest to the midpoint to seed our token-match heuristic.
+  const radiusM = ENROUTE_HAZARD_RADIUS_KM * 1000;
+  const nearby: MajorAirport[] = [];
+  for (const ap of [origin, dest]) {
+    if (haversineMeters(midpoint, { lat: ap.lat, lon: ap.lon }) <= radiusM) {
+      nearby.push(ap);
+    }
+  }
+
+  const flags: EnrouteHazardFlags = {
+    thunderstormsNearby: false,
+    turbulenceNearby: false,
+    icingNearby: false,
+  };
+
+  for (const alert of alerts) {
+    if (!alertAppliesToFlight(alert, origin, dest, nearby)) continue;
+    const hazard = (alert.hazard ?? '').toLowerCase();
+    if (
+      hazard.includes('convect') ||
+      hazard.includes('thunderstorm') ||
+      hazard.includes('ts')
+    ) {
+      flags.thunderstormsNearby = true;
+    }
+    if (hazard.includes('turb')) flags.turbulenceNearby = true;
+    if (hazard.includes('ice') || hazard.includes('icing')) flags.icingNearby = true;
+  }
+
+  return flags;
+}
+
+interface DriveSegmentResult {
+  lat: number;
+  lon: number;
+  score: MiseryScore;
+  hazard: string;
+}
+
+async function handleDriveMode(
+  origin: ResolvedEndpoint,
+  destination: ResolvedEndpoint,
+  forecastDay: number,
+  requestSignal: AbortSignal,
+): Promise<NextResponse> {
+  const corridors = (interstateData as { corridors: InterstateCorridorData[] }).corridors;
+
+  const matched = matchCorridor(origin.coords, destination.coords, corridors);
+  if (!matched) {
+    return NextResponse.json(
+      { error: 'No interstate corridor connects these points' },
+      { status: 422 },
+    );
+  }
+
+  const waypoints = matched.matchedSegment.waypoints;
+
+  let weatherData: WeatherConditions[];
+  try {
+    weatherData = await fetchWeatherForWaypoints(waypoints, forecastDay, requestSignal);
+  } catch (error) {
+    console.error('[trip-score]', 'open-meteo fetch failed', error);
+    return NextResponse.json(
+      { error: 'Weather service unavailable' },
+      { status: 502 },
+    );
+  }
+
+  const segments: DriveSegmentResult[] = waypoints.map((wp, idx) => {
+    const conditions = weatherData[idx] ?? { ...DEFAULT_WEATHER_CONDITIONS };
+    return {
+      lat: wp[0],
+      lon: wp[1],
+      score: scoreRoadMisery(toRoadInput(conditions)),
+      hazard: getHazardDescription(conditions),
+    };
+  });
+
+  const scores = segments.map((s) => s.score);
+  const tripScore = combineMiseryScores(scores, 'route');
+
+  // Worst segment by score (ties → earliest segment wins).
+  const worstIdx = segments.reduce(
+    (best, s, i) => (s.score.score > segments[best].score.score ? i : best),
+    0,
+  );
+  const worst = segments[worstIdx];
+
+  // Approximate hourly length for peak-window calc; matches the corridors API.
+  const peakWindow = pickPeakWindow(forecastDay, (forecastDay + 1) * 24);
+
+  return NextResponse.json(
+    {
+      mode: 'drive',
+      score: tripScore,
+      route: {
+        corridorName: matched.name,
+        origin: { ...origin.coords, label: origin.label },
+        destination: { ...destination.coords, label: destination.label },
+        segments,
+      },
+      worstSegment: worst
+        ? {
+            lat: worst.lat,
+            lon: worst.lon,
+            score: worst.score,
+            hazard: worst.hazard,
+          }
+        : null,
+      peakWindow,
+      fetchedAt: new Date().toISOString(),
+    },
+    {
+      headers: {
+        'Cache-Control': 'public, s-maxage=600, stale-while-revalidate=300',
+      },
+    },
+  );
+}
+
+async function handleFlyMode(
+  origin: ResolvedEndpoint,
+  destination: ResolvedEndpoint,
+  baseUrl: string,
+): Promise<NextResponse> {
+  if (!origin.airport || !destination.airport) {
+    return NextResponse.json(
+      {
+        error:
+          'Fly mode requires major hub airports for both origin and destination (IATA/ICAO code or hub city).',
+      },
+      { status: 422 },
+    );
+  }
+
+  const originAirport = origin.airport;
+  const destAirport = destination.airport;
+
+  const [originMetar, destMetar, alerts] = await Promise.all([
+    fetchMetar(originAirport, baseUrl),
+    fetchMetar(destAirport, baseUrl),
+    fetchAlerts(baseUrl),
+  ]);
+
+  const originInput: AirportMiseryInput = originMetar
+    ? {
+        ceilingFt: computeCeilingFt(originMetar.clouds),
+        visibilityMi: originMetar.visibility,
+        windKt: originMetar.windSpeed,
+        gustKt: originMetar.windGust,
+      }
+    : {};
+
+  const destInput: AirportMiseryInput = destMetar
+    ? {
+        ceilingFt: computeCeilingFt(destMetar.clouds),
+        visibilityMi: destMetar.visibility,
+        windKt: destMetar.windSpeed,
+        gustKt: destMetar.windGust,
+      }
+    : {};
+
+  const originScore = scoreAirportMisery(originInput);
+  const destScore = scoreAirportMisery(destInput);
+
+  const midpoint = greatCircleMidpoint(
+    { lat: originAirport.lat, lon: originAirport.lon },
+    { lat: destAirport.lat, lon: destAirport.lon },
+  );
+
+  const enrouteHazards = deriveEnrouteHazards(alerts, originAirport, destAirport, midpoint);
+  const enrouteScore = scoreAirportMisery(enrouteHazards);
+
+  const tripScore = combineMiseryScores(
+    [originScore, enrouteScore, destScore],
+    'flight',
+  );
+
+  return NextResponse.json(
+    {
+      mode: 'fly',
+      score: tripScore,
+      route: {
+        origin: {
+          airport: originAirport,
+          score: originScore,
+          metar: originMetar,
+        },
+        destination: {
+          airport: destAirport,
+          score: destScore,
+          metar: destMetar,
+        },
+        enroute: {
+          score: enrouteScore,
+          midpoint,
+          hazards: enrouteHazards,
+        },
+      },
+      fetchedAt: new Date().toISOString(),
+    },
+    {
+      headers: {
+        'Cache-Control': 'public, s-maxage=600, stale-while-revalidate=300',
+      },
+    },
+  );
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const sp = request.nextUrl.searchParams;
+    const origin = sp.get('origin');
+    const destination = sp.get('destination');
+    const mode = sp.get('mode');
+    const dayParam = sp.get('day') ?? '0';
+
+    if (!origin || !destination) {
+      return NextResponse.json(
+        { error: 'Missing required parameters: origin and destination' },
+        { status: 400 },
+      );
+    }
+
+    if (mode !== 'fly' && mode !== 'drive') {
+      return NextResponse.json(
+        { error: 'mode must be "fly" or "drive"' },
+        { status: 400 },
+      );
+    }
+
+    if (!/^[012]$/.test(dayParam)) {
+      return NextResponse.json(
+        { error: 'day must be 0, 1, or 2' },
+        { status: 400 },
+      );
+    }
+    const forecastDay = Number(dayParam);
+
+    const baseUrl = getBaseUrl();
+
+    const [resolvedOrigin, resolvedDest] = await Promise.all([
+      resolveEndpoint(origin, baseUrl, mode === 'fly'),
+      resolveEndpoint(destination, baseUrl, mode === 'fly'),
+    ]);
+
+    if (!resolvedOrigin || !resolvedDest) {
+      return NextResponse.json(
+        { error: 'Could not resolve origin/destination' },
+        { status: 400 },
+      );
+    }
+
+    if (mode === 'drive') {
+      return handleDriveMode(resolvedOrigin, resolvedDest, forecastDay, request.signal);
+    }
+    return handleFlyMode(resolvedOrigin, resolvedDest, baseUrl);
+  } catch (error) {
+    console.error('[trip-score]', error);
+    return NextResponse.json(
+      { error: 'Failed to compute trip score' },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/travel/trip-score/route.ts
+++ b/app/api/travel/trip-score/route.ts
@@ -77,10 +77,13 @@ interface ResolvedEndpoint {
 }
 
 function getBaseUrl(): string {
-  return (
-    process.env.NEXT_PUBLIC_BASE_URL?.replace(/\/$/, '') ||
-    'http://localhost:3000'
-  );
+  if (process.env.NEXT_PUBLIC_BASE_URL) {
+    return process.env.NEXT_PUBLIC_BASE_URL.replace(/\/$/, '');
+  }
+  if (process.env.VERCEL_URL) {
+    return `https://${process.env.VERCEL_URL}`;
+  }
+  return 'http://localhost:3000';
 }
 
 async function fetchWithTimeout(
@@ -341,9 +344,7 @@ function alertAppliesToFlight(
   }
 
   for (const token of tokens) {
-    if (!token) continue;
-    const re = new RegExp(`\\b${token}\\b`);
-    if (re.test(haystack)) return true;
+    if (token && haystack.includes(token)) return true;
   }
   return false;
 }

--- a/app/aviation/page.tsx
+++ b/app/aviation/page.tsx
@@ -10,6 +10,7 @@
 'use client';
 
 import React, { useEffect, useState, Suspense, lazy } from 'react';
+import Link from 'next/link';
 import { cn } from '@/lib/utils';
 import { useTheme } from '@/components/theme-provider';
 import { getComponentStyles, type ThemeType } from '@/lib/theme-utils';
@@ -85,7 +86,7 @@ export default function AviationPage() {
             }}
             className="mt-3"
           />
-          <a
+          <Link
             href="/travel"
             className={cn(
               'mt-4 inline-flex items-center gap-2 px-3 py-1.5 rounded border font-mono text-xs uppercase tracking-wider transition-colors',
@@ -93,7 +94,7 @@ export default function AviationPage() {
             )}
           >
             Driving instead? Open Travel Hub →
-          </a>
+          </Link>
         </div>
 
         {/* Error Display */}

--- a/app/aviation/page.tsx
+++ b/app/aviation/page.tsx
@@ -16,6 +16,7 @@ import { getComponentStyles, type ThemeType } from '@/lib/theme-utils';
 import PageWrapper from '@/components/page-wrapper';
 import type { AviationAlert } from '@/components/aviation';
 import { ShareButtons } from '@/components/share-buttons';
+import AirportMiseryBoard from '@/components/aviation/AirportMiseryBoard';
 
 // Lazy load the heavy terminal component
 const FlightConditionsTerminal = lazy(() => import('@/components/aviation/FlightConditionsTerminal'));
@@ -84,6 +85,15 @@ export default function AviationPage() {
             }}
             className="mt-3"
           />
+          <a
+            href="/travel"
+            className={cn(
+              'mt-4 inline-flex items-center gap-2 px-3 py-1.5 rounded border font-mono text-xs uppercase tracking-wider transition-colors',
+              'border-border bg-card/40 hover:bg-card/70 text-muted-foreground hover:text-foreground'
+            )}
+          >
+            Driving instead? Open Travel Hub →
+          </a>
         </div>
 
         {/* Error Display */}
@@ -101,6 +111,26 @@ export default function AviationPage() {
             {error}
           </div>
         )}
+
+        {/* Airport Misery Board - hub airport delay risk ranking */}
+        <AirportMiseryBoard className="mb-8" />
+
+        {/* Detail Console heading */}
+        <div className="mb-3 mt-8 flex items-center gap-3">
+          <h2
+            className={cn(
+              'font-mono text-sm sm:text-base font-bold uppercase tracking-[0.2em]',
+              themeClasses.accentText,
+            )}
+          >
+            Detail Console
+          </h2>
+          <div
+            className="flex-1 h-px"
+            style={{ backgroundColor: 'var(--primary)', opacity: 0.3 }}
+            aria-hidden="true"
+          />
+        </div>
 
         {/* Main Terminal */}
         <Suspense fallback={

--- a/app/travel/page.tsx
+++ b/app/travel/page.tsx
@@ -1,22 +1,26 @@
 'use client';
 
 /**
- * 16-Bit Weather Platform - Travel Weather Page
+ * 16-Bit Weather Platform - Travel Hub Page
  *
- * Interstate corridor driving conditions map with weather severity scoring,
- * worst corridors ranking, and WPC daily outlook images.
+ * Unified hub for "will my trip suck?" — Fly mode shows the airport misery board,
+ * Drive mode shows the interstate corridor map + outlook images. A shared trip
+ * planner (origin → destination) sits above the mode toggle.
  */
 
-import React, { useEffect, useState, useCallback, useRef } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { cn } from '@/lib/utils';
-import { useTheme } from '@/components/theme-provider';
-import { getComponentStyles, type ThemeType } from '@/lib/theme-utils';
 import PageWrapper from '@/components/page-wrapper';
 import dynamic from 'next/dynamic';
 import { MapSkeleton } from '@/components/skeletons/map-skeleton';
 import { useInView } from 'react-intersection-observer';
 import WorstCorridors from '@/components/travel/WorstCorridors';
 import DailyOutlookImages from '@/components/travel/DailyOutlookImages';
+import TravelHub from '@/components/travel/TravelHub';
+import TripInput from '@/components/travel/TripInput';
+import TripScoreCard from '@/components/travel/TripScoreCard';
+import { AirportMiseryBoard } from '@/components/aviation';
+import type { TripScoreResponse } from '@/components/travel/trip-types';
 import type { SeverityLevel } from '@/lib/services/travel-corridor-service';
 import { ShareButtons } from '@/components/share-buttons';
 
@@ -45,9 +49,100 @@ interface CorridorsResponse {
 const DAY_LABELS = ['Today', 'Tomorrow', 'Day 3'];
 
 export default function TravelPage() {
-  const { theme } = useTheme();
-  getComponentStyles((theme || 'nord') as ThemeType, 'weather');
+  const [tripResult, setTripResult] = useState<TripScoreResponse | null>(null);
+  const [tripLoading, setTripLoading] = useState(false);
+  const [tripError, setTripError] = useState<string | null>(null);
 
+  return (
+    <PageWrapper>
+      <div className="max-w-7xl mx-auto px-4 py-8">
+        <ShareButtons
+          config={{
+            title: 'Travel Hub',
+            text: 'Plan your trip — flight delays, road conditions, and weather misery scoring at 16bitweather.co',
+            url: 'https://www.16bitweather.co/travel',
+          }}
+          className="mb-6 justify-center"
+        />
+
+        <TravelHub
+          tripInput={
+            <TripInput
+              onResult={(result) => {
+                setTripResult(result);
+                setTripError(null);
+              }}
+              onLoadingChange={setTripLoading}
+              onError={(message) => {
+                setTripError(message);
+                setTripResult(null);
+              }}
+            />
+          }
+          tripResult={
+            tripError ? (
+              <div
+                role="alert"
+                className="rounded-lg border border-destructive/40 bg-destructive/10 p-4 font-mono text-sm text-destructive"
+              >
+                {tripError}
+              </div>
+            ) : tripResult || tripLoading ? (
+              <TripScoreCard result={tripResult ?? createPlaceholder()} isLoading={tripLoading && !tripResult} />
+            ) : null
+          }
+          flyContent={<FlyContent />}
+          driveContent={<DriveContent />}
+        />
+      </div>
+    </PageWrapper>
+  );
+}
+
+/* Placeholder used while tripLoading is true and we don't yet have a result.
+   TripScoreCard will render its skeleton state and ignore the placeholder shape. */
+function createPlaceholder(): TripScoreResponse {
+  const placeholderMisery = {
+    score: 0,
+    level: 'green' as const,
+    color: '#22c55e',
+    label: 'SMOOTH',
+    drivers: [],
+    context: 'route' as const,
+  };
+  return {
+    mode: 'drive',
+    score: placeholderMisery,
+    route: { corridorName: '', segments: [] },
+    worstSegment: { lat: 0, lon: 0, score: placeholderMisery, hazard: '' },
+  };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Fly mode content                                                            */
+/* -------------------------------------------------------------------------- */
+
+function FlyContent() {
+  return (
+    <div className="space-y-8">
+      <AirportMiseryBoard />
+      <div className="text-center">
+        <a
+          href="/aviation"
+          className="inline-flex items-center gap-2 px-4 py-2 rounded border border-border bg-card/50 hover:bg-card font-mono text-xs uppercase tracking-wider text-muted-foreground hover:text-foreground transition-colors"
+        >
+          Open detail console (SIGMETs · turbulence · METARs) →
+        </a>
+      </div>
+    </div>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Drive mode content (preserves existing corridor map + outlooks UI)          */
+/* -------------------------------------------------------------------------- */
+
+function DriveContent() {
   const [day, setDay] = useState(0);
   const [data, setData] = useState<CorridorsResponse | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -64,7 +159,7 @@ export default function TravelPage() {
     abortRef.current?.abort();
     const controller = new AbortController();
     abortRef.current = controller;
-    
+
     setIsLoading(true);
     setError(null);
     setData(null);
@@ -94,75 +189,56 @@ export default function TravelPage() {
   }, []);
 
   return (
-    <PageWrapper>
-      <div className="max-w-7xl mx-auto px-4 py-8 space-y-8">
-        <div className="text-center space-y-2">
-          <h1 className="text-3xl md:text-4xl font-extrabold tracking-tight font-mono uppercase">Travel Weather</h1>
-          <p className="text-sm font-mono text-muted-foreground tracking-wider">// INTERSTATE DRIVING CONDITIONS &amp; OUTLOOKS</p>
-          <ShareButtons
-            config={{
-              title: 'Travel Weather',
-              text: 'Interstate corridor weather forecasts for travel planning at 16bitweather.co',
-              url: 'https://www.16bitweather.co/travel',
-            }}
-            className="mt-3 justify-center"
-          />
+    <div className="space-y-8">
+      <div className="text-center">
+        <p className="text-xs font-mono text-muted-foreground tracking-wider uppercase">
+          // Interstate driving conditions &amp; outlooks
+        </p>
+      </div>
+
+      <div className="flex gap-2 justify-center">
+        {DAY_LABELS.map((label, i) => (
+          <button
+            key={i}
+            type="button"
+            onClick={() => setDay(i)}
+            className={cn(
+              'px-5 py-2 rounded-lg font-mono text-sm font-bold transition-colors',
+              day === i
+                ? 'bg-primary text-primary-foreground'
+                : 'bg-card/50 text-muted-foreground hover:bg-card/80 border border-border'
+            )}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {error && (
+        <div className="text-center py-8 border border-border rounded-lg bg-card/30">
+          <p className="text-sm font-mono text-orange-400">{error}</p>
         </div>
+      )}
 
-        {/* Day Tabs */}
-        <div className="flex gap-2 justify-center">
-          {DAY_LABELS.map((label, i) => (
-            <button
-              key={i}
-              type="button"
-              onClick={() => setDay(i)}
-              className={cn(
-                'px-5 py-2 rounded-lg font-mono text-sm font-bold transition-colors',
-                day === i
-                  ? 'bg-primary text-primary-foreground'
-                  : 'bg-card/50 text-muted-foreground hover:bg-card/80 border border-border'
-              )}
-            >
-              {label}
-            </button>
-          ))}
-        </div>
-
-        {error && (
-          <div className="text-center py-8 border border-border rounded-lg bg-card/30">
-            <p className="text-sm font-mono text-orange-400">{error}</p>
-          </div>
-        )}
-
-        {/* Corridor Map */}
-        <div ref={ref} style={{ minHeight: '500px', contain: 'layout style paint' }}>
-          {inView ? (
-            <TravelCorridorMap
-              corridors={data?.corridors ?? []}
-              isLoading={isLoading}
-            />
-          ) : (
-            <MapSkeleton height="h-[500px]" />
-          )}
-        </div>
-
-        {/* Worst Corridors - hidden during error state */}
-        {!error && (
-          <WorstCorridors
-            corridors={data?.worstCorridors ?? []}
-            isLoading={isLoading}
-          />
-        )}
-
-        {/* Daily Outlook Images */}
-        <DailyOutlookImages />
-
-        {data?.fetchedAt && (
-          <p className="text-center text-xs font-mono text-muted-foreground">
-            Last updated: {new Date(data.fetchedAt).toLocaleTimeString()}
-          </p>
+      <div ref={ref} style={{ minHeight: '500px', contain: 'layout style paint' }}>
+        {inView ? (
+          <TravelCorridorMap corridors={data?.corridors ?? []} isLoading={isLoading} />
+        ) : (
+          <MapSkeleton height="h-[500px]" />
         )}
       </div>
-    </PageWrapper>
+
+      {!error && (
+        <WorstCorridors corridors={data?.worstCorridors ?? []} isLoading={isLoading} />
+      )}
+
+      <DailyOutlookImages />
+
+      {data?.fetchedAt && (
+        <p className="text-center text-xs font-mono text-muted-foreground">
+          Last updated: {new Date(data.fetchedAt).toLocaleTimeString()}
+        </p>
+      )}
+    </div>
   );
 }

--- a/app/travel/page.tsx
+++ b/app/travel/page.tsx
@@ -9,6 +9,7 @@
  */
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
+import Link from 'next/link';
 import { cn } from '@/lib/utils';
 import PageWrapper from '@/components/page-wrapper';
 import dynamic from 'next/dynamic';
@@ -127,12 +128,12 @@ function FlyContent() {
     <div className="space-y-8">
       <AirportMiseryBoard />
       <div className="text-center">
-        <a
+        <Link
           href="/aviation"
           className="inline-flex items-center gap-2 px-4 py-2 rounded border border-border bg-card/50 hover:bg-card font-mono text-xs uppercase tracking-wider text-muted-foreground hover:text-foreground transition-colors"
         >
           Open detail console (SIGMETs · turbulence · METARs) →
-        </a>
+        </Link>
       </div>
     </div>
   );

--- a/components/aviation/AirportMiseryBoard.tsx
+++ b/components/aviation/AirportMiseryBoard.tsx
@@ -1,0 +1,420 @@
+/**
+ * 16-Bit Weather Platform - Airport Misery Board
+ *
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ *
+ * Sortable retro terminal board ranking the top US hub airports by
+ * weather-driven delay risk (the unified "misery score"). Sits above the
+ * detail flight conditions terminal on /aviation.
+ */
+
+'use client';
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { AlertTriangle, ArrowDown, ArrowUp, Clock, Plane, RefreshCw } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { MiseryBadge, MiseryDriverList } from '@/components/ui/misery-badge';
+import type { MiseryScore } from '@/lib/services/misery-score-service';
+import type { MajorAirport } from '@/lib/data/major-us-airports';
+import type { MetarObservation } from '@/app/api/aviation/metar/route';
+
+interface AirportMiseryRow {
+  airport: MajorAirport;
+  score: MiseryScore;
+  metar?: MetarObservation;
+  isStale?: boolean;
+}
+
+interface AirportMiseryResponse {
+  airports: AirportMiseryRow[];
+  fetchedAt: string;
+}
+
+type SortKey = 'score' | 'iata' | 'city';
+type SortDir = 'asc' | 'desc';
+
+interface AirportMiseryBoardProps {
+  className?: string;
+}
+
+const REFRESH_INTERVAL_MS = 10 * 60 * 1000; // 10 minutes
+
+const FLIGHT_CATEGORY_COLOR: Record<string, string> = {
+  VFR: 'var(--severity-light)',
+  MVFR: 'var(--severity-moderate)',
+  IFR: 'var(--severity-severe)',
+  LIFR: 'var(--severity-extreme)',
+  UNKNOWN: 'var(--text)',
+};
+
+function formatTimeAgo(fetchedAt: string | null, now: number): string {
+  if (!fetchedAt) return '--';
+  const ms = now - new Date(fetchedAt).getTime();
+  if (!Number.isFinite(ms) || ms < 0) return 'just now';
+  const minutes = Math.floor(ms / 60000);
+  if (minutes < 1) return 'just now';
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  return `${hours}h ${minutes % 60}m ago`;
+}
+
+function compareRows(a: AirportMiseryRow, b: AirportMiseryRow, key: SortKey, dir: SortDir): number {
+  let cmp = 0;
+  if (key === 'score') {
+    cmp = a.score.score - b.score.score;
+  } else if (key === 'iata') {
+    cmp = a.airport.iata.localeCompare(b.airport.iata);
+  } else if (key === 'city') {
+    cmp = a.airport.city.localeCompare(b.airport.city);
+  }
+  return dir === 'asc' ? cmp : -cmp;
+}
+
+interface SortHeaderProps {
+  label: string;
+  active: boolean;
+  dir: SortDir;
+  onClick: () => void;
+  className?: string;
+}
+
+function SortHeader({ label, active, dir, onClick, className }: SortHeaderProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        'inline-flex items-center gap-1 font-mono text-xs uppercase tracking-wider hover:opacity-80 transition-opacity',
+        active && 'underline underline-offset-4',
+        className,
+      )}
+      aria-sort={active ? (dir === 'asc' ? 'ascending' : 'descending') : 'none'}
+    >
+      <span>{label}</span>
+      {active &&
+        (dir === 'asc' ? (
+          <ArrowUp className="w-3 h-3" aria-hidden="true" />
+        ) : (
+          <ArrowDown className="w-3 h-3" aria-hidden="true" />
+        ))}
+    </button>
+  );
+}
+
+function FlightCategoryChip({ category }: { category?: string }) {
+  const value = (category && category.toUpperCase()) || 'UNKNOWN';
+  const color = FLIGHT_CATEGORY_COLOR[value] ?? 'var(--text)';
+  return (
+    <span
+      className="inline-flex items-center px-1.5 py-0.5 font-mono text-[10px] tracking-wider border rounded"
+      style={{ color, borderColor: color, backgroundColor: `${color}1a` }}
+      title={`Flight category: ${value}`}
+    >
+      {value}
+    </span>
+  );
+}
+
+function SkeletonRow({ idx }: { idx: number }) {
+  return (
+    <tr className="border-t border-subtle">
+      <td className="px-3 py-3 font-mono text-xs opacity-60">{idx + 1}</td>
+      <td className="px-3 py-3">
+        <div className="h-4 w-24 bg-muted/40 animate-pulse rounded" />
+      </td>
+      <td className="px-3 py-3">
+        <div className="h-5 w-20 bg-muted/40 animate-pulse rounded" />
+      </td>
+      <td className="px-3 py-3">
+        <div className="h-4 w-40 bg-muted/40 animate-pulse rounded" />
+      </td>
+      <td className="px-3 py-3">
+        <div className="h-4 w-12 bg-muted/40 animate-pulse rounded" />
+      </td>
+    </tr>
+  );
+}
+
+export default function AirportMiseryBoard({ className }: AirportMiseryBoardProps) {
+  const [rows, setRows] = useState<AirportMiseryRow[]>([]);
+  const [fetchedAt, setFetchedAt] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [now, setNow] = useState<number>(() => Date.now());
+  const [sortKey, setSortKey] = useState<SortKey>('score');
+  const [sortDir, setSortDir] = useState<SortDir>('desc');
+
+  const load = useCallback(async (initial: boolean) => {
+    try {
+      if (initial) setIsLoading(true);
+      else setIsRefreshing(true);
+      const res = await fetch('/api/aviation/airport-misery', { cache: 'no-store' });
+      if (!res.ok) {
+        throw new Error(`Request failed (${res.status})`);
+      }
+      const data: AirportMiseryResponse = await res.json();
+      setRows(data.airports ?? []);
+      setFetchedAt(data.fetchedAt ?? new Date().toISOString());
+      setError(null);
+    } catch (err) {
+      console.error('[AirportMiseryBoard]', err);
+      setError('Unable to load airport misery board.');
+    } finally {
+      setIsLoading(false);
+      setIsRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load(true);
+    const interval = setInterval(() => load(false), REFRESH_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [load]);
+
+  useEffect(() => {
+    const tick = setInterval(() => setNow(Date.now()), 30000);
+    return () => clearInterval(tick);
+  }, []);
+
+  const sortedRows = useMemo(() => {
+    const copy = [...rows];
+    copy.sort((a, b) => compareRows(a, b, sortKey, sortDir));
+    return copy;
+  }, [rows, sortKey, sortDir]);
+
+  const toggleSort = (key: SortKey) => {
+    if (key === sortKey) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortKey(key);
+      setSortDir(key === 'score' ? 'desc' : 'asc');
+    }
+  };
+
+  const lastUpdated = formatTimeAgo(fetchedAt, now);
+
+  return (
+    <section
+      className={cn('container-primary', className)}
+      style={{ backgroundColor: 'var(--bg)' }}
+      aria-labelledby="airport-misery-heading"
+    >
+      {/* Header */}
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 px-4 py-3 border-b border-subtle">
+        <h2
+          id="airport-misery-heading"
+          className="flex items-center gap-2 font-mono text-lg font-bold uppercase tracking-wider"
+          style={{ color: 'var(--primary)' }}
+        >
+          <Plane className="w-5 h-5" aria-hidden="true" />
+          Airport Misery Board
+        </h2>
+        <div className="flex items-center gap-3 font-mono text-xs" style={{ color: 'var(--text)' }}>
+          <span className="inline-flex items-center gap-1 opacity-80">
+            <Clock className="w-3 h-3" aria-hidden="true" />
+            <span>Updated {lastUpdated}</span>
+          </span>
+          <button
+            type="button"
+            onClick={() => load(false)}
+            disabled={isLoading || isRefreshing}
+            className="inline-flex items-center gap-1 px-2 py-1 border border-border rounded hover:bg-muted/40 disabled:opacity-50 transition-colors"
+            aria-label="Refresh airport misery board"
+          >
+            <RefreshCw
+              className={cn('w-3 h-3', isRefreshing && 'animate-spin')}
+              aria-hidden="true"
+            />
+            <span>Refresh</span>
+          </button>
+        </div>
+      </div>
+
+      {/* Sub-header: sort controls (mobile-friendly) */}
+      <div className="flex flex-wrap items-center gap-3 px-4 py-2 border-b border-subtle font-mono text-xs uppercase tracking-wider opacity-80" style={{ color: 'var(--text)' }}>
+        <span>Sort:</span>
+        <SortHeader
+          label="Score"
+          active={sortKey === 'score'}
+          dir={sortDir}
+          onClick={() => toggleSort('score')}
+        />
+        <SortHeader
+          label="Code"
+          active={sortKey === 'iata'}
+          dir={sortDir}
+          onClick={() => toggleSort('iata')}
+        />
+        <SortHeader
+          label="City"
+          active={sortKey === 'city'}
+          dir={sortDir}
+          onClick={() => toggleSort('city')}
+        />
+      </div>
+
+      {/* Error state */}
+      {error && !isLoading && (
+        <div
+          className="m-4 p-4 border-4 font-mono text-sm flex items-start gap-2"
+          style={{
+            color: 'var(--severity-extreme)',
+            backgroundColor: 'var(--severity-extreme-bg)',
+            borderColor: 'var(--severity-extreme)',
+          }}
+          role="alert"
+          aria-live="polite"
+        >
+          <AlertTriangle className="w-4 h-4 mt-0.5 flex-shrink-0" aria-hidden="true" />
+          <div>
+            <div className="font-bold uppercase tracking-wider">Signal lost</div>
+            <div className="opacity-90">{error}</div>
+          </div>
+        </div>
+      )}
+
+      {/* Desktop table */}
+      <div className="hidden md:block overflow-x-auto">
+        <table className="w-full font-mono text-sm" role="table">
+          <thead>
+            <tr className="text-left" style={{ color: 'var(--text)' }}>
+              <th scope="col" className="px-3 py-2 text-xs uppercase tracking-wider opacity-80 w-12">
+                #
+              </th>
+              <th scope="col" className="px-3 py-2 text-xs uppercase tracking-wider opacity-80">
+                <SortHeader
+                  label="Airport"
+                  active={sortKey === 'iata' || sortKey === 'city'}
+                  dir={sortDir}
+                  onClick={() => toggleSort('iata')}
+                />
+              </th>
+              <th scope="col" className="px-3 py-2 text-xs uppercase tracking-wider opacity-80">
+                <SortHeader
+                  label="Score"
+                  active={sortKey === 'score'}
+                  dir={sortDir}
+                  onClick={() => toggleSort('score')}
+                />
+              </th>
+              <th scope="col" className="px-3 py-2 text-xs uppercase tracking-wider opacity-80">
+                Drivers
+              </th>
+              <th scope="col" className="px-3 py-2 text-xs uppercase tracking-wider opacity-80">
+                Cat
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {isLoading
+              ? Array.from({ length: 10 }).map((_, i) => <SkeletonRow key={i} idx={i} />)
+              : sortedRows.map((row, idx) => (
+                  <tr
+                    key={row.airport.icao}
+                    className={cn(
+                      'border-t border-subtle hover:bg-muted/30 transition-colors',
+                      row.isStale && 'opacity-70',
+                    )}
+                  >
+                    <td className="px-3 py-3 font-mono text-xs opacity-70 align-top">
+                      {idx + 1}
+                    </td>
+                    <td className="px-3 py-3 align-top">
+                      <div className="flex flex-col">
+                        <span
+                          className="font-bold tracking-wider"
+                          style={{ color: 'var(--primary)' }}
+                        >
+                          {row.airport.iata}
+                          <span className="ml-1 text-[10px] opacity-60">
+                            {row.airport.icao}
+                          </span>
+                        </span>
+                        <span className="text-xs opacity-80" style={{ color: 'var(--text)' }}>
+                          {row.airport.city}, {row.airport.state}
+                        </span>
+                      </div>
+                    </td>
+                    <td className="px-3 py-3 align-top">
+                      <MiseryBadge score={row.score} size="sm" />
+                      {row.isStale && (
+                        <div className="mt-1 text-[10px] uppercase tracking-wider opacity-60">
+                          stale
+                        </div>
+                      )}
+                    </td>
+                    <td className="px-3 py-3 align-top max-w-md">
+                      <MiseryDriverList score={row.score} />
+                    </td>
+                    <td className="px-3 py-3 align-top">
+                      <FlightCategoryChip category={row.metar?.flightCategory} />
+                    </td>
+                  </tr>
+                ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Mobile stacked cards */}
+      <div className="md:hidden divide-y divide-subtle">
+        {isLoading ? (
+          <div className="p-4 space-y-3">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div key={i} className="p-3 card-inner">
+                <div className="h-4 w-24 bg-muted/40 animate-pulse rounded mb-2" />
+                <div className="h-5 w-32 bg-muted/40 animate-pulse rounded mb-2" />
+                <div className="h-3 w-full bg-muted/40 animate-pulse rounded" />
+              </div>
+            ))}
+          </div>
+        ) : (
+          sortedRows.map((row, idx) => (
+            <div
+              key={row.airport.icao}
+              className={cn('p-4 space-y-2', row.isStale && 'opacity-70')}
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <div className="font-mono text-xs opacity-60">#{idx + 1}</div>
+                  <div
+                    className="font-mono font-bold text-base tracking-wider"
+                    style={{ color: 'var(--primary)' }}
+                  >
+                    {row.airport.iata}
+                    <span className="ml-1 text-[10px] opacity-60">{row.airport.icao}</span>
+                  </div>
+                  <div
+                    className="font-mono text-xs opacity-80"
+                    style={{ color: 'var(--text)' }}
+                  >
+                    {row.airport.city}, {row.airport.state}
+                  </div>
+                </div>
+                <div className="flex flex-col items-end gap-1">
+                  <MiseryBadge score={row.score} size="sm" />
+                  <FlightCategoryChip category={row.metar?.flightCategory} />
+                  {row.isStale && (
+                    <div className="text-[10px] uppercase tracking-wider opacity-60">
+                      stale
+                    </div>
+                  )}
+                </div>
+              </div>
+              <MiseryDriverList score={row.score} />
+            </div>
+          ))
+        )}
+      </div>
+
+      {/* Footer */}
+      <div
+        className="px-4 py-2 border-t border-subtle font-mono text-[10px] uppercase tracking-wider opacity-60 text-center"
+        style={{ color: 'var(--text)' }}
+      >
+        METAR + SIGMET/AIRMET via NOAA AWC. Misery score is illustrative; not for flight planning.
+      </div>
+    </section>
+  );
+}

--- a/components/aviation/AirportMiseryBoard.tsx
+++ b/components/aviation/AirportMiseryBoard.tsx
@@ -108,7 +108,11 @@ function FlightCategoryChip({ category }: { category?: string }) {
   return (
     <span
       className="inline-flex items-center px-1.5 py-0.5 font-mono text-[10px] tracking-wider border rounded"
-      style={{ color, borderColor: color, backgroundColor: `${color}1a` }}
+      style={{
+        color,
+        borderColor: color,
+        backgroundColor: `color-mix(in srgb, ${color} 10%, transparent)`,
+      }}
       title={`Flight category: ${value}`}
     >
       {value}

--- a/components/aviation/index.ts
+++ b/components/aviation/index.ts
@@ -12,3 +12,4 @@ export { default as TurbulenceMap } from './TurbulenceMap';
 export { default as FlightRouteLookup } from './FlightRouteLookup';
 export { default as FlightNumberInput } from './FlightNumberInput';
 export type { FlightData } from './FlightNumberInput';
+export { default as AirportMiseryBoard } from './AirportMiseryBoard';

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -18,7 +18,7 @@
 import { useState } from "react"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
-import { Menu, X, Home, Map, Plane, GraduationCap, Newspaper, Sun, ChevronDown, Cloud, AlertTriangle, CloudLightning, Snowflake, CloudRain, Route, Info, FileText, Star, Activity, BellRing } from "lucide-react"
+import { Menu, X, Home, Map, GraduationCap, Newspaper, Sun, ChevronDown, Cloud, AlertTriangle, CloudLightning, Snowflake, CloudRain, Route, Info, FileText, Star, Activity, BellRing } from "lucide-react"
 import { useTheme } from "@/components/theme-provider"
 import { getComponentStyles, type ThemeType } from "@/lib/theme-utils"
 import AuthButton from "@/components/auth/auth-button"
@@ -131,7 +131,6 @@ export default function Navigation({ weatherLocation, weatherTemperature, weathe
     { href: "/winter", label: "WINTER", icon: Snowflake },
     { href: "/tropical", label: "TROPICAL", icon: CloudRain },
     { href: "/travel", label: "TRAVEL", icon: Route },
-    { href: "/aviation", label: "AVIATION", icon: Plane },
     { href: "/space-weather", label: "SPACE", icon: Sun },
     { href: "/stargazer", label: "STARGAZER", icon: Star },
     { href: "/earth-sciences", label: "EARTH SCI", icon: Activity },

--- a/components/page-wrapper.tsx
+++ b/components/page-wrapper.tsx
@@ -53,6 +53,7 @@ export default function PageWrapper({ children, weatherLocation, weatherTemperat
               <nav className="flex flex-col gap-1.5">
                 <Link href="/radar" className="text-muted-foreground hover:text-foreground transition-colors">Radar</Link>
                 <Link href="/severe" className="text-muted-foreground hover:text-foreground transition-colors">Severe Weather</Link>
+                <Link href="/aviation" className="text-muted-foreground hover:text-foreground transition-colors">Aviation</Link>
                 <Link href="/space-weather" className="text-muted-foreground hover:text-foreground transition-colors">Space Weather</Link>
                 <Link href="/stargazer" className="text-muted-foreground hover:text-foreground transition-colors">Stargazer</Link>
                 <Link href="/tropical" className="text-muted-foreground hover:text-foreground transition-colors">Tropical</Link>

--- a/components/page-wrapper.tsx
+++ b/components/page-wrapper.tsx
@@ -53,7 +53,6 @@ export default function PageWrapper({ children, weatherLocation, weatherTemperat
               <nav className="flex flex-col gap-1.5">
                 <Link href="/radar" className="text-muted-foreground hover:text-foreground transition-colors">Radar</Link>
                 <Link href="/severe" className="text-muted-foreground hover:text-foreground transition-colors">Severe Weather</Link>
-                <Link href="/aviation" className="text-muted-foreground hover:text-foreground transition-colors">Aviation</Link>
                 <Link href="/space-weather" className="text-muted-foreground hover:text-foreground transition-colors">Space Weather</Link>
                 <Link href="/stargazer" className="text-muted-foreground hover:text-foreground transition-colors">Stargazer</Link>
                 <Link href="/tropical" className="text-muted-foreground hover:text-foreground transition-colors">Tropical</Link>

--- a/components/travel/TravelHub.tsx
+++ b/components/travel/TravelHub.tsx
@@ -1,0 +1,161 @@
+'use client';
+
+/**
+ * 16-Bit Weather Platform - Travel Hub
+ *
+ * Shell layout for the unified /travel page. Provides a Fly/Drive mode toggle,
+ * slots for Trip Input + Trip Result, and renders the active mode's content.
+ * Persists the selected mode in localStorage so the user's choice survives reloads.
+ */
+
+import { useEffect, useState } from 'react';
+import type { ReactNode } from 'react';
+import { Plane, Car } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+export type TravelHubMode = 'fly' | 'drive';
+
+export interface TravelHubProps {
+  tripInput?: ReactNode;
+  tripResult?: ReactNode;
+  flyContent: ReactNode;
+  driveContent: ReactNode;
+  defaultMode?: TravelHubMode;
+  className?: string;
+}
+
+const STORAGE_KEY = 'travel-hub-mode';
+
+function isTravelHubMode(value: unknown): value is TravelHubMode {
+  return value === 'fly' || value === 'drive';
+}
+
+export default function TravelHub({
+  tripInput,
+  tripResult,
+  flyContent,
+  driveContent,
+  defaultMode,
+  className,
+}: TravelHubProps) {
+  const initialMode: TravelHubMode = defaultMode ?? 'drive';
+  const [mode, setMode] = useState<TravelHubMode>(initialMode);
+
+  // Hydrate mode from localStorage after mount to avoid SSR mismatch.
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      const stored = window.localStorage.getItem(STORAGE_KEY);
+      if (isTravelHubMode(stored)) {
+        setMode(stored);
+      }
+    } catch {
+      // Ignore storage access errors (private mode, etc.)
+    }
+  }, []);
+
+  const handleModeChange = (next: TravelHubMode) => {
+    setMode(next);
+    if (typeof window === 'undefined') return;
+    try {
+      window.localStorage.setItem(STORAGE_KEY, next);
+    } catch {
+      // Ignore storage access errors.
+    }
+  };
+
+  return (
+    <div className={cn('space-y-8', className)}>
+      {/* Hub header */}
+      <div className="text-center space-y-2">
+        <h1 className="text-3xl md:text-4xl font-extrabold tracking-tight font-mono uppercase">
+          Travel Hub
+        </h1>
+        <p className="text-sm font-mono text-muted-foreground tracking-wider">
+          // WILL YOUR TRIP SUCK? PICK A MODE TO FIND OUT.
+        </p>
+      </div>
+
+      {/* Trip input slot */}
+      {tripInput && (
+        <>
+          <div className="border-t border-border" />
+          <div>{tripInput}</div>
+        </>
+      )}
+
+      {/* Trip result slot */}
+      {tripResult && (
+        <>
+          <div className="border-t border-border" />
+          <div>{tripResult}</div>
+        </>
+      )}
+
+      {/* Mode toggle */}
+      <div className="border-t border-border" />
+      <div
+        role="tablist"
+        aria-label="Travel mode"
+        className="flex flex-col md:flex-row gap-3 md:gap-4 justify-center items-stretch md:items-center"
+      >
+        <ModeButton
+          mode="fly"
+          active={mode === 'fly'}
+          onClick={() => handleModeChange('fly')}
+          icon={<Plane className="h-5 w-5" aria-hidden="true" />}
+          label="Fly"
+        />
+        <ModeButton
+          mode="drive"
+          active={mode === 'drive'}
+          onClick={() => handleModeChange('drive')}
+          icon={<Car className="h-5 w-5" aria-hidden="true" />}
+          label="Drive"
+        />
+      </div>
+
+      {/* Active mode content */}
+      <div className="border-t border-border" />
+      <div
+        role="tabpanel"
+        id={`travel-hub-panel-${mode}`}
+        aria-labelledby={`travel-hub-tab-${mode}`}
+      >
+        {mode === 'fly' ? flyContent : driveContent}
+      </div>
+    </div>
+  );
+}
+
+interface ModeButtonProps {
+  mode: TravelHubMode;
+  active: boolean;
+  onClick: () => void;
+  icon: ReactNode;
+  label: string;
+}
+
+function ModeButton({ mode, active, onClick, icon, label }: ModeButtonProps) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      id={`travel-hub-tab-${mode}`}
+      aria-selected={active}
+      aria-controls={`travel-hub-panel-${mode}`}
+      onClick={onClick}
+      className={cn(
+        'flex-1 md:flex-none md:min-w-[180px] inline-flex items-center justify-center gap-3',
+        'px-6 py-4 md:px-8 md:py-3 rounded-lg font-mono text-base font-bold uppercase tracking-wider',
+        'transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+        active
+          ? 'bg-primary text-primary-foreground border border-primary'
+          : 'bg-card text-foreground border border-border hover:bg-card/80'
+      )}
+    >
+      {icon}
+      <span>{label}</span>
+    </button>
+  );
+}

--- a/components/travel/TripInput.tsx
+++ b/components/travel/TripInput.tsx
@@ -1,0 +1,363 @@
+/**
+ * TripInput - origin/destination + mode + day selector for the trip planner.
+ *
+ * Submits to /api/travel/trip-score and lifts the parsed `TripScoreResponse`
+ * via callback. Autocomplete is sourced from MAJOR_US_AIRPORTS; in drive mode
+ * a small set of major US cities is appended for convenience.
+ */
+
+'use client';
+
+import React, { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
+import { Plane, Car, Search, AlertTriangle, MapPin } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { MAJOR_US_AIRPORTS } from '@/lib/data/major-us-airports';
+import type { TripDay, TripMode, TripScoreResponse } from './trip-types';
+
+export type { TripScoreResponse } from './trip-types';
+
+interface TripInputProps {
+  defaultMode?: TripMode;
+  defaultDay?: TripDay;
+  onResult: (result: TripScoreResponse) => void;
+  onLoadingChange?: (loading: boolean) => void;
+  onError?: (error: string) => void;
+  className?: string;
+}
+
+const DAY_LABELS: Record<TripDay, string> = {
+  0: 'Today',
+  1: 'Tomorrow',
+  2: 'Day 3',
+};
+
+const DAYS: TripDay[] = [0, 1, 2];
+
+/**
+ * Lightweight set of additional drive-mode destinations. Keep this small —
+ * the airport list is the canonical autocomplete; cities are just a convenience.
+ */
+const MAJOR_US_CITIES: Array<{ city: string; state: string }> = [
+  { city: 'Atlanta', state: 'GA' },
+  { city: 'Austin', state: 'TX' },
+  { city: 'Boston', state: 'MA' },
+  { city: 'Chicago', state: 'IL' },
+  { city: 'Dallas', state: 'TX' },
+  { city: 'Denver', state: 'CO' },
+  { city: 'Detroit', state: 'MI' },
+  { city: 'Houston', state: 'TX' },
+  { city: 'Indianapolis', state: 'IN' },
+  { city: 'Kansas City', state: 'MO' },
+  { city: 'Las Vegas', state: 'NV' },
+  { city: 'Los Angeles', state: 'CA' },
+  { city: 'Memphis', state: 'TN' },
+  { city: 'Miami', state: 'FL' },
+  { city: 'Minneapolis', state: 'MN' },
+  { city: 'Nashville', state: 'TN' },
+  { city: 'New Orleans', state: 'LA' },
+  { city: 'New York', state: 'NY' },
+  { city: 'Oklahoma City', state: 'OK' },
+  { city: 'Omaha', state: 'NE' },
+  { city: 'Philadelphia', state: 'PA' },
+  { city: 'Phoenix', state: 'AZ' },
+  { city: 'Pittsburgh', state: 'PA' },
+  { city: 'Portland', state: 'OR' },
+  { city: 'Salt Lake City', state: 'UT' },
+  { city: 'San Antonio', state: 'TX' },
+  { city: 'San Diego', state: 'CA' },
+  { city: 'San Francisco', state: 'CA' },
+  { city: 'Seattle', state: 'WA' },
+  { city: 'St. Louis', state: 'MO' },
+  { city: 'Tampa', state: 'FL' },
+  { city: 'Washington', state: 'DC' },
+];
+
+interface AutocompleteOption {
+  value: string;
+  label: string;
+}
+
+function buildAutocompleteOptions(mode: TripMode): AutocompleteOption[] {
+  const airportOptions: AutocompleteOption[] = MAJOR_US_AIRPORTS.map((a) => ({
+    value: `${a.iata} — ${a.city}, ${a.state}`,
+    label: `${a.iata} — ${a.city}, ${a.state}`,
+  }));
+
+  if (mode === 'fly') return airportOptions;
+
+  const cityOptions: AutocompleteOption[] = MAJOR_US_CITIES.map((c) => ({
+    value: `${c.city}, ${c.state}`,
+    label: `${c.city}, ${c.state}`,
+  }));
+
+  // De-dupe on value so airport-city overlap doesn't render twice.
+  const seen = new Set<string>();
+  return [...airportOptions, ...cityOptions].filter((opt) => {
+    if (seen.has(opt.value)) return false;
+    seen.add(opt.value);
+    return true;
+  });
+}
+
+export default function TripInput({
+  defaultMode = 'fly',
+  defaultDay = 0,
+  onResult,
+  onLoadingChange,
+  onError,
+  className,
+}: TripInputProps) {
+  const [mode, setMode] = useState<TripMode>(defaultMode);
+  const [day, setDay] = useState<TripDay>(defaultDay);
+  const [origin, setOrigin] = useState('');
+  const [destination, setDestination] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const abortRef = useRef<AbortController | null>(null);
+  const reactId = useId();
+  const datalistId = `trip-input-options-${reactId}`;
+
+  const options = useMemo(() => buildAutocompleteOptions(mode), [mode]);
+
+  // Tear down any in-flight request when the component unmounts.
+  useEffect(() => {
+    return () => abortRef.current?.abort();
+  }, []);
+
+  const setLoading = useCallback(
+    (value: boolean) => {
+      setIsLoading(value);
+      onLoadingChange?.(value);
+    },
+    [onLoadingChange],
+  );
+
+  const reportError = useCallback(
+    (message: string) => {
+      setError(message);
+      onError?.(message);
+    },
+    [onError],
+  );
+
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      const o = origin.trim();
+      const d = destination.trim();
+      if (!o || !d) {
+        reportError('Enter both an origin and a destination.');
+        return;
+      }
+
+      // Cancel any prior request before starting a new one.
+      abortRef.current?.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      setError(null);
+      setLoading(true);
+      try {
+        const params = new URLSearchParams({
+          origin: o,
+          destination: d,
+          mode,
+          day: String(day),
+        });
+        const res = await fetch(`/api/travel/trip-score?${params.toString()}`, {
+          signal: controller.signal,
+        });
+        const payload = (await res.json().catch(() => null)) as
+          | TripScoreResponse
+          | { error?: string }
+          | null;
+
+        if (controller.signal.aborted) return;
+
+        if (!res.ok || !payload || 'error' in payload) {
+          const message =
+            (payload && 'error' in payload && payload.error) ||
+            `Trip lookup failed (${res.status})`;
+          reportError(message);
+          return;
+        }
+
+        onResult(payload as TripScoreResponse);
+      } catch (err) {
+        if (controller.signal.aborted) return;
+        console.error('[TripInput]', err);
+        reportError('Unable to score this trip. Please try again.');
+      } finally {
+        if (!controller.signal.aborted) {
+          setLoading(false);
+        }
+      }
+    },
+    [origin, destination, mode, day, onResult, reportError, setLoading],
+  );
+
+  const canSubmit = !isLoading && origin.trim().length > 0 && destination.trim().length > 0;
+
+  return (
+    <div className={cn('space-y-3', className)}>
+      {/* Mode toggle */}
+      <div
+        className="inline-flex rounded border-2 border-border overflow-hidden font-mono text-sm"
+        role="tablist"
+        aria-label="Trip mode"
+      >
+        {(['fly', 'drive'] as const).map((m) => {
+          const active = mode === m;
+          return (
+            <button
+              key={m}
+              type="button"
+              role="tab"
+              aria-selected={active}
+              onClick={() => setMode(m)}
+              className={cn(
+                'flex items-center gap-2 px-4 py-2 font-bold uppercase tracking-wider transition-colors',
+                active
+                  ? 'bg-primary text-primary-foreground'
+                  : 'bg-card/50 text-muted-foreground hover:bg-card/80',
+              )}
+              data-testid={`trip-mode-${m}`}
+            >
+              {m === 'fly' ? <Plane className="w-4 h-4" /> : <Car className="w-4 h-4" />}
+              {m === 'fly' ? 'Fly' : 'Drive'}
+            </button>
+          );
+        })}
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-3">
+        {/* Origin / destination inputs */}
+        <div className="grid grid-cols-1 md:grid-cols-[1fr_1fr_auto] gap-2">
+          <div className="relative">
+            <MapPin className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+            <input
+              type="text"
+              value={origin}
+              onChange={(e) => {
+                setOrigin(e.target.value);
+                if (error) setError(null);
+              }}
+              placeholder={mode === 'fly' ? 'Origin airport (e.g. ATL)' : 'Origin city or airport'}
+              list={datalistId}
+              disabled={isLoading}
+              autoComplete="off"
+              spellCheck={false}
+              className={cn(
+                'w-full pl-10 pr-3 py-2 font-mono text-sm border-2 rounded bg-card border-border',
+                'focus:outline-none focus:ring-2 focus:ring-primary',
+                'placeholder:text-muted-foreground',
+                isLoading && 'opacity-50 cursor-not-allowed',
+              )}
+              data-testid="trip-origin-input"
+              aria-label="Origin"
+            />
+          </div>
+
+          <div className="relative">
+            <MapPin className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+            <input
+              type="text"
+              value={destination}
+              onChange={(e) => {
+                setDestination(e.target.value);
+                if (error) setError(null);
+              }}
+              placeholder={
+                mode === 'fly' ? 'Destination airport (e.g. DEN)' : 'Destination city or airport'
+              }
+              list={datalistId}
+              disabled={isLoading}
+              autoComplete="off"
+              spellCheck={false}
+              className={cn(
+                'w-full pl-10 pr-3 py-2 font-mono text-sm border-2 rounded bg-card border-border',
+                'focus:outline-none focus:ring-2 focus:ring-primary',
+                'placeholder:text-muted-foreground',
+                isLoading && 'opacity-50 cursor-not-allowed',
+              )}
+              data-testid="trip-destination-input"
+              aria-label="Destination"
+            />
+          </div>
+
+          <button
+            type="submit"
+            disabled={!canSubmit}
+            className={cn(
+              'flex items-center justify-center gap-2 px-5 py-2 font-mono text-sm font-bold border-2 rounded uppercase tracking-wider transition-colors',
+              'border-border min-w-[120px]',
+              canSubmit
+                ? 'bg-primary text-primary-foreground hover:opacity-90'
+                : 'bg-muted text-muted-foreground opacity-50 cursor-not-allowed',
+            )}
+            data-testid="trip-submit"
+            aria-label="Plan trip"
+          >
+            <Search className="w-4 h-4" aria-hidden="true" />
+            {isLoading ? 'Scoring…' : 'Plan Trip'}
+          </button>
+        </div>
+
+        {/* Day selector */}
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-xs font-mono uppercase tracking-wider text-muted-foreground">
+            When:
+          </span>
+          {DAYS.map((d) => {
+            const active = day === d;
+            return (
+              <button
+                key={d}
+                type="button"
+                onClick={() => setDay(d)}
+                className={cn(
+                  'px-3 py-1 rounded font-mono text-xs font-bold uppercase tracking-wider transition-colors border',
+                  active
+                    ? 'bg-primary text-primary-foreground border-primary'
+                    : 'bg-card/50 text-muted-foreground hover:bg-card/80 border-border',
+                )}
+                aria-pressed={active}
+                data-testid={`trip-day-${d}`}
+              >
+                {DAY_LABELS[d]}
+              </button>
+            );
+          })}
+        </div>
+      </form>
+
+      {/* Datalist (shared between both inputs) */}
+      <datalist id={datalistId}>
+        {options.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </datalist>
+
+      {/* Error */}
+      {error && (
+        <div
+          className="flex items-center gap-2 p-2 text-xs font-mono rounded border"
+          style={{
+            color: 'var(--severity-extreme)',
+            backgroundColor: 'var(--severity-extreme-bg)',
+            borderColor: 'var(--severity-extreme)',
+          }}
+          role="alert"
+          aria-live="polite"
+          data-testid="trip-input-error"
+        >
+          <AlertTriangle className="w-3 h-3 flex-shrink-0" aria-hidden="true" />
+          <span>{error}</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/travel/TripScoreCard.tsx
+++ b/components/travel/TripScoreCard.tsx
@@ -1,0 +1,295 @@
+/**
+ * TripScoreCard - renders the unified misery score for a planned trip.
+ *
+ * Handles both `fly` and `drive` shapes from /api/travel/trip-score:
+ * - Drive: corridor name + worst-stretch callout + optional peak-misery window.
+ * - Fly: origin / en-route / destination sub-cards.
+ */
+
+'use client';
+
+import React from 'react';
+import { Plane, Car, AlertTriangle, Clock, MapPin } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { MiseryBadge, MiseryDriverList } from '@/components/ui/misery-badge';
+import type {
+  DriveTripScore,
+  FlyTripScore,
+  TripScoreResponse,
+} from './trip-types';
+
+interface TripScoreCardProps {
+  result: TripScoreResponse;
+  isLoading?: boolean;
+  className?: string;
+}
+
+export default function TripScoreCard({
+  result,
+  isLoading = false,
+  className,
+}: TripScoreCardProps) {
+  if (isLoading) {
+    return <TripScoreCardSkeleton className={className} />;
+  }
+
+  return (
+    <div
+      className={cn(
+        'rounded-lg border border-border bg-card/50 p-4 md:p-6 space-y-5',
+        className,
+      )}
+      data-testid="trip-score-card"
+    >
+      {result.mode === 'drive' ? (
+        <DriveBody result={result} />
+      ) : (
+        <FlyBody result={result} />
+      )}
+    </div>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Drive                                                                       */
+/* -------------------------------------------------------------------------- */
+
+function DriveBody({ result }: { result: DriveTripScore }) {
+  const { score, route, worstSegment, peakWindow } = result;
+
+  return (
+    <>
+      <header className="flex flex-col md:flex-row md:items-center md:justify-between gap-3">
+        <div className="flex items-center gap-3 min-w-0">
+          <Car className="w-5 h-5 text-muted-foreground shrink-0" aria-hidden="true" />
+          <div className="min-w-0">
+            <p className="text-[10px] font-mono uppercase tracking-wider text-muted-foreground">
+              Drive
+            </p>
+            <h3
+              className="font-mono font-bold text-lg md:text-xl truncate"
+              title={route.corridorName}
+            >
+              {route.corridorName}
+            </h3>
+          </div>
+        </div>
+        <MiseryBadge score={score} size="lg" />
+      </header>
+
+      <div>
+        <p className="text-xs font-mono uppercase tracking-wider text-muted-foreground mb-2">
+          Top drivers
+        </p>
+        <MiseryDriverList score={score} />
+      </div>
+
+      <WorstStretchCallout segment={worstSegment} />
+
+      {peakWindow && (
+        <div
+          className="flex items-center gap-2 text-xs font-mono text-muted-foreground border-t border-border pt-3"
+          data-testid="trip-peak-window"
+        >
+          <Clock className="w-3.5 h-3.5" aria-hidden="true" />
+          <span className="uppercase tracking-wider">Peak misery:</span>
+          <span className="text-foreground font-bold">
+            {formatPeakWindow(peakWindow.startISO, peakWindow.endISO)}
+          </span>
+        </div>
+      )}
+    </>
+  );
+}
+
+function WorstStretchCallout({
+  segment,
+}: {
+  segment: DriveTripScore['worstSegment'];
+}) {
+  const place = segment.nearestPlace?.trim();
+  return (
+    <div
+      className="flex items-start gap-3 rounded border border-border bg-card/40 p-3"
+      data-testid="trip-worst-segment"
+    >
+      <AlertTriangle
+        className="w-4 h-4 mt-0.5 shrink-0"
+        style={{ color: 'var(--severity-extreme)' }}
+        aria-hidden="true"
+      />
+      <div className="flex-1 min-w-0 space-y-1">
+        <p className="text-[10px] font-mono uppercase tracking-wider text-muted-foreground">
+          Worst stretch
+        </p>
+        <p className="font-mono text-sm font-bold">
+          {segment.hazard}
+          {place && (
+            <>
+              <span className="text-muted-foreground"> — near </span>
+              {place}
+            </>
+          )}
+        </p>
+        <p className="text-[11px] font-mono text-muted-foreground">
+          {segment.lat.toFixed(2)}°, {segment.lon.toFixed(2)}°
+        </p>
+      </div>
+      <MiseryBadge score={segment.score} size="sm" />
+    </div>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Fly                                                                         */
+/* -------------------------------------------------------------------------- */
+
+function FlyBody({ result }: { result: FlyTripScore }) {
+  const { score, route } = result;
+  const routeSummary = `${route.origin.airport.iata} → ${route.destination.airport.iata}`;
+
+  return (
+    <>
+      <header className="flex flex-col md:flex-row md:items-center md:justify-between gap-3">
+        <div className="flex items-center gap-3 min-w-0">
+          <Plane className="w-5 h-5 text-muted-foreground shrink-0" aria-hidden="true" />
+          <div className="min-w-0">
+            <p className="text-[10px] font-mono uppercase tracking-wider text-muted-foreground">
+              Fly
+            </p>
+            <h3 className="font-mono font-bold text-lg md:text-xl">
+              {routeSummary}
+            </h3>
+            <p className="text-xs font-mono text-muted-foreground truncate">
+              {route.origin.airport.city} to {route.destination.airport.city}
+            </p>
+          </div>
+        </div>
+        <MiseryBadge score={score} size="lg" />
+      </header>
+
+      <div>
+        <p className="text-xs font-mono uppercase tracking-wider text-muted-foreground mb-2">
+          Top drivers
+        </p>
+        <MiseryDriverList score={score} />
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-2">
+        <FlyLegCard
+          label="Origin"
+          primary={route.origin.airport.iata}
+          secondary={route.origin.airport.city}
+          score={route.origin.score}
+        />
+        <FlyLegCard
+          label="En-route"
+          primary="Midpoint"
+          secondary={`${route.enroute.midpoint.lat.toFixed(2)}°, ${route.enroute.midpoint.lon.toFixed(2)}°`}
+          score={route.enroute.score}
+        />
+        <FlyLegCard
+          label="Destination"
+          primary={route.destination.airport.iata}
+          secondary={route.destination.airport.city}
+          score={route.destination.score}
+        />
+      </div>
+    </>
+  );
+}
+
+function FlyLegCard({
+  label,
+  primary,
+  secondary,
+  score,
+}: {
+  label: string;
+  primary: string;
+  secondary: string;
+  score: FlyTripScore['route']['origin']['score'];
+}) {
+  return (
+    <div
+      className="rounded border border-border bg-card/40 p-3 space-y-2"
+      data-testid={`trip-fly-leg-${label.toLowerCase()}`}
+    >
+      <div className="flex items-center gap-1.5 text-[10px] font-mono uppercase tracking-wider text-muted-foreground">
+        <MapPin className="w-3 h-3" aria-hidden="true" />
+        {label}
+      </div>
+      <div className="font-mono">
+        <p className="text-sm font-bold leading-tight">{primary}</p>
+        <p className="text-[11px] text-muted-foreground truncate" title={secondary}>
+          {secondary}
+        </p>
+      </div>
+      <MiseryBadge score={score} size="sm" />
+    </div>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Helpers                                                                     */
+/* -------------------------------------------------------------------------- */
+
+function formatPeakWindow(startISO: string, endISO: string): string {
+  const start = new Date(startISO);
+  const end = new Date(endISO);
+  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
+    return `${startISO} – ${endISO}`;
+  }
+
+  const sameDay =
+    start.getFullYear() === end.getFullYear() &&
+    start.getMonth() === end.getMonth() &&
+    start.getDate() === end.getDate();
+
+  const timeFmt: Intl.DateTimeFormatOptions = { hour: 'numeric', minute: '2-digit' };
+  const dayFmt: Intl.DateTimeFormatOptions = { weekday: 'short', month: 'short', day: 'numeric' };
+
+  if (sameDay) {
+    return `${start.toLocaleDateString(undefined, dayFmt)} ${start.toLocaleTimeString(
+      undefined,
+      timeFmt,
+    )} – ${end.toLocaleTimeString(undefined, timeFmt)}`;
+  }
+  return `${start.toLocaleDateString(undefined, dayFmt)} ${start.toLocaleTimeString(
+    undefined,
+    timeFmt,
+  )} – ${end.toLocaleDateString(undefined, dayFmt)} ${end.toLocaleTimeString(
+    undefined,
+    timeFmt,
+  )}`;
+}
+
+function TripScoreCardSkeleton({ className }: { className?: string }) {
+  return (
+    <div
+      className={cn(
+        'rounded-lg border border-border bg-card/50 p-4 md:p-6 space-y-5 animate-pulse',
+        className,
+      )}
+      data-testid="trip-score-card-skeleton"
+      aria-busy="true"
+    >
+      <div className="flex items-center justify-between gap-3">
+        <div className="space-y-2">
+          <div className="h-3 w-16 rounded bg-muted/60" />
+          <div className="h-6 w-48 rounded bg-muted/60" />
+        </div>
+        <div className="h-9 w-24 rounded bg-muted/60" />
+      </div>
+      <div className="space-y-2">
+        <div className="h-3 w-24 rounded bg-muted/60" />
+        <div className="flex gap-1.5">
+          <div className="h-5 w-20 rounded bg-muted/60" />
+          <div className="h-5 w-24 rounded bg-muted/60" />
+          <div className="h-5 w-16 rounded bg-muted/60" />
+        </div>
+      </div>
+      <div className="h-16 rounded bg-muted/60" />
+    </div>
+  );
+}

--- a/components/travel/trip-types.ts
+++ b/components/travel/trip-types.ts
@@ -1,0 +1,56 @@
+/**
+ * Shared types for the Trip Planner UI.
+ *
+ * The `/api/travel/trip-score` endpoint returns one of two discriminated shapes
+ * depending on `mode`. These types let `<TripInput>`, `<TripScoreCard>`, and any
+ * future trip widgets agree on the response contract without re-declaring it.
+ */
+
+import type { MiseryScore } from '@/lib/services/misery-score-service';
+
+export type TripMode = 'fly' | 'drive';
+export type TripDay = 0 | 1 | 2;
+
+export interface DriveSegment {
+  lat: number;
+  lon: number;
+  score: MiseryScore;
+  hazard: string;
+}
+
+export interface DriveWorstSegment extends DriveSegment {
+  nearestPlace?: string;
+}
+
+export interface DrivePeakWindow {
+  startISO: string;
+  endISO: string;
+}
+
+export interface DriveTripScore {
+  mode: 'drive';
+  score: MiseryScore;
+  route: {
+    corridorName: string;
+    segments: DriveSegment[];
+  };
+  worstSegment: DriveWorstSegment;
+  peakWindow?: DrivePeakWindow;
+}
+
+export interface FlyAirportInfo {
+  iata: string;
+  city: string;
+}
+
+export interface FlyTripScore {
+  mode: 'fly';
+  score: MiseryScore;
+  route: {
+    origin: { airport: FlyAirportInfo; score: MiseryScore };
+    destination: { airport: FlyAirportInfo; score: MiseryScore };
+    enroute: { score: MiseryScore; midpoint: { lat: number; lon: number } };
+  };
+}
+
+export type TripScoreResponse = DriveTripScore | FlyTripScore;

--- a/components/travel/trip-types.ts
+++ b/components/travel/trip-types.ts
@@ -27,12 +27,20 @@ export interface DrivePeakWindow {
   endISO: string;
 }
 
+export interface TripEndpointPoint {
+  lat: number;
+  lon: number;
+  label?: string;
+}
+
 export interface DriveTripScore {
   mode: 'drive';
   score: MiseryScore;
   route: {
     corridorName: string;
     segments: DriveSegment[];
+    origin?: TripEndpointPoint;
+    destination?: TripEndpointPoint;
   };
   worstSegment: DriveWorstSegment;
   peakWindow?: DrivePeakWindow;

--- a/components/ui/misery-badge.tsx
+++ b/components/ui/misery-badge.tsx
@@ -1,0 +1,81 @@
+/**
+ * MiseryBadge - shared visual badge for the unified 0–100 misery score.
+ * Used on the airport board, trip score card, and corridor list.
+ */
+
+'use client';
+
+import React from 'react';
+import { cn } from '@/lib/utils';
+import {
+  MISERY_LEVEL_DESCRIPTIONS,
+  type MiseryScore,
+} from '@/lib/services/misery-score-service';
+
+interface MiseryBadgeProps {
+  score: MiseryScore;
+  size?: 'sm' | 'md' | 'lg';
+  showLabel?: boolean;
+  className?: string;
+}
+
+const SIZE_CLASSES = {
+  sm: 'text-xs px-2 py-0.5 gap-1',
+  md: 'text-sm px-2.5 py-1 gap-1.5',
+  lg: 'text-base px-3 py-1.5 gap-2',
+};
+
+export function MiseryBadge({
+  score,
+  size = 'md',
+  showLabel = true,
+  className,
+}: MiseryBadgeProps) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center font-mono font-bold rounded border-2 uppercase tracking-wider',
+        SIZE_CLASSES[size],
+        className,
+      )}
+      style={{
+        color: score.color,
+        borderColor: score.color,
+        backgroundColor: `${score.color}1a`,
+      }}
+      title={MISERY_LEVEL_DESCRIPTIONS[score.level]}
+      aria-label={`Misery score ${score.score} of 100, ${score.label}`}
+    >
+      <span>{score.score}</span>
+      {showLabel && <span>{score.label}</span>}
+    </span>
+  );
+}
+
+interface MiseryDriverListProps {
+  score: MiseryScore;
+  className?: string;
+}
+
+export function MiseryDriverList({ score, className }: MiseryDriverListProps) {
+  if (score.drivers.length === 0) {
+    return (
+      <p className={cn('text-xs font-mono text-muted-foreground', className)}>
+        No significant weather impacts
+      </p>
+    );
+  }
+
+  return (
+    <ul className={cn('flex flex-wrap gap-1.5 text-xs font-mono', className)}>
+      {score.drivers.map((driver) => (
+        <li
+          key={driver.label}
+          className="px-1.5 py-0.5 rounded border border-border bg-card/50 text-muted-foreground"
+        >
+          {driver.label}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/lib/data/major-us-airports.ts
+++ b/lib/data/major-us-airports.ts
@@ -1,0 +1,65 @@
+/**
+ * Top US hub airports for the airport misery board.
+ * Coordinates used to fetch nearest-station METAR-equivalent data and to
+ * intersect with SIGMET regions.
+ */
+
+export interface MajorAirport {
+  iata: string;
+  icao: string;
+  name: string;
+  city: string;
+  state: string;
+  lat: number;
+  lon: number;
+  tzOffset: number;
+}
+
+export const MAJOR_US_AIRPORTS: MajorAirport[] = [
+  { iata: 'ATL', icao: 'KATL', name: 'Hartsfield-Jackson Atlanta', city: 'Atlanta', state: 'GA', lat: 33.6407, lon: -84.4277, tzOffset: -5 },
+  { iata: 'DFW', icao: 'KDFW', name: 'Dallas/Fort Worth', city: 'Dallas', state: 'TX', lat: 32.8998, lon: -97.0403, tzOffset: -6 },
+  { iata: 'DEN', icao: 'KDEN', name: 'Denver International', city: 'Denver', state: 'CO', lat: 39.8561, lon: -104.6737, tzOffset: -7 },
+  { iata: 'ORD', icao: 'KORD', name: "Chicago O'Hare", city: 'Chicago', state: 'IL', lat: 41.9742, lon: -87.9073, tzOffset: -6 },
+  { iata: 'LAX', icao: 'KLAX', name: 'Los Angeles International', city: 'Los Angeles', state: 'CA', lat: 33.9416, lon: -118.4085, tzOffset: -8 },
+  { iata: 'JFK', icao: 'KJFK', name: 'John F. Kennedy International', city: 'New York', state: 'NY', lat: 40.6413, lon: -73.7781, tzOffset: -5 },
+  { iata: 'LAS', icao: 'KLAS', name: 'Harry Reid International', city: 'Las Vegas', state: 'NV', lat: 36.0840, lon: -115.1537, tzOffset: -8 },
+  { iata: 'MCO', icao: 'KMCO', name: 'Orlando International', city: 'Orlando', state: 'FL', lat: 28.4312, lon: -81.3081, tzOffset: -5 },
+  { iata: 'CLT', icao: 'KCLT', name: 'Charlotte Douglas', city: 'Charlotte', state: 'NC', lat: 35.2140, lon: -80.9431, tzOffset: -5 },
+  { iata: 'MIA', icao: 'KMIA', name: 'Miami International', city: 'Miami', state: 'FL', lat: 25.7959, lon: -80.2870, tzOffset: -5 },
+  { iata: 'SEA', icao: 'KSEA', name: 'Seattle-Tacoma', city: 'Seattle', state: 'WA', lat: 47.4502, lon: -122.3088, tzOffset: -8 },
+  { iata: 'PHX', icao: 'KPHX', name: 'Phoenix Sky Harbor', city: 'Phoenix', state: 'AZ', lat: 33.4342, lon: -112.0116, tzOffset: -7 },
+  { iata: 'EWR', icao: 'KEWR', name: 'Newark Liberty', city: 'Newark', state: 'NJ', lat: 40.6895, lon: -74.1745, tzOffset: -5 },
+  { iata: 'SFO', icao: 'KSFO', name: 'San Francisco International', city: 'San Francisco', state: 'CA', lat: 37.6213, lon: -122.3790, tzOffset: -8 },
+  { iata: 'IAH', icao: 'KIAH', name: 'Houston Intercontinental', city: 'Houston', state: 'TX', lat: 29.9844, lon: -95.3414, tzOffset: -6 },
+  { iata: 'BOS', icao: 'KBOS', name: 'Boston Logan', city: 'Boston', state: 'MA', lat: 42.3656, lon: -71.0096, tzOffset: -5 },
+  { iata: 'MSP', icao: 'KMSP', name: 'Minneapolis-St Paul', city: 'Minneapolis', state: 'MN', lat: 44.8848, lon: -93.2223, tzOffset: -6 },
+  { iata: 'FLL', icao: 'KFLL', name: 'Fort Lauderdale-Hollywood', city: 'Fort Lauderdale', state: 'FL', lat: 26.0726, lon: -80.1527, tzOffset: -5 },
+  { iata: 'DTW', icao: 'KDTW', name: 'Detroit Metropolitan', city: 'Detroit', state: 'MI', lat: 42.2162, lon: -83.3554, tzOffset: -5 },
+  { iata: 'PHL', icao: 'KPHL', name: 'Philadelphia International', city: 'Philadelphia', state: 'PA', lat: 39.8744, lon: -75.2424, tzOffset: -5 },
+  { iata: 'LGA', icao: 'KLGA', name: 'LaGuardia', city: 'New York', state: 'NY', lat: 40.7769, lon: -73.8740, tzOffset: -5 },
+  { iata: 'BWI', icao: 'KBWI', name: 'Baltimore/Washington', city: 'Baltimore', state: 'MD', lat: 39.1774, lon: -76.6684, tzOffset: -5 },
+  { iata: 'SLC', icao: 'KSLC', name: 'Salt Lake City', city: 'Salt Lake City', state: 'UT', lat: 40.7899, lon: -111.9791, tzOffset: -7 },
+  { iata: 'DCA', icao: 'KDCA', name: 'Reagan Washington National', city: 'Washington', state: 'DC', lat: 38.8512, lon: -77.0402, tzOffset: -5 },
+  { iata: 'MDW', icao: 'KMDW', name: 'Chicago Midway', city: 'Chicago', state: 'IL', lat: 41.7868, lon: -87.7522, tzOffset: -6 },
+  { iata: 'IAD', icao: 'KIAD', name: 'Washington Dulles', city: 'Washington', state: 'DC', lat: 38.9531, lon: -77.4565, tzOffset: -5 },
+  { iata: 'SAN', icao: 'KSAN', name: 'San Diego International', city: 'San Diego', state: 'CA', lat: 32.7338, lon: -117.1933, tzOffset: -8 },
+  { iata: 'TPA', icao: 'KTPA', name: 'Tampa International', city: 'Tampa', state: 'FL', lat: 27.9755, lon: -82.5332, tzOffset: -5 },
+  { iata: 'PDX', icao: 'KPDX', name: 'Portland International', city: 'Portland', state: 'OR', lat: 45.5898, lon: -122.5951, tzOffset: -8 },
+  { iata: 'AUS', icao: 'KAUS', name: 'Austin-Bergstrom', city: 'Austin', state: 'TX', lat: 30.1945, lon: -97.6699, tzOffset: -6 },
+];
+
+export function findAirportByCode(code: string): MajorAirport | undefined {
+  const upper = code.trim().toUpperCase();
+  return MAJOR_US_AIRPORTS.find(
+    (a) => a.iata === upper || a.icao === upper,
+  );
+}
+
+export function findAirportByCity(query: string): MajorAirport | undefined {
+  const lower = query.trim().toLowerCase();
+  return MAJOR_US_AIRPORTS.find(
+    (a) =>
+      a.city.toLowerCase() === lower ||
+      a.name.toLowerCase().includes(lower),
+  );
+}

--- a/lib/services/misery-score-service.ts
+++ b/lib/services/misery-score-service.ts
@@ -1,0 +1,279 @@
+/**
+ * Misery Score Service
+ *
+ * Unified "will this trip suck?" scoring used by both aviation (airport delay risk)
+ * and travel (driving conditions). Reuses the existing SeverityLevel / 0–100 scale
+ * from travel-corridor-service so badges and colors stay consistent across the app.
+ */
+
+import {
+  getSeverityLevel,
+  SEVERITY_COLORS,
+  type SeverityLevel,
+} from './travel-corridor-service';
+
+export type MiseryContext = 'airport' | 'road-segment' | 'route' | 'flight';
+
+export type MiseryDriverCategory =
+  | 'precip'
+  | 'wind'
+  | 'visibility'
+  | 'turbulence'
+  | 'storm'
+  | 'temp';
+
+export interface MiseryDriver {
+  label: string;
+  weight: number;
+  category: MiseryDriverCategory;
+}
+
+export interface MiseryScore {
+  score: number;
+  level: SeverityLevel;
+  color: string;
+  label: string;
+  drivers: MiseryDriver[];
+  context: MiseryContext;
+}
+
+export const MISERY_LEVEL_LABELS: Record<SeverityLevel, string> = {
+  green: 'SMOOTH',
+  yellow: 'BUMPY',
+  orange: 'ROUGH',
+  red: 'BRUTAL',
+};
+
+export const MISERY_LEVEL_DESCRIPTIONS: Record<SeverityLevel, string> = {
+  green: 'No weather impact expected',
+  yellow: 'Minor delays or discomfort possible',
+  orange: 'Significant delays or hazardous conditions likely',
+  red: 'Severe disruption — consider alternatives',
+};
+
+export interface AirportMiseryInput {
+  ceilingFt?: number;
+  visibilityMi?: number;
+  windKt?: number;
+  gustKt?: number;
+  precipitationMmHr?: number;
+  snowfallMmHr?: number;
+  thunderstormsNearby?: boolean;
+  turbulenceNearby?: boolean;
+  icingNearby?: boolean;
+}
+
+export interface RoadMiseryInput {
+  precipitationMmHr?: number;
+  snowfallMmHr?: number;
+  windGustsKmh?: number;
+  visibilityM?: number;
+  freezingRain?: boolean;
+}
+
+const clampScore = (n: number): number =>
+  Number.isFinite(n) ? Math.min(100, Math.max(0, Math.round(n))) : 0;
+
+/**
+ * Score an airport's weather-driven delay risk on the unified 0–100 scale.
+ * Driver weights are normalized so the most-impactful single condition wins
+ * the "headline" driver in the badge.
+ */
+export function scoreAirportMisery(input: AirportMiseryInput): MiseryScore {
+  const drivers: MiseryDriver[] = [];
+  let score = 0;
+
+  const ceiling = input.ceilingFt;
+  if (ceiling !== undefined && Number.isFinite(ceiling)) {
+    if (ceiling < 200) {
+      score += 35;
+      drivers.push({ label: `Ceiling ${ceiling} ft (LIFR)`, weight: 35, category: 'visibility' });
+    } else if (ceiling < 500) {
+      score += 25;
+      drivers.push({ label: `Low ceiling ${ceiling} ft (IFR)`, weight: 25, category: 'visibility' });
+    } else if (ceiling < 1000) {
+      score += 12;
+      drivers.push({ label: `Ceiling ${ceiling} ft (MVFR)`, weight: 12, category: 'visibility' });
+    }
+  }
+
+  const vis = input.visibilityMi;
+  if (vis !== undefined && Number.isFinite(vis)) {
+    if (vis < 1) {
+      score += 30;
+      drivers.push({ label: `Visibility ${vis.toFixed(1)} mi`, weight: 30, category: 'visibility' });
+    } else if (vis < 3) {
+      score += 18;
+      drivers.push({ label: `Visibility ${vis.toFixed(1)} mi`, weight: 18, category: 'visibility' });
+    } else if (vis < 5) {
+      score += 8;
+      drivers.push({ label: `Reduced vis ${vis.toFixed(1)} mi`, weight: 8, category: 'visibility' });
+    }
+  }
+
+  const gust = input.gustKt ?? input.windKt ?? 0;
+  if (gust >= 50) {
+    score += 30;
+    drivers.push({ label: `Gusts ${Math.round(gust)} kt`, weight: 30, category: 'wind' });
+  } else if (gust >= 35) {
+    score += 18;
+    drivers.push({ label: `Strong gusts ${Math.round(gust)} kt`, weight: 18, category: 'wind' });
+  } else if (gust >= 25) {
+    score += 8;
+    drivers.push({ label: `Wind ${Math.round(gust)} kt`, weight: 8, category: 'wind' });
+  }
+
+  const snow = input.snowfallMmHr ?? 0;
+  if (snow >= 5) {
+    score += 25;
+    drivers.push({ label: 'Heavy snow', weight: 25, category: 'precip' });
+  } else if (snow > 0) {
+    score += 12;
+    drivers.push({ label: 'Snow', weight: 12, category: 'precip' });
+  }
+
+  const precip = input.precipitationMmHr ?? 0;
+  if (snow === 0 && precip >= 10) {
+    score += 15;
+    drivers.push({ label: 'Heavy rain', weight: 15, category: 'precip' });
+  } else if (snow === 0 && precip >= 2) {
+    score += 6;
+    drivers.push({ label: 'Rain', weight: 6, category: 'precip' });
+  }
+
+  if (input.thunderstormsNearby) {
+    score += 25;
+    drivers.push({ label: 'Convection in TMA', weight: 25, category: 'storm' });
+  }
+  if (input.turbulenceNearby) {
+    score += 12;
+    drivers.push({ label: 'Turbulence advisory', weight: 12, category: 'turbulence' });
+  }
+  if (input.icingNearby) {
+    score += 12;
+    drivers.push({ label: 'Icing advisory', weight: 12, category: 'turbulence' });
+  }
+
+  const finalScore = clampScore(score);
+  const level = getSeverityLevel(finalScore);
+
+  drivers.sort((a, b) => b.weight - a.weight);
+
+  return {
+    score: finalScore,
+    level,
+    color: SEVERITY_COLORS[level],
+    label: MISERY_LEVEL_LABELS[level],
+    drivers: drivers.slice(0, 3),
+    context: 'airport',
+  };
+}
+
+/**
+ * Score a road segment using the same model travel-corridor-service uses,
+ * but produce drivers + label so it renders identically to airport misery.
+ */
+export function scoreRoadMisery(input: RoadMiseryInput): MiseryScore {
+  const drivers: MiseryDriver[] = [];
+  let score = 0;
+
+  const snow = input.snowfallMmHr ?? 0;
+  if (snow > 1) {
+    score += 30;
+    drivers.push({ label: 'Heavy snow', weight: 30, category: 'precip' });
+  } else if (snow > 0) {
+    score += 15;
+    drivers.push({ label: 'Snow', weight: 15, category: 'precip' });
+  }
+
+  const precip = input.precipitationMmHr ?? 0;
+  if (snow === 0 && precip > 5) {
+    score += 18;
+    drivers.push({ label: 'Heavy rain', weight: 18, category: 'precip' });
+  } else if (snow === 0 && precip > 0.5) {
+    score += 8;
+    drivers.push({ label: 'Rain', weight: 8, category: 'precip' });
+  }
+
+  const visM = input.visibilityM ?? 10000;
+  if (visM < 1000) {
+    score += 25;
+    drivers.push({ label: 'Dense fog', weight: 25, category: 'visibility' });
+  } else if (visM < 3000) {
+    score += 12;
+    drivers.push({ label: 'Low visibility', weight: 12, category: 'visibility' });
+  }
+
+  const gusts = input.windGustsKmh ?? 0;
+  if (gusts > 80) {
+    score += 20;
+    drivers.push({ label: 'Dangerous winds', weight: 20, category: 'wind' });
+  } else if (gusts > 50) {
+    score += 10;
+    drivers.push({ label: 'High winds', weight: 10, category: 'wind' });
+  }
+
+  if (input.freezingRain) {
+    score += 25;
+    drivers.push({ label: 'Freezing rain', weight: 25, category: 'precip' });
+  }
+
+  const finalScore = clampScore(score);
+  const level = getSeverityLevel(finalScore);
+
+  drivers.sort((a, b) => b.weight - a.weight);
+
+  return {
+    score: finalScore,
+    level,
+    color: SEVERITY_COLORS[level],
+    label: MISERY_LEVEL_LABELS[level],
+    drivers: drivers.slice(0, 3),
+    context: 'road-segment',
+  };
+}
+
+/**
+ * Combine multiple segment scores into a single trip score.
+ * Trip score = max(worst, weighted avg) so a single brutal segment dominates.
+ */
+export function combineMiseryScores(
+  scores: MiseryScore[],
+  context: MiseryContext = 'route',
+): MiseryScore {
+  if (scores.length === 0) {
+    return {
+      score: 0,
+      level: 'green',
+      color: SEVERITY_COLORS.green,
+      label: MISERY_LEVEL_LABELS.green,
+      drivers: [],
+      context,
+    };
+  }
+
+  const worst = scores.reduce((acc, s) => (s.score > acc.score ? s : acc), scores[0]);
+  const avg = Math.round(scores.reduce((sum, s) => sum + s.score, 0) / scores.length);
+  const finalScore = clampScore(Math.max(worst.score - 5, avg));
+  const level = getSeverityLevel(finalScore);
+
+  const driverMap = new Map<string, MiseryDriver>();
+  for (const s of scores) {
+    for (const d of s.drivers) {
+      const existing = driverMap.get(d.label);
+      if (!existing || d.weight > existing.weight) {
+        driverMap.set(d.label, d);
+      }
+    }
+  }
+  const drivers = [...driverMap.values()].sort((a, b) => b.weight - a.weight).slice(0, 3);
+
+  return {
+    score: finalScore,
+    level,
+    color: SEVERITY_COLORS[level],
+    label: MISERY_LEVEL_LABELS[level],
+    drivers,
+    context,
+  };
+}

--- a/lib/services/misery-score-service.ts
+++ b/lib/services/misery-score-service.ts
@@ -151,7 +151,7 @@ export function scoreAirportMisery(input: AirportMiseryInput): MiseryScore {
   }
   if (input.icingNearby) {
     score += 12;
-    drivers.push({ label: 'Icing advisory', weight: 12, category: 'turbulence' });
+    drivers.push({ label: 'Icing advisory', weight: 12, category: 'precip' });
   }
 
   const finalScore = clampScore(score);

--- a/lib/services/trip-routing-service.ts
+++ b/lib/services/trip-routing-service.ts
@@ -1,0 +1,187 @@
+/**
+ * Trip Routing Service
+ *
+ * Pure routing logic — no fetches. Used by /api/travel/trip-score to:
+ *  - measure great-circle distance between two points (haversine)
+ *  - find the nearest waypoint on an interstate corridor to a given point
+ *  - match an origin/destination pair to the best US interstate corridor and
+ *    return the slice of waypoints that connects them
+ *  - compute the great-circle midpoint between two airports for fly-mode
+ *    en-route hazard scoring
+ */
+
+import type { MajorAirport } from '@/lib/data/major-us-airports';
+
+export interface TripEndpoint {
+  /** Raw user input (free text or IATA/ICAO code). */
+  query: string;
+  /** Coordinates after geocoding/airport resolution. */
+  resolved?: { lat: number; lon: number; label: string };
+  /** Populated when the endpoint matched an IATA/ICAO code or hub city. */
+  airport?: MajorAirport;
+}
+
+export interface MatchedCorridor {
+  name: string;
+  matchedSegment: {
+    startIdx: number;
+    endIdx: number;
+    /** Waypoints from startIdx to endIdx inclusive, in route-of-travel order. */
+    waypoints: number[][];
+  };
+  /** Total number of waypoints on the parent corridor. */
+  totalCorridorLength: number;
+}
+
+/** How close (km) origin/dest must be to a corridor path to consider it a match. */
+const CORRIDOR_MATCH_RADIUS_KM = 150;
+const EARTH_RADIUS_M = 6_371_000;
+
+const toRad = (deg: number): number => (deg * Math.PI) / 180;
+const toDeg = (rad: number): number => (rad * 180) / Math.PI;
+
+/**
+ * Great-circle distance in meters between two lat/lon points (haversine).
+ * Stable for short and antipodal pairs; sufficient for routing distances.
+ */
+export function haversineMeters(
+  a: { lat: number; lon: number },
+  b: { lat: number; lon: number },
+): number {
+  const phi1 = toRad(a.lat);
+  const phi2 = toRad(b.lat);
+  const dPhi = toRad(b.lat - a.lat);
+  const dLambda = toRad(b.lon - a.lon);
+
+  const sinDPhi = Math.sin(dPhi / 2);
+  const sinDLambda = Math.sin(dLambda / 2);
+  const h =
+    sinDPhi * sinDPhi +
+    Math.cos(phi1) * Math.cos(phi2) * sinDLambda * sinDLambda;
+  const c = 2 * Math.atan2(Math.sqrt(h), Math.sqrt(1 - h));
+  return EARTH_RADIUS_M * c;
+}
+
+/**
+ * Find the index of the waypoint nearest to `point`. Each waypoint is
+ * `[lat, lon]` to match the public/data/us-interstates.json schema.
+ */
+export function nearestWaypointIndex(
+  point: { lat: number; lon: number },
+  waypoints: number[][],
+): { idx: number; distanceM: number } {
+  let bestIdx = 0;
+  let bestDist = Infinity;
+
+  for (let i = 0; i < waypoints.length; i++) {
+    const wp = waypoints[i];
+    if (!wp || wp.length < 2) continue;
+    const dist = haversineMeters(point, { lat: wp[0], lon: wp[1] });
+    if (dist < bestDist) {
+      bestDist = dist;
+      bestIdx = i;
+    }
+  }
+
+  return { idx: bestIdx, distanceM: bestDist };
+}
+
+/**
+ * Match origin + destination to a corridor. We pick the corridor where both
+ * endpoints are within ~150 km of *some* waypoint on the path AND where the
+ * sum of (origin→nearest, dest→nearest) is minimized — that combination
+ * favors corridors that genuinely connect the two cities over corridors that
+ * happen to pass near just one of them.
+ *
+ * Returns the slice of waypoints between the two nearest indices (inclusive),
+ * oriented in route-of-travel order so the caller can iterate origin→dest.
+ */
+export function matchCorridor(
+  origin: { lat: number; lon: number },
+  dest: { lat: number; lon: number },
+  corridors: { name: string; waypoints: number[][] }[],
+): MatchedCorridor | null {
+  const radiusM = CORRIDOR_MATCH_RADIUS_KM * 1000;
+
+  let best: {
+    name: string;
+    waypoints: number[][];
+    originIdx: number;
+    destIdx: number;
+    sumDistM: number;
+  } | null = null;
+
+  for (const corridor of corridors) {
+    if (!corridor.waypoints || corridor.waypoints.length < 2) continue;
+
+    const originHit = nearestWaypointIndex(origin, corridor.waypoints);
+    const destHit = nearestWaypointIndex(dest, corridor.waypoints);
+
+    if (originHit.distanceM > radiusM || destHit.distanceM > radiusM) continue;
+    if (originHit.idx === destHit.idx) continue; // Need a real segment.
+
+    const sum = originHit.distanceM + destHit.distanceM;
+    if (!best || sum < best.sumDistM) {
+      best = {
+        name: corridor.name,
+        waypoints: corridor.waypoints,
+        originIdx: originHit.idx,
+        destIdx: destHit.idx,
+        sumDistM: sum,
+      };
+    }
+  }
+
+  if (!best) return null;
+
+  const startIdx = Math.min(best.originIdx, best.destIdx);
+  const endIdx = Math.max(best.originIdx, best.destIdx);
+  let slice = best.waypoints.slice(startIdx, endIdx + 1);
+
+  // Orient origin → destination so callers see the route in travel order.
+  if (best.originIdx > best.destIdx) {
+    slice = [...slice].reverse();
+  }
+
+  return {
+    name: best.name,
+    matchedSegment: {
+      startIdx,
+      endIdx,
+      waypoints: slice,
+    },
+    totalCorridorLength: best.waypoints.length,
+  };
+}
+
+/**
+ * Great-circle (spherical) midpoint between two lat/lon points. Used as a
+ * stand-in for "somewhere over the route" when scoring en-route hazards on
+ * fly-mode trips. For short/medium domestic flights this is well within the
+ * accuracy needed for SIGMET proximity checks.
+ *
+ * Reference: https://www.movable-type.co.uk/scripts/latlong.html#midpoint
+ */
+export function greatCircleMidpoint(
+  a: { lat: number; lon: number },
+  b: { lat: number; lon: number },
+): { lat: number; lon: number } {
+  const phi1 = toRad(a.lat);
+  const phi2 = toRad(b.lat);
+  const lambda1 = toRad(a.lon);
+  const dLambda = toRad(b.lon - a.lon);
+
+  const Bx = Math.cos(phi2) * Math.cos(dLambda);
+  const By = Math.cos(phi2) * Math.sin(dLambda);
+
+  const phiM = Math.atan2(
+    Math.sin(phi1) + Math.sin(phi2),
+    Math.sqrt((Math.cos(phi1) + Bx) ** 2 + By * By),
+  );
+  const lambdaM = lambda1 + Math.atan2(By, Math.cos(phi1) + Bx);
+
+  // Normalize longitude into -180..180.
+  const lonNorm = ((toDeg(lambdaM) + 540) % 360) - 180;
+
+  return { lat: toDeg(phiM), lon: lonNorm };
+}

--- a/lib/services/trip-routing-service.ts
+++ b/lib/services/trip-routing-service.ts
@@ -10,17 +10,6 @@
  *    en-route hazard scoring
  */
 
-import type { MajorAirport } from '@/lib/data/major-us-airports';
-
-export interface TripEndpoint {
-  /** Raw user input (free text or IATA/ICAO code). */
-  query: string;
-  /** Coordinates after geocoding/airport resolution. */
-  resolved?: { lat: number; lon: number; label: string };
-  /** Populated when the endpoint matched an IATA/ICAO code or hub city. */
-  airport?: MajorAirport;
-}
-
 export interface MatchedCorridor {
   name: string;
   matchedSegment: {


### PR DESCRIPTION
## Summary

Reframes `/aviation` and `/travel` around the user question **"will my trip suck?"** instead of presenting raw weather data. Three concrete moves stitched together by a shared severity model:

- **Airport Misery Board** ranks the top 30 US hubs by weather-driven delay risk (live METAR + SIGMET/AIRMET overlap). Replaces the old aviation landing; the existing terminal is preserved as a "Detail Console" below.
- **Trip Score** answers "I'm going from X to Y" with one number plus the worst segment and peak window. Fly mode scores both airports plus an en-route midpoint; drive mode matches the trip onto a single US interstate corridor.
- **Travel Hub** at `/travel` with a Fly/Drive toggle (persisted in localStorage). Fly surfaces the airport board, Drive keeps the existing corridor map + WPC outlook. Cross-link added from `/aviation`.

A new shared misery-score module (`lib/services/misery-score-service.ts`) reuses the existing `SeverityLevel`/0-100 scale and color tokens so badges read identically across surfaces.

## Files

- `lib/services/misery-score-service.ts` - unified score (airport/road/route/flight contexts) + `combineMiseryScores`
- `lib/services/trip-routing-service.ts` - haversine, single-corridor matching, great-circle midpoint
- `lib/data/major-us-airports.ts` - 30 hub airports with coords/IATA/ICAO
- `app/api/aviation/airport-misery/route.ts` - scores all 30 hubs in parallel
- `app/api/travel/trip-score/route.ts` - drive + fly modes with `mode`, `origin`, `destination`, `day` params
- `components/ui/misery-badge.tsx` - `<MiseryBadge>` and `<MiseryDriverList>`
- `components/aviation/AirportMiseryBoard.tsx` - sortable terminal-style table, mobile cards
- `components/travel/{TravelHub,TripInput,TripScoreCard,trip-types}.tsx` - hub shell + trip planner UI
- `app/travel/page.tsx`, `app/aviation/page.tsx` - integration + cross-links

## Test plan

- [ ] `/travel` loads, defaults to Drive (or last-selected mode in localStorage), shows existing corridor map + outlook
- [ ] Toggle to Fly, verify the Airport Misery Board renders 30 rows ranked by score, sortable by score / IATA / city
- [ ] Click "Detail Console" link (Fly mode) - lands on `/aviation`
- [ ] Trip planner: Drive `ATL` -> `CLT` returns I-85 corridor with segment scores
- [ ] Trip planner: Fly `LAX` -> `JFK` returns origin / en-route midpoint / destination breakdown
- [ ] Trip planner: cross-corridor drive (e.g. `ATL` -> `ORD`) returns the v1 422 "no single corridor connects" message gracefully
- [ ] `/aviation` shows the Misery Board above the existing terminal, plus the "Driving instead?" link to `/travel`
- [ ] Mobile: mode toggle stacks, board renders as cards, trip card layout collapses

## Known v1 limitation

Drive trips that span multiple interstates (e.g. ATL->ORD across I-75/I-65/I-90) return 422 since the matcher picks a single corridor. Same-corridor pairs (ATL->CLT on I-85, Memphis->Nashville on I-40) score correctly. Multi-corridor routing is a future improvement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Unified Travel Hub for trip planning with switchable drive and fly modes
- Airport Misery Board displaying real-time weather conditions and hazard scores for major US airports
- Trip Score system evaluating weather impact on planned routes
- Trip planning interface with origin, destination, and date selection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->