### PR TITLE
fix(travel): call NOAA directly so airport board works on Vercel

### DIFF
--- a/app/api/aviation/airport-misery/route.ts
+++ b/app/api/aviation/airport-misery/route.ts
@@ -7,6 +7,10 @@
  * Aggregates METAR observations + SIGMET/AIRMET advisories across the top US
  * hub airports, scores each one with the unified misery model, and returns a
  * sortable board for the aviation page.
+ *
+ * Data fetches go directly to NOAA via aviation-noaa-service so we don't have
+ * to spawn 30 self-fetched serverless invocations per request (which silently
+ * failed on Vercel when NEXT_PUBLIC_BASE_URL was misconfigured to localhost).
  */
 
 import { NextResponse } from 'next/server';
@@ -19,7 +23,12 @@ import {
   type AirportMiseryInput,
   type MiseryScore,
 } from '@/lib/services/misery-score-service';
-import type { MetarObservation, MetarResponse } from '@/app/api/aviation/metar/route';
+import {
+  fetchMetarsBulk,
+  fetchAviationAlertsFromNOAA,
+  type NoaaAlert,
+} from '@/lib/services/aviation-noaa-service';
+import type { MetarObservation } from '@/app/api/aviation/metar/route';
 
 export interface AirportMiseryRow {
   airport: MajorAirport;
@@ -31,40 +40,6 @@ export interface AirportMiseryRow {
 interface AirportMiseryResponse {
   airports: AirportMiseryRow[];
   fetchedAt: string;
-}
-
-interface AlertLike {
-  hazard?: string;
-  region?: string;
-  rawText?: string;
-  text?: string;
-  type?: string;
-}
-
-const REQUEST_TIMEOUT_MS = 8000;
-
-function getBaseUrl(): string {
-  if (process.env.NEXT_PUBLIC_BASE_URL) {
-    return process.env.NEXT_PUBLIC_BASE_URL.replace(/\/$/, '');
-  }
-  if (process.env.VERCEL_URL) {
-    return `https://${process.env.VERCEL_URL}`;
-  }
-  return 'http://localhost:3000';
-}
-
-async function fetchWithTimeout(url: string, ms: number): Promise<Response> {
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), ms);
-  try {
-    return await fetch(url, {
-      signal: controller.signal,
-      headers: { Accept: 'application/json' },
-      cache: 'no-store',
-    });
-  } finally {
-    clearTimeout(timer);
-  }
 }
 
 /**
@@ -93,7 +68,7 @@ function computeCeilingFt(
  * Determine whether an active SIGMET/AIRMET applies to a given airport.
  * Heuristic: text mentions the airport's ICAO, IATA, or state code.
  */
-function alertAppliesToAirport(alert: AlertLike, airport: MajorAirport): boolean {
+function alertAppliesToAirport(alert: NoaaAlert, airport: MajorAirport): boolean {
   const haystack = `${alert.region ?? ''} ${alert.text ?? ''} ${alert.rawText ?? ''}`.toUpperCase();
   if (!haystack.trim()) return false;
 
@@ -107,7 +82,7 @@ interface HazardFlags {
   icingNearby: boolean;
 }
 
-function hazardFlagsFor(airport: MajorAirport, alerts: AlertLike[]): HazardFlags {
+function hazardFlagsFor(airport: MajorAirport, alerts: NoaaAlert[]): HazardFlags {
   const flags: HazardFlags = {
     thunderstormsNearby: false,
     turbulenceNearby: false,
@@ -135,86 +110,48 @@ function hazardFlagsFor(airport: MajorAirport, alerts: AlertLike[]): HazardFlags
   return flags;
 }
 
-function placeholderRow(airport: MajorAirport): AirportMiseryRow {
+function buildRow(
+  airport: MajorAirport,
+  observation: MetarObservation | undefined,
+  alerts: NoaaAlert[],
+): AirportMiseryRow {
+  const hazards = hazardFlagsFor(airport, alerts);
+
+  if (!observation) {
+    return {
+      airport,
+      score: scoreAirportMisery({ ...hazards }),
+      isStale: true,
+    };
+  }
+
+  const input: AirportMiseryInput = {
+    ceilingFt: computeCeilingFt(observation.clouds),
+    visibilityMi: observation.visibility,
+    windKt: observation.windSpeed,
+    gustKt: observation.windGust,
+    ...hazards,
+  };
+
   return {
     airport,
-    score: scoreAirportMisery({}),
-    isStale: true,
+    score: scoreAirportMisery(input),
+    metar: observation,
+    isStale: false,
   };
-}
-
-async function fetchMetarForAirport(
-  airport: MajorAirport,
-  baseUrl: string,
-): Promise<MetarObservation | undefined> {
-  try {
-    const res = await fetchWithTimeout(
-      `${baseUrl}/api/aviation/metar?station=${airport.icao}`,
-      REQUEST_TIMEOUT_MS,
-    );
-    if (!res.ok) return undefined;
-    const data: MetarResponse = await res.json();
-    return data.observation;
-  } catch (error) {
-    console.error('[airport-misery]', `metar fetch failed for ${airport.icao}`, error);
-    return undefined;
-  }
-}
-
-async function fetchAlerts(baseUrl: string): Promise<AlertLike[]> {
-  try {
-    const res = await fetchWithTimeout(
-      `${baseUrl}/api/aviation/alerts`,
-      REQUEST_TIMEOUT_MS,
-    );
-    if (!res.ok) return [];
-    const data = (await res.json()) as { alerts?: AlertLike[] };
-    return Array.isArray(data.alerts) ? data.alerts : [];
-  } catch (error) {
-    console.error('[airport-misery]', 'alerts fetch failed', error);
-    return [];
-  }
 }
 
 export async function GET() {
   try {
-    const baseUrl = getBaseUrl();
+    const icaos = MAJOR_US_AIRPORTS.map((a) => a.icao);
 
-    const alerts = await fetchAlerts(baseUrl);
+    const [metars, alerts] = await Promise.all([
+      fetchMetarsBulk(icaos),
+      fetchAviationAlertsFromNOAA(),
+    ]);
 
-    const rows: AirportMiseryRow[] = await Promise.all(
-      MAJOR_US_AIRPORTS.map(async (airport): Promise<AirportMiseryRow> => {
-        try {
-          const observation = await fetchMetarForAirport(airport, baseUrl);
-          const hazards = hazardFlagsFor(airport, alerts);
-
-          if (!observation) {
-            return {
-              airport,
-              score: scoreAirportMisery({ ...hazards }),
-              isStale: true,
-            };
-          }
-
-          const input: AirportMiseryInput = {
-            ceilingFt: computeCeilingFt(observation.clouds),
-            visibilityMi: observation.visibility,
-            windKt: observation.windSpeed,
-            gustKt: observation.windGust,
-            ...hazards,
-          };
-
-          return {
-            airport,
-            score: scoreAirportMisery(input),
-            metar: observation,
-            isStale: false,
-          };
-        } catch (error) {
-          console.error('[airport-misery]', `row failed for ${airport.icao}`, error);
-          return placeholderRow(airport);
-        }
-      }),
+    const rows = MAJOR_US_AIRPORTS.map((airport) =>
+      buildRow(airport, metars.get(airport.icao), alerts),
     );
 
     const payload: AirportMiseryResponse = {

--- a/app/api/travel/trip-score/route.ts
+++ b/app/api/travel/trip-score/route.ts
@@ -39,7 +39,12 @@ import {
   haversineMeters,
   matchCorridor,
 } from '@/lib/services/trip-routing-service';
-import type { MetarObservation, MetarResponse } from '@/app/api/aviation/metar/route';
+import type { MetarObservation } from '@/app/api/aviation/metar/route';
+import {
+  fetchMetarsBulk,
+  fetchAviationAlertsFromNOAA,
+  type NoaaAlert,
+} from '@/lib/services/aviation-noaa-service';
 import interstateData from '@/public/data/us-interstates.json';
 
 const OPEN_METEO_BASE = 'https://api.open-meteo.com/v1/forecast';
@@ -53,13 +58,6 @@ interface InterstateCorridorData {
   path: number[][];
 }
 
-interface AlertLike {
-  hazard?: string;
-  region?: string;
-  rawText?: string;
-  text?: string;
-  type?: string;
-}
 
 interface GeocodingResult {
   name: string;
@@ -291,29 +289,20 @@ function computeCeilingFt(clouds: MetarObservation['clouds'] | undefined): numbe
   return ceiling;
 }
 
-async function fetchMetar(
-  airport: MajorAirport,
-  baseUrl: string,
-): Promise<MetarObservation | undefined> {
+async function fetchMetarsForAirports(
+  airports: MajorAirport[],
+): Promise<Map<string, MetarObservation>> {
   try {
-    const res = await fetchWithTimeout(
-      `${baseUrl}/api/aviation/metar?station=${airport.icao}`,
-    );
-    if (!res.ok) return undefined;
-    const data = (await res.json()) as MetarResponse;
-    return data.observation;
+    return await fetchMetarsBulk(airports.map((a) => a.icao));
   } catch (error) {
-    console.error('[trip-score]', `metar fetch failed for ${airport.icao}`, error);
-    return undefined;
+    console.error('[trip-score]', 'bulk metar fetch failed', error);
+    return new Map();
   }
 }
 
-async function fetchAlerts(baseUrl: string): Promise<AlertLike[]> {
+async function fetchAlerts(): Promise<NoaaAlert[]> {
   try {
-    const res = await fetchWithTimeout(`${baseUrl}/api/aviation/alerts`);
-    if (!res.ok) return [];
-    const data = (await res.json()) as { alerts?: AlertLike[] };
-    return Array.isArray(data.alerts) ? data.alerts : [];
+    return await fetchAviationAlertsFromNOAA();
   } catch (error) {
     console.error('[trip-score]', 'alerts fetch failed', error);
     return [];
@@ -328,7 +317,7 @@ async function fetchAlerts(baseUrl: string): Promise<AlertLike[]> {
  * between MAJOR_US_AIRPORTS hubs) this catches >95% of relevant advisories.
  */
 function alertAppliesToFlight(
-  alert: AlertLike,
+  alert: NoaaAlert,
   origin: MajorAirport,
   dest: MajorAirport,
   midpointAirports: MajorAirport[],
@@ -356,7 +345,7 @@ interface EnrouteHazardFlags {
 }
 
 function deriveEnrouteHazards(
-  alerts: AlertLike[],
+  alerts: NoaaAlert[],
   origin: MajorAirport,
   dest: MajorAirport,
   midpoint: { lat: number; lon: number },
@@ -499,11 +488,12 @@ async function handleFlyMode(
   const originAirport = origin.airport;
   const destAirport = destination.airport;
 
-  const [originMetar, destMetar, alerts] = await Promise.all([
-    fetchMetar(originAirport, baseUrl),
-    fetchMetar(destAirport, baseUrl),
-    fetchAlerts(baseUrl),
+  const [metars, alerts] = await Promise.all([
+    fetchMetarsForAirports([originAirport, destAirport]),
+    fetchAlerts(),
   ]);
+  const originMetar = metars.get(originAirport.icao);
+  const destMetar = metars.get(destAirport.icao);
 
   const originInput: AirportMiseryInput = originMetar
     ? {

--- a/lib/services/aviation-noaa-service.ts
+++ b/lib/services/aviation-noaa-service.ts
@@ -1,0 +1,285 @@
+/**
+ * Aviation NOAA Service
+ *
+ * Direct NOAA Aviation Weather Center fetchers for METAR observations and
+ * SIGMET/AIRMET alerts. Used by airport-misery and trip-score so those routes
+ * don't have to self-fetch through `/api/aviation/metar` and `/api/aviation/alerts`
+ * (which is fragile when NEXT_PUBLIC_BASE_URL is misconfigured on Vercel and
+ * would otherwise spawn 30 cold-start serverless invocations per board refresh).
+ *
+ * The existing /api/aviation/{metar,alerts} HTTP routes are unchanged; they
+ * still serve other callers (FlightConditionsTerminal, AI context, etc.).
+ */
+import type { MetarObservation } from '@/app/api/aviation/metar/route';
+
+const NOAA_METAR_BASE = 'https://aviationweather.gov/api/data/metar';
+const NOAA_AIRSIGMET = 'https://aviationweather.gov/api/data/airsigmet';
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+const NOAA_HEADERS = { 'User-Agent': '16-Bit-Weather/aviation-service' } as const;
+
+export interface NoaaAlert {
+  id: string;
+  type: 'SIGMET' | 'AIRMET';
+  severity: 'low' | 'moderate' | 'severe' | 'extreme';
+  hazard: string;
+  region: string;
+  validFrom: string;
+  validTo: string;
+  text: string;
+  rawText: string;
+}
+
+interface AWCAlert {
+  airsigmetId: number;
+  icaoId: string;
+  validTimeFrom: string;
+  validTimeTo: string;
+  rawAirSigmet: string;
+  hazard: string;
+  severity: string;
+  airsigmetType: string;
+  altitudeLow1: number;
+  altitudeHi1: number;
+}
+
+/* -------------------------------------------------------------------------- */
+/* METAR parsing — kept aligned with app/api/aviation/metar/route.ts so the   */
+/* output shape matches the existing MetarObservation type.                    */
+/* -------------------------------------------------------------------------- */
+
+function determineFlightCategory(
+  visibility: number | undefined,
+  clouds: Array<{ cover: string; base?: number }> | undefined,
+): MetarObservation['flightCategory'] {
+  let ceiling: number | undefined;
+  for (const cloud of clouds ?? []) {
+    if ((cloud.cover === 'BKN' || cloud.cover === 'OVC') && cloud.base !== undefined) {
+      if (ceiling === undefined || cloud.base < ceiling) ceiling = cloud.base;
+    }
+  }
+
+  if ((ceiling !== undefined && ceiling < 500) || (visibility !== undefined && visibility < 1)) return 'LIFR';
+  if ((ceiling !== undefined && ceiling < 1000) || (visibility !== undefined && visibility < 3)) return 'IFR';
+  if ((ceiling !== undefined && ceiling < 3000) || (visibility !== undefined && visibility < 5)) return 'MVFR';
+  if (visibility === undefined && ceiling === undefined) return 'UNKNOWN';
+  return 'VFR';
+}
+
+export function parseMetarRaw(raw: string): MetarObservation | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+
+  const result: Partial<MetarObservation> = { raw: trimmed, clouds: [] };
+
+  const icaoMatch = trimmed.match(/\b([A-Z]{4})\b/);
+  if (icaoMatch) result.icao = icaoMatch[1];
+  if (!result.icao) return null;
+
+  const timeMatch = trimmed.match(/\b(\d{6})Z\b/);
+  if (timeMatch) {
+    const day = parseInt(timeMatch[1].slice(0, 2));
+    const hour = parseInt(timeMatch[1].slice(2, 4));
+    const minute = parseInt(timeMatch[1].slice(4, 6));
+    const now = new Date();
+    let year = now.getUTCFullYear();
+    let month = now.getUTCMonth();
+    let obsTime = new Date(Date.UTC(year, month, day, hour, minute));
+    if (obsTime > now) {
+      month -= 1;
+      if (month < 0) { month = 11; year -= 1; }
+      obsTime = new Date(Date.UTC(year, month, day, hour, minute));
+    }
+    result.observationTime = obsTime.toISOString();
+  } else {
+    result.observationTime = new Date().toISOString();
+  }
+
+  const windMatch = trimmed.match(/\b(\d{3}|VRB)(\d{2,3})(?:G(\d{2,3}))?KT\b/);
+  if (windMatch) {
+    if (windMatch[1] !== 'VRB') result.windDirection = parseInt(windMatch[1]);
+    result.windSpeed = parseInt(windMatch[2]);
+    if (windMatch[3]) result.windGust = parseInt(windMatch[3]);
+  }
+
+  const visMatch = trimmed.match(/\b([PM])?(\d+)?\s*(\d+\/\d+)?\s*SM\b/);
+  if (visMatch) {
+    const prefix = visMatch[1];
+    const wholePart = visMatch[2] ? parseInt(visMatch[2]) : 0;
+    const fractionPart = visMatch[3];
+    let visibility: number;
+    if (fractionPart) {
+      const [num, denom] = fractionPart.split('/').map(Number);
+      visibility = wholePart + num / denom;
+    } else {
+      visibility = wholePart;
+    }
+    if (prefix === 'P') result.visibility = visibility || 6;
+    else if (prefix === 'M') result.visibility = Math.max(0, visibility - 0.01);
+    else result.visibility = visibility;
+  }
+
+  const tempMatch = trimmed.match(/\b(M?\d{2})\/(M?\d{2})\b/);
+  if (tempMatch) {
+    result.temperature = parseInt(tempMatch[1].replace('M', '-'));
+    result.dewpoint = parseInt(tempMatch[2].replace('M', '-'));
+  }
+
+  const altMatch = trimmed.match(/\bA(\d{4})\b/);
+  if (altMatch) result.altimeter = parseInt(altMatch[1]) / 100;
+
+  const cloudPattern = /\b(FEW|SCT|BKN|OVC|CLR|SKC)(\d{3})?\b/g;
+  let cloudMatch: RegExpExecArray | null;
+  while ((cloudMatch = cloudPattern.exec(trimmed)) !== null) {
+    const cover = cloudMatch[1];
+    const base = cloudMatch[2] ? parseInt(cloudMatch[2]) * 100 : undefined;
+    result.clouds!.push({ cover, base });
+  }
+
+  result.flightCategory = determineFlightCategory(result.visibility, result.clouds);
+
+  return {
+    raw: result.raw!,
+    icao: result.icao,
+    observationTime: result.observationTime!,
+    temperature: result.temperature,
+    dewpoint: result.dewpoint,
+    windDirection: result.windDirection,
+    windSpeed: result.windSpeed,
+    windGust: result.windGust,
+    visibility: result.visibility,
+    altimeter: result.altimeter,
+    flightCategory: result.flightCategory ?? 'UNKNOWN',
+    clouds: result.clouds ?? [],
+  };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Public fetchers                                                             */
+/* -------------------------------------------------------------------------- */
+
+async function fetchWithTimeout(url: string, ms: number = DEFAULT_TIMEOUT_MS): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), ms);
+  try {
+    return await fetch(url, { signal: controller.signal, headers: NOAA_HEADERS });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Fetch METARs for many stations in a single NOAA call. NOAA's API accepts
+ * comma-separated ICAO codes via `?ids=KATL,KORD,...` and returns one METAR
+ * per line, which we route back to a Map keyed by ICAO.
+ */
+export async function fetchMetarsBulk(icaos: string[]): Promise<Map<string, MetarObservation>> {
+  const results = new Map<string, MetarObservation>();
+  const valid = icaos.map((i) => i.toUpperCase()).filter((i) => /^[A-Z]{4}$/.test(i));
+  if (valid.length === 0) return results;
+
+  const url = `${NOAA_METAR_BASE}?ids=${encodeURIComponent(valid.join(','))}&format=raw&taf=false`;
+
+  let response: Response;
+  try {
+    response = await fetchWithTimeout(url);
+  } catch (error) {
+    console.error('[aviation-noaa-service]', 'metar bulk fetch failed', error);
+    return results;
+  }
+
+  if (!response.ok) {
+    console.error('[aviation-noaa-service]', `NOAA METAR returned ${response.status}`);
+    return results;
+  }
+
+  const text = await response.text();
+  for (const line of text.split('\n')) {
+    const parsed = parseMetarRaw(line);
+    if (parsed?.icao) results.set(parsed.icao, parsed);
+  }
+
+  return results;
+}
+
+function mapSeverity(hazard: string, severity: string): NoaaAlert['severity'] {
+  const h = hazard.toLowerCase();
+  const s = (severity ?? '').toLowerCase();
+  if (h.includes('extreme') || s.includes('extreme')) return 'extreme';
+  if (h.includes('severe') || s.includes('sev')) return 'severe';
+  if (h.includes('moderate') || s.includes('mod')) return 'moderate';
+  return 'low';
+}
+
+const HAZARD_MAP: Record<string, string> = {
+  TURB: 'Turbulence',
+  ICE: 'Icing',
+  CONVECTIVE: 'Convective Activity',
+  IFR: 'Instrument Flight Rules',
+  MTN_OBSCN: 'Mountain Obscuration',
+  ASH: 'Volcanic Ash',
+  LLWS: 'Low-Level Wind Shear',
+  'SFC WND': 'Surface Wind',
+  MTW: 'Mountain Wave',
+};
+
+function formatHazard(hazard: string): string {
+  const upper = hazard.toUpperCase().trim();
+  return HAZARD_MAP[upper] ?? hazard.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function formatTime(iso: string | undefined): string {
+  if (!iso) return '';
+  try {
+    return new Date(iso).toISOString().slice(0, 16).replace('T', ' ') + 'Z';
+  } catch {
+    return iso;
+  }
+}
+
+/**
+ * Fetch active SIGMET + AIRMET advisories from NOAA. Mirrors the parsing in
+ * /api/aviation/alerts/route.ts so the shape stays compatible.
+ */
+export async function fetchAviationAlertsFromNOAA(): Promise<NoaaAlert[]> {
+  const [sigmetRes, airmetRes] = await Promise.allSettled([
+    fetchWithTimeout(`${NOAA_AIRSIGMET}?format=json&type=sigmet`),
+    fetchWithTimeout(`${NOAA_AIRSIGMET}?format=json&type=airmet`),
+  ]);
+
+  const alerts: NoaaAlert[] = [];
+
+  async function consume(
+    settled: PromiseSettledResult<Response>,
+    type: 'SIGMET' | 'AIRMET',
+    fallbackHi: number,
+  ) {
+    if (settled.status !== 'fulfilled' || !settled.value.ok) return;
+    try {
+      const data = (await settled.value.json()) as AWCAlert[];
+      if (!Array.isArray(data)) return;
+      for (const alert of data.slice(0, 10)) {
+        alerts.push({
+          id: `${type.toLowerCase()}-${alert.airsigmetId}`,
+          type,
+          severity: mapSeverity(alert.hazard ?? '', alert.severity ?? ''),
+          hazard: formatHazard(alert.hazard ?? 'Unknown'),
+          region: alert.icaoId ?? 'CONUS',
+          validFrom: formatTime(alert.validTimeFrom),
+          validTo: formatTime(alert.validTimeTo),
+          text: `${formatHazard(alert.hazard ?? 'Unknown')} from FL${alert.altitudeLow1 || 0} to FL${alert.altitudeHi1 || fallbackHi}`,
+          rawText: alert.rawAirSigmet ?? '',
+        });
+      }
+    } catch (error) {
+      console.error('[aviation-noaa-service]', `${type} parse failed`, error);
+    }
+  }
+
+  await consume(sigmetRes, 'SIGMET', 450);
+  await consume(airmetRes, 'AIRMET', 180);
+
+  const order = { extreme: 0, severe: 1, moderate: 2, low: 3 } as const;
+  alerts.sort((a, b) => order[a.severity] - order[b.severity]);
+  return alerts;
+}


### PR DESCRIPTION
## Summary

Production after #382 was showing all 30 airports as score 0 with isStale:true. Root cause: `NEXT_PUBLIC_BASE_URL=http://localhost:3000` is set in production env, so the airport-misery route handed an unreachable URL to its 30 self-fetched `/api/aviation/metar` calls. Every fetch threw ECONNREFUSED immediately (which is why the function returned in 0.4s with no Vercel logs of internal METAR calls — they never started).

Same failure mode hit the fly side of `/api/travel/trip-score`.

## Fix

Bypass the HTTP self-fetch for these data paths and call NOAA directly. NOAA's METAR endpoint accepts comma-separated ICAOs via `?ids=`, so 30 airports cost one HTTPS round-trip instead of 30 cold-start serverless invocations.

- New `lib/services/aviation-noaa-service.ts` — `fetchMetarsBulk(icaos)`, `fetchAviationAlertsFromNOAA()`, plus the METAR parser kept aligned with the existing `app/api/aviation/metar/route.ts` shape.
- `airport-misery/route.ts` — replaces the 30-fetch fan-out + `getBaseUrl` with one bulk NOAA call + one alerts call.
- `trip-score/route.ts` (fly path) — same. Drive path is unchanged. Geocoding self-fetch in `resolveEndpoint` stays since it's only one call per request and uses a different code path.
- Existing `/api/aviation/{metar,alerts}` routes are untouched — other callers (FlightConditionsTerminal, AI context block) keep working.

## Verified locally

- Airport board: 30 airports, 0 stale, all have live METAR. ATL 900ft ceiling -> score 12, DFW/DEN VFR -> 0.
- Fly trip-score ATL->DFW: combined score 7, origin 12, dest 0, driver "Ceiling 900 ft (MVFR)".
- Drive trip-score ATL->CLT: still routes I-85 with 4 segments.
- Board responds in ~2s end-to-end.

## Test plan

- [ ] Open `/aviation` in preview - airport board renders with non-zero scores for at least the airports with active weather (ATL, anywhere with low ceilings/IFR).
- [ ] Open `/travel`, switch to Fly mode - same board renders.
- [ ] Trip planner Fly: e.g. `ATL` -> `DFW` returns a real combined score.
- [ ] Trip planner Drive: `ATL` -> `CLT` still scores I-85.
- [ ] Existing `/api/aviation/metar?station=KATL` and `/api/aviation/alerts` routes still work for the terminal view.

## Out of scope

The `NEXT_PUBLIC_BASE_URL=http://localhost:3000` value in Vercel env can stay misconfigured without affecting these features now, but it's worth fixing in the project settings to avoid surprising other code paths that might rely on it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized airport misery and trip-score aviation endpoints to fetch weather data in bulk instead of individual requests, improving performance and reliability.
  * Consolidated aviation weather alert data retrieval for more efficient and consistent information processing.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jelrod27/Weather-application-/pull/384)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->