### PR TITLE
fix(blog): coerce gray-matter Date to ISO string for OG metadata

### DIFF
--- a/lib/blog/index.ts
+++ b/lib/blog/index.ts
@@ -44,10 +44,22 @@ export function getAllPosts(): BlogPost[] {
     const fileContents = fs.readFileSync(filePath, 'utf8')
     const { data, content } = matter(fileContents)
     
+    // gray-matter (js-yaml) auto-coerces YAML timestamp scalars to Date
+    // objects. Next's metadata serializer renders that as "[object Object]"
+    // for `article:published_time`, which X's card validator rejects —
+    // breaking the share preview image. Force a string here.
+    const rawDate = data.date;
+    const dateString =
+      rawDate instanceof Date
+        ? rawDate.toISOString()
+        : typeof rawDate === 'string' && rawDate
+          ? rawDate
+          : new Date().toISOString();
+
     return {
       slug: data.slug || filename.replace(/\.mdx?$/, ''),
       title: data.title || 'Untitled',
-      date: data.date || new Date().toISOString(),
+      date: dateString,
       author: data.author || '16bitbot',
       summary: data.summary || '',
       tags: data.tags || [],


### PR DESCRIPTION
## Summary
Sharing a blog post link on X showed a generic gray placeholder card with no image. The OG and Twitter image tags are correct and the image endpoint returns 200/image/png — but a malformed \`article:published_time\` was tripping X's card parser.

## Root cause
\`gray-matter\` delegates YAML parsing to \`js-yaml\`, which auto-coerces ISO-8601 timestamp scalars in front-matter (\`date: 2026-05-10T19:00:03.170Z\`) to JS \`Date\` objects. \`getAllPosts\` in \`lib/blog/index.ts\` passed \`data.date\` through unchanged (the \`as BlogPost\` cast masked the type mismatch), and Next's metadata serializer stringified the Date as \`[object Object]\` for the article OG field:

\`\`\`html
<meta property=\"article:published_time\" content=\"[object Object]\"/>
\`\`\`

X's card validator is strict about Article OG tags and falls back to the generic icon when a required field is malformed.

## Fix
Coerce \`data.date\` to an ISO string at parse time in \`lib/blog/index.ts\`:
- Date object → \`.toISOString()\`
- Non-empty string → unchanged
- Missing → \`new Date().toISOString()\` (same as before)

## Test plan
- [ ] After deploy, hit the blog page and confirm \`article:published_time\` is an ISO string (not \`[object Object]\`):
      \`curl -A 'Mozilla/5.0' -sL https://www.16bitweather.co/blog/this-week-in-weather-2026-05-10 | grep article:published_time\`
- [ ] Use X's Card Validator (\`cards-dev.twitter.com/validator\`) to confirm the image renders
- [ ] If X has cached the broken card, append \`?v=2\` to the share URL to bust the cache
- [ ] Verify on-page rendering still shows post date correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)