### PR TITLE
fix(travel): autocomplete inserts bare IATA, not formatted prefix

### DIFF
--- a/components/travel/TripInput.tsx
+++ b/components/travel/TripInput.tsx
@@ -78,8 +78,13 @@ interface AutocompleteOption {
 }
 
 function buildAutocompleteOptions(mode: TripMode): AutocompleteOption[] {
+  // value = bare IATA code so picking from the dropdown puts only "DEN"
+  // into the field. The full "DEN — Denver, CO" label still renders in
+  // the dropdown for searchability (chrome/edge match label too) and
+  // visual confirmation. Submitting the bare code matches what the
+  // server resolver expects without prefix-parsing gymnastics.
   const airportOptions: AutocompleteOption[] = MAJOR_US_AIRPORTS.map((a) => ({
-    value: `${a.iata} — ${a.city}, ${a.state}`,
+    value: a.iata,
     label: `${a.iata} — ${a.city}, ${a.state}`,
   }));
 


### PR DESCRIPTION
## Summary
When you pick \"DEN — Denver, CO\" from the TripInput dropdown, the field gets populated with the whole formatted string. Submitting then sends \`DEN — Denver, CO\` as the origin/destination — which fails server-side resolution (\"Could not resolve origin/destination\"). Typing the bare code (\`DEN\`) works fine; the bug is purely the autocomplete carrying down the prefix.

## Fix
Change the airport option's \`value\` to the bare IATA code (\`a.iata\`). Keep the formatted \"DEN — Denver, CO\" as the option's text content so:
- The dropdown still shows the full label (so users can find airports by city name)
- Selecting puts only \`DEN\` into the input field
- The form submits the canonical bare code that \`findAirportByCode\` consumes directly — no prefix-parsing required

City options in drive mode are unchanged (\"Denver, CO\" stays — the geocoder consumes that form).

## Why this and not the server fix
PR #388 added server-side prefix-parsing as defense-in-depth. This PR fixes the actual UX bug at the source. They're complementary — even after PR #388 lands, this still cleans up the input field so users see what they actually selected.

## Test plan
- [ ] On the deploy preview /travel page: select \"DEN — Denver, CO\" from the dropdown, confirm input shows just \`DEN\`
- [ ] Plan Trip with menu-selected origin/destination → expect trip score, not 400
- [ ] Type \`Denver\` → confirm DEN airport still appears in dropdown (label-side filter)
- [ ] Drive mode: select \"Denver, CO\" city option → confirm input shows \"Denver, CO\" and trip computes

🤖 Generated with [Claude Code](https://claude.com/claude-code)