### PR TITLE
fix(api): add timeouts to upstream weather/aviation fetches

### DIFF
--- a/app/api/aviation/metar/route.ts
+++ b/app/api/aviation/metar/route.ts
@@ -9,6 +9,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
+import { fetchWithTimeout } from '@/lib/fetch-with-timeout';
 
 // Simple in-memory cache with 10-minute TTL
 const metarCache = new Map<string, { data: MetarResponse; expires: number }>();
@@ -260,12 +261,13 @@ export async function GET(request: NextRequest) {
     // Using the Text Data Server API
     const url = `https://aviationweather.gov/api/data/metar?ids=${station}&format=raw&taf=false`;
 
-    const response = await fetch(url, {
+    const response = await fetchWithTimeout(url, {
       headers: {
         'Accept': 'text/plain',
         'User-Agent': '16-Bit-Weather/1.0',
       },
       cache: 'no-store', // Don't cache at edge, we manage our own cache
+      signal: request.signal,
     });
 
     if (!response.ok) {

--- a/app/api/extremes/route.ts
+++ b/app/api/extremes/route.ts
@@ -20,6 +20,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { HOT_LOCATIONS, COLD_LOCATIONS, LOCATION_FACTS, HISTORICAL_AVERAGES, type LocationTemperature } from '@/lib/extremes/extremes-data';
 import { parseOptionalLatLonQuery } from '@/lib/extremes/parse-query-coords';
+import { fetchWithTimeout } from '@/lib/fetch-with-timeout';
 
 /**
  * Fetch temperature data for a specific location using server-side API
@@ -29,7 +30,7 @@ async function fetchLocationTemperature(
   apiKey: string
 ): Promise<LocationTemperature | null> {
   try {
-    const response = await fetch(
+    const response = await fetchWithTimeout(
       `https://api.openweathermap.org/data/2.5/weather?lat=${location.lat}&lon=${location.lon}&units=imperial&appid=${apiKey}`,
       { next: { revalidate: 1800 } } // Cache for 30 minutes
     );
@@ -100,8 +101,9 @@ export async function GET(request: NextRequest) {
     let userLocation;
     if (userCoords) {
       try {
-        const response = await fetch(
-          `https://api.openweathermap.org/data/2.5/weather?lat=${userCoords.lat}&lon=${userCoords.lon}&units=imperial&appid=${apiKey}`
+        const response = await fetchWithTimeout(
+          `https://api.openweathermap.org/data/2.5/weather?lat=${userCoords.lat}&lon=${userCoords.lon}&units=imperial&appid=${apiKey}`,
+          { signal: request.signal }
         );
         
         if (response.ok) {

--- a/app/api/weather/forecast/route.ts
+++ b/app/api/weather/forecast/route.ts
@@ -14,6 +14,7 @@
 
 import { NextRequest, NextResponse } from 'next/server'
 import { rateLimitRequest } from '@/lib/services/weather-rate-limiter'
+import { fetchWithTimeout } from '@/lib/fetch-with-timeout'
 
 const BASE_URL = 'https://api.openweathermap.org/data/2.5'
 
@@ -70,7 +71,7 @@ export async function GET(request: NextRequest) {
     // Make request to OpenWeatherMap API
     const forecastUrl = `${BASE_URL}/forecast?lat=${latitude}&lon=${longitude}&appid=${apiKey}&units=${units}`
     
-    const response = await fetch(forecastUrl)
+    const response = await fetchWithTimeout(forecastUrl, { signal: request.signal })
     
     if (!response.ok) {
       const errorData = await response.text()

--- a/app/api/weather/pollen/route.ts
+++ b/app/api/weather/pollen/route.ts
@@ -14,6 +14,7 @@
 
 import { NextRequest, NextResponse } from 'next/server'
 import { rateLimitRequest } from '@/lib/services/weather-rate-limiter'
+import { fetchWithTimeout } from '@/lib/fetch-with-timeout'
 
 const BASE_URL = 'https://api.openweathermap.org/data/2.5'
 
@@ -72,7 +73,7 @@ export async function GET(request: NextRequest) {
       try {
         const googlePollenUrl = `https://pollen.googleapis.com/v1/forecast:lookup?key=${googlePollenApiKey}&location.latitude=${latitude}&location.longitude=${longitude}&days=1`
         
-        const response = await fetch(googlePollenUrl)
+        const response = await fetchWithTimeout(googlePollenUrl, { signal: request.signal })
         
         if (response.ok) {
           const data = await response.json()
@@ -160,7 +161,7 @@ export async function GET(request: NextRequest) {
     // Fallback to OpenWeather Air Pollution API for basic air quality data
     const airPollutionUrl = `${BASE_URL}/air_pollution?lat=${latitude}&lon=${longitude}&appid=${openWeatherApiKey}`
     
-    const response = await fetch(airPollutionUrl)
+    const response = await fetchWithTimeout(airPollutionUrl, { signal: request.signal })
     
     if (!response.ok) {
       return NextResponse.json({


### PR DESCRIPTION
## Summary
- Five external `fetch()` calls (OpenWeather forecast, Google Pollen + OpenWeather AQ fallback, NOAA AWC METAR, Extremes per-location + user-location) had no `AbortSignal`. A slow or hung upstream could pin a Vercel function for its full execution budget and exhaust the connection pool.
- Switched all five to the existing `lib/fetch-with-timeout` helper — 10s default timeout, retries on 429/502/503, and forwards the incoming `request.signal` so client disconnects abort upstream work.
- No behavior change on the happy path; the helper returns a `Response` exactly like `fetch`.

## Routes touched
- `app/api/weather/forecast/route.ts`
- `app/api/weather/pollen/route.ts` (both Google Pollen and OpenWeather fallback)
- `app/api/aviation/metar/route.ts`
- `app/api/extremes/route.ts` (per-location + user-location)

## Context
Came out of a Sentry/codebase audit. The only open Sentry issue (`JAVASCRIPT-NEXTJS-Z`) is from the deleted `/games` feature and can be marked resolved separately — no code change needed there.

## Test plan
- [ ] `npm run lint` — no new warnings (verified, 16 pre-existing)
- [ ] `npx tsc --noEmit` — clean (verified)
- [ ] Hit `/api/weather/forecast?lat=40.7&lon=-74` and confirm normal 200 response
- [ ] Hit `/api/aviation/metar?station=KJFK` and confirm normal METAR response
- [ ] Confirm Vercel function logs show no new error patterns post-deploy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes & Reliability**
  * Enhanced request timeout handling and cancellation support across weather API endpoints to improve service stability and responsiveness.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jelrod27/Weather-application-/pull/385)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->