### PR TITLE
fix(travel): parse autocomplete-formatted input in trip-score resolver

### DIFF
--- a/app/api/travel/trip-score/route.ts
+++ b/app/api/travel/trip-score/route.ts
@@ -122,13 +122,18 @@ async function resolveEndpoint(
   const trimmed = query.trim();
   if (!trimmed) return null;
 
-  const dashSplit = trimmed.split(/\s+[—–-]\s+/);
-  const codeCandidate = dashSplit[0]?.trim() ?? trimmed;
-  const cityCandidate = dashSplit.length > 1
-    ? dashSplit.slice(1).join(' ').trim()
-    : trimmed;
+  // Only treat the input as a "<CODE> — <City, ST>" autocomplete value if it
+  // actually starts with a 3-4 letter IATA/ICAO-shaped token. Without this
+  // gate, "Toledo — OH" would split as code=Toledo, city=OH (and 3-4 letter
+  // city names would do worse). The single anchored prefix match is also
+  // immune to the polynomial-backtracking concern CodeQL raised about a
+  // bare `\s+[—–-]\s+` split on user-controlled input.
+  const prefixMatch = trimmed.match(/^([A-Za-z]{3,4})\s+[—–-]\s+(.+)$/);
+  const hasAirportPrefix = prefixMatch !== null;
+  const codeCandidate = hasAirportPrefix ? prefixMatch[1] : trimmed;
+  const cityCandidate = hasAirportPrefix ? prefixMatch[2].trim() : trimmed;
 
-  const codeMatch = findAirportByCode(codeCandidate) ?? findAirportByCode(trimmed);
+  const codeMatch = findAirportByCode(codeCandidate);
   if (codeMatch) {
     return {
       query: trimmed,
@@ -143,7 +148,7 @@ async function resolveEndpoint(
     const cityMatch =
       (cityOnly && findAirportByCity(cityOnly)) ||
       findAirportByCity(cityCandidate) ||
-      findAirportByCity(trimmed);
+      (hasAirportPrefix ? undefined : findAirportByCity(trimmed));
     if (cityMatch) {
       return {
         query: trimmed,
@@ -154,7 +159,7 @@ async function resolveEndpoint(
     }
   }
 
-  const geocodeQuery = cityCandidate || trimmed;
+  const geocodeQuery = hasAirportPrefix ? cityCandidate : trimmed;
   try {
     const url = `${baseUrl}/api/weather/geocoding?q=${encodeURIComponent(geocodeQuery)}&limit=1`;
     const res = await fetchWithTimeout(url);

--- a/app/api/travel/trip-score/route.ts
+++ b/app/api/travel/trip-score/route.ts
@@ -107,10 +107,12 @@ async function fetchWithTimeout(
 }
 
 /**
- * Resolve a free-text query to coordinates. Tries:
- *   1. IATA/ICAO code lookup against the major airports table.
- *   2. City match against the major airports table (so "Atlanta" → ATL).
- *   3. Internal /api/weather/geocoding (Open-Meteo).
+ * Resolve a free-text query to coordinates. Tries the airports table by
+ * IATA/ICAO, then by city, then falls back to /api/weather/geocoding.
+ *
+ * TripInput autocomplete sends pre-formatted "<CODE> — <City>, <ST>"; we
+ * split on the dash before lookup since neither findAirportByCode nor the
+ * geocoder understand the prefixed form.
  */
 async function resolveEndpoint(
   query: string,
@@ -120,8 +122,13 @@ async function resolveEndpoint(
   const trimmed = query.trim();
   if (!trimmed) return null;
 
-  // 1) Direct airport code match.
-  const codeMatch = findAirportByCode(trimmed);
+  const dashSplit = trimmed.split(/\s+[—–-]\s+/);
+  const codeCandidate = dashSplit[0]?.trim() ?? trimmed;
+  const cityCandidate = dashSplit.length > 1
+    ? dashSplit.slice(1).join(' ').trim()
+    : trimmed;
+
+  const codeMatch = findAirportByCode(codeCandidate) ?? findAirportByCode(trimmed);
   if (codeMatch) {
     return {
       query: trimmed,
@@ -131,9 +138,12 @@ async function resolveEndpoint(
     };
   }
 
-  // 2) City/name match against hubs (most useful in fly mode).
   if (preferAirport) {
-    const cityMatch = findAirportByCity(trimmed);
+    const cityOnly = cityCandidate.replace(/,\s*[A-Z]{2}$/i, '').trim();
+    const cityMatch =
+      (cityOnly && findAirportByCity(cityOnly)) ||
+      findAirportByCity(cityCandidate) ||
+      findAirportByCity(trimmed);
     if (cityMatch) {
       return {
         query: trimmed,
@@ -144,9 +154,9 @@ async function resolveEndpoint(
     }
   }
 
-  // 3) Generic geocoding for free-text input.
+  const geocodeQuery = cityCandidate || trimmed;
   try {
-    const url = `${baseUrl}/api/weather/geocoding?q=${encodeURIComponent(trimmed)}&limit=1`;
+    const url = `${baseUrl}/api/weather/geocoding?q=${encodeURIComponent(geocodeQuery)}&limit=1`;
     const res = await fetchWithTimeout(url);
     if (!res.ok) return null;
 


### PR DESCRIPTION
## Summary
- The Travel Hub's \"Plan Trip\" button was returning HTTP 400 \"Could not resolve origin/destination\" on prod. The autocomplete formats values as \`DEN — Denver, CO\` and submits the raw string, but \`resolveEndpoint\` passed that whole string to \`findAirportByCode\`, which expects bare \`DEN\`. All three resolution paths (code → city → geocoder) failed.
- Fix: split on the em-dash/en-dash/hyphen separator, look up the IATA prefix against the airports table, fall back to city portion (with trailing \`, ST\` stripped) for the city lookup, and pass the city portion to the geocoder.

## Root cause
\`TripInput.tsx\` builds an autocomplete suggestion list whose values include the IATA prefix, then submits the selected value verbatim via URLSearchParams. \`resolveEndpoint\` was written for free-text input and never accounted for the prefixed form coming back from its own response shape.

## Test plan
- [ ] Hit /travel on prod after deploy, select \"DEN — Denver, CO\" / \"DFW — Dallas, TX\", verify trip score renders
- [ ] Bare IATA \"ATL\" still resolves (regression check)
- [ ] City-only \"Denver\" still resolves in fly mode (regression check)
- [ ] Free-text \"Toledo, OH\" still hits the geocoder fallback (regression check)
- [ ] No new lint or typecheck errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of airport code and city input formats, particularly dash-separated values
  * Enhanced location resolution with refined city matching and more robust geocoding fallback

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jelrod27/Weather-application-/pull/388)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->