### PR TITLE
feat(blog): replace 40+ tag filters with 4 curated categories

### DIFF
--- a/__tests__/blog-index-layout.test.tsx
+++ b/__tests__/blog-index-layout.test.tsx
@@ -32,8 +32,9 @@ jest.mock('@/components/share-buttons', () => ({
   ShareButtons: () => <div data-testid="share-buttons" />,
 }))
 
-import { render, screen } from '@testing-library/react'
-import type { BlogPost } from '@/lib/blog'
+import { render, screen, fireEvent } from '@testing-library/react'
+import type { BlogPost, BlogCategory } from '@/lib/blog'
+import { getAllPosts, getPostCategoryIds, BLOG_CATEGORIES } from '@/lib/blog'
 
 const makePosts = (count: number): BlogPost[] =>
   Array.from({ length: count }, (_, i) => ({
@@ -48,25 +49,63 @@ const makePosts = (count: number): BlogPost[] =>
     content: `Content for post ${i}`,
   }))
 
+let BlogIndex: React.ComponentType<{
+  posts: BlogPost[]
+  categories: BlogCategory[]
+  initialCategory: string | null
+}>
+
+beforeAll(async () => {
+  const mod = await import('@/app/blog/blog-index')
+  BlogIndex = mod.BlogIndex
+})
+
 describe('Blog index layout', () => {
-  let BlogIndex: React.ComponentType<{ posts: BlogPost[]; tags: string[]; initialTag: string | null }>
-
-  beforeAll(async () => {
-    const mod = await import('@/app/blog/blog-index')
-    BlogIndex = mod.BlogIndex
-  })
-
   it('should render a FEATURED INTEL badge on the first post', () => {
-    render(<BlogIndex posts={makePosts(4)} tags={[]} initialTag={null} />)
+    render(<BlogIndex posts={makePosts(4)} categories={[]} initialCategory={null} />)
     expect(screen.getByText('FEATURED INTEL')).toBeInTheDocument()
   })
 
   it('should render remaining posts in a grid container', () => {
-    const { container } = render(<BlogIndex posts={makePosts(4)} tags={[]} initialTag={null} />)
+    const { container } = render(<BlogIndex posts={makePosts(4)} categories={[]} initialCategory={null} />)
     const grid = container.querySelector('.grid')
     expect(grid).toBeInTheDocument()
     // Grid should contain 3 posts (4 total minus 1 featured)
     const gridLinks = grid!.querySelectorAll('a')
     expect(gridLinks).toHaveLength(3)
+  })
+})
+
+describe('Blog category filter', () => {
+  it('renders an ALL button plus one button per provided category', () => {
+    render(<BlogIndex posts={makePosts(3)} categories={BLOG_CATEGORIES} initialCategory={null} />)
+    expect(screen.getByText('ALL')).toBeInTheDocument()
+    for (const category of BLOG_CATEGORIES) {
+      expect(screen.getByText(category.label)).toBeInTheDocument()
+    }
+  })
+
+  it('maps every published post to at least one category', () => {
+    const posts = getAllPosts()
+    expect(posts.length).toBeGreaterThan(0)
+    const orphans = posts
+      .filter(p => getPostCategoryIds(p.tags).length === 0)
+      .map(p => p.slug)
+    expect(orphans).toEqual([])
+  })
+
+  it('filters the list to posts in the selected category', () => {
+    const [base] = makePosts(1)
+    const posts: BlogPost[] = [
+      { ...base, slug: 'space-post', title: 'Solar Flare Watch', tags: ['space weather'] },
+      { ...base, slug: 'severe-post', title: 'Tornado Outbreak', tags: ['tornadoes'] },
+    ]
+    render(<BlogIndex posts={posts} categories={BLOG_CATEGORIES} initialCategory={null} />)
+    expect(screen.getByText('Solar Flare Watch')).toBeInTheDocument()
+    expect(screen.getByText('Tornado Outbreak')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('Severe Weather'))
+    expect(screen.queryByText('Solar Flare Watch')).not.toBeInTheDocument()
+    expect(screen.getByText('Tornado Outbreak')).toBeInTheDocument()
   })
 })

--- a/app/blog/blog-index.tsx
+++ b/app/blog/blog-index.tsx
@@ -10,23 +10,24 @@ import { getComponentStyles, type ThemeType } from '@/lib/theme-utils'
 import PageWrapper from '@/components/page-wrapper'
 import { ShareButtons } from '@/components/share-buttons'
 import type { BlogPost } from '@/lib/blog'
+import { getPostCategoryIds, type BlogCategory } from '@/lib/blog/categories'
 
 const POSTS_PER_PAGE = 10
 
 interface BlogIndexProps {
   posts: BlogPost[]
-  tags: string[]
-  initialTag: string | null
+  categories: BlogCategory[]
+  initialCategory: string | null
 }
 
-export function BlogIndex({ posts, tags, initialTag }: BlogIndexProps) {
-  const [selectedTag, setSelectedTag] = useState<string | null>(initialTag)
+export function BlogIndex({ posts, categories, initialCategory }: BlogIndexProps) {
+  const [selectedCategory, setSelectedCategory] = useState<string | null>(initialCategory)
   const [page, setPage] = useState(1)
   const { theme } = useTheme()
   const themeClasses = getComponentStyles(theme as ThemeType, 'card')
 
-  const filtered = selectedTag
-    ? posts.filter(p => p.tags.some(t => t.toLowerCase() === selectedTag.toLowerCase()))
+  const filtered = selectedCategory
+    ? posts.filter(p => getPostCategoryIds(p.tags).some(id => id === selectedCategory))
     : posts
 
   const totalPages = Math.ceil(filtered.length / POSTS_PER_PAGE)
@@ -63,32 +64,32 @@ export function BlogIndex({ posts, tags, initialTag }: BlogIndexProps) {
           />
         </div>
 
-        {/* Tag filter */}
-        {tags.length > 0 && (
+        {/* Category filter */}
+        {categories.length > 0 && (
           <div className="flex flex-wrap gap-2 justify-center">
             <button
-              onClick={() => { setSelectedTag(null); setPage(1) }}
+              onClick={() => { setSelectedCategory(null); setPage(1) }}
               className={cn(
                 'px-3 py-1 text-xs font-mono uppercase tracking-wider rounded border transition-colors',
-                !selectedTag
+                !selectedCategory
                   ? 'bg-[hsl(var(--primary))] text-[hsl(var(--primary-foreground))] border-[hsl(var(--primary))]'
                   : 'border-[hsl(var(--border))] text-[hsl(var(--muted-foreground))] hover:border-[hsl(var(--primary))]'
               )}
             >
               ALL
             </button>
-            {tags.map(tag => (
+            {categories.map(category => (
               <button
-                key={tag}
-                onClick={() => { setSelectedTag(tag); setPage(1) }}
+                key={category.id}
+                onClick={() => { setSelectedCategory(category.id); setPage(1) }}
                 className={cn(
                   'px-3 py-1 text-xs font-mono uppercase tracking-wider rounded border transition-colors',
-                  selectedTag === tag
+                  selectedCategory === category.id
                     ? 'bg-[hsl(var(--primary))] text-[hsl(var(--primary-foreground))] border-[hsl(var(--primary))]'
                     : 'border-[hsl(var(--border))] text-[hsl(var(--muted-foreground))] hover:border-[hsl(var(--primary))]'
                 )}
               >
-                {tag}
+                {category.label}
               </button>
             ))}
           </div>

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,26 +1,27 @@
 import type { Metadata } from 'next'
-import { getAllPosts, getAllTags } from '@/lib/blog'
+import { getAllPosts, getCategoriesInUse, BLOG_CATEGORIES } from '@/lib/blog'
 import { BlogIndex } from './blog-index'
 
 const BASE_URL = 'https://www.16bitweather.co'
 
 interface PageProps {
-  searchParams: Promise<{ tag?: string }>
+  searchParams: Promise<{ category?: string }>
 }
 
 export async function generateMetadata({ searchParams }: PageProps): Promise<Metadata> {
-  const { tag } = await searchParams
+  const { category } = await searchParams
 
   const baseTitle = '16 Bit Weather Blog | Weekly Dispatches from 16bitbot'
   const baseDescription =
     'Weekly dispatches from 16bitbot. Space weather, severe storms, weather phenomena, and climate records.'
 
-  // Tag-filtered URLs are near-duplicates of the index — keep them out of the index
-  // so crawl budget concentrates on canonical /blog and individual posts.
-  if (tag) {
+  // Category-filtered URLs are near-duplicates of the index — keep them out of
+  // the index so crawl budget concentrates on canonical /blog and posts.
+  const categoryLabel = BLOG_CATEGORIES.find(c => c.id === category)?.label
+  if (categoryLabel) {
     return {
-      title: `${tag} | ${baseTitle}`,
-      description: `${tag} posts — ${baseDescription}`,
+      title: `${categoryLabel} | ${baseTitle}`,
+      description: `${categoryLabel} posts — ${baseDescription}`,
       robots: { index: false, follow: true },
       alternates: { canonical: `${BASE_URL}/blog` },
     }
@@ -35,7 +36,9 @@ export async function generateMetadata({ searchParams }: PageProps): Promise<Met
 
 export default async function BlogPage({ searchParams }: PageProps) {
   const posts = getAllPosts()
-  const tags = getAllTags()
-  const { tag } = await searchParams
-  return <BlogIndex posts={posts} tags={tags} initialTag={tag || null} />
+  const categories = getCategoriesInUse()
+  const { category } = await searchParams
+  const initialCategory =
+    category && BLOG_CATEGORIES.some(c => c.id === category) ? category : null
+  return <BlogIndex posts={posts} categories={categories} initialCategory={initialCategory} />
 }

--- a/lib/blog/categories.ts
+++ b/lib/blog/categories.ts
@@ -1,0 +1,101 @@
+/**
+ * Blog filter categories.
+ *
+ * The blog index filters posts by a small, fixed set of categories rather
+ * than exposing every raw frontmatter tag (which produced 40+ near-duplicate
+ * buttons). Posts keep their original `tags`; this module just maps those
+ * tags onto categories.
+ *
+ * Pure module — no `fs`/Node imports — so it is safe to import from both
+ * server and client components.
+ */
+
+export type BlogCategoryId =
+  | 'space-weather'
+  | 'severe-weather'
+  | 'climate-earth'
+  | 'weekly-dispatch'
+
+export interface BlogCategory {
+  id: BlogCategoryId
+  label: string
+}
+
+/** Canonical category list, in display order. */
+export const BLOG_CATEGORIES: BlogCategory[] = [
+  { id: 'space-weather', label: 'Space Weather' },
+  { id: 'severe-weather', label: 'Severe Weather' },
+  { id: 'climate-earth', label: 'Climate & Earth' },
+  { id: 'weekly-dispatch', label: 'Weekly Dispatch' },
+]
+
+/**
+ * Maps a normalized tag to its category. A tag that is not listed here simply
+ * contributes no category — the post still appears under "All". The
+ * blog-index test asserts every current post lands in at least one category,
+ * so add new tags here as they appear.
+ */
+const TAG_TO_CATEGORY: Record<string, BlogCategoryId> = {
+  // Space Weather
+  'aurora': 'space-weather',
+  'sun': 'space-weather',
+  'solar weather': 'space-weather',
+  'solar cycle': 'space-weather',
+  'solar flare': 'space-weather',
+  'solar flares': 'space-weather',
+  'solar activity': 'space-weather',
+  'geomagnetic': 'space-weather',
+  'geomagnetic storms': 'space-weather',
+  'space weather': 'space-weather',
+  'lyrid meteor shower': 'space-weather',
+  // Severe Weather
+  'severe weather': 'severe-weather',
+  'tornadoes': 'severe-weather',
+  'supercells': 'severe-weather',
+  'plains': 'severe-weather',
+  'spring storms': 'severe-weather',
+  'spring pattern': 'severe-weather',
+  'spring weather': 'severe-weather',
+  'freeze warning': 'severe-weather',
+  'tropical': 'severe-weather',
+  'california rain': 'severe-weather',
+  'forecast': 'severe-weather',
+  // Climate & Earth
+  'climate': 'climate-earth',
+  'paleoclimate': 'climate-earth',
+  'cryosphere': 'climate-earth',
+  'ocean currents': 'climate-earth',
+  'pacific': 'climate-earth',
+  'el nino': 'climate-earth',
+  'earth day': 'climate-earth',
+  'earthquakes': 'climate-earth',
+  'tsunami': 'climate-earth',
+  'volcanoes': 'climate-earth',
+  'atmosphere layers': 'climate-earth',
+  'aviation': 'climate-earth',
+  'science': 'climate-earth',
+  'weather': 'climate-earth',
+  'historical events': 'climate-earth',
+  // Weekly Dispatch
+  'weekly recap': 'weekly-dispatch',
+  'weekly dispatch': 'weekly-dispatch',
+  'roadmap': 'weekly-dispatch',
+}
+
+/** Lowercase, collapse hyphen/whitespace runs to a single space, trim. */
+function normalizeTag(tag: string): string {
+  return tag.toLowerCase().replace(/[\s-]+/g, ' ').trim()
+}
+
+/**
+ * Category ids for a set of post tags, in canonical order. May be empty if
+ * none of the tags map to a known category.
+ */
+export function getPostCategoryIds(tags: string[]): BlogCategoryId[] {
+  const matched = new Set<BlogCategoryId>()
+  for (const tag of tags) {
+    const id = TAG_TO_CATEGORY[normalizeTag(tag)]
+    if (id) matched.add(id)
+  }
+  return BLOG_CATEGORIES.map(c => c.id).filter(id => matched.has(id))
+}

--- a/lib/blog/index.ts
+++ b/lib/blog/index.ts
@@ -2,6 +2,14 @@ import fs from 'fs'
 import path from 'path'
 import matter from 'gray-matter'
 
+import { BLOG_CATEGORIES, getPostCategoryIds, type BlogCategory } from './categories'
+
+// Re-export the category layer so server code can import everything from
+// `@/lib/blog`. Client components should import from `@/lib/blog/categories`
+// directly to avoid pulling this fs-backed module into the browser bundle.
+export { BLOG_CATEGORIES, getPostCategoryIds } from './categories'
+export type { BlogCategory, BlogCategoryId } from './categories'
+
 const BLOG_DIR = path.join(process.cwd(), 'content/blog')
 
 export type NewsletterCadence = 'wednesday_topic' | 'sunday_rearview'
@@ -104,6 +112,12 @@ export function getAllTags(): string[] {
   const tagSet = new Set<string>()
   posts.forEach(p => p.tags.forEach(t => tagSet.add(t)))
   return Array.from(tagSet).sort()
+}
+
+/** Categories that have at least one published post, in canonical order. */
+export function getCategoriesInUse(): BlogCategory[] {
+  const used = new Set(getAllPosts().flatMap(p => getPostCategoryIds(p.tags)))
+  return BLOG_CATEGORIES.filter(c => used.has(c.id))
 }
 
 function getPostsByTag(tag: string): BlogPost[] {


### PR DESCRIPTION
The blog index filter bar rendered one button per raw frontmatter tag, producing 40+ near-duplicate options (e.g. "severe weather" vs "severe-weather", five separate solar tags). Add a small fixed category taxonomy and filter by that instead.

- lib/blog/categories.ts: pure tag-to-category map (no fs imports, safe for client + server). Categories: Space Weather, Severe Weather, Climate & Earth, Weekly Dispatch.
- lib/blog/index.ts: add getCategoriesInUse(); re-export category layer.
- app/blog/page.tsx: ?tag= search param becomes ?category=.
- app/blog/blog-index.tsx: render the 4 category buttons and filter by category membership. Per-post tag chips on cards are unchanged.
- tests: filter bar shows ALL + 4 categories; every post maps to >=1 category (drift guard); selecting a category filters the list.

Posts keep their original `tags` (related-posts scoring, RSS, card chips). getAllTags() is retained but no longer used by the index page.