### PR TITLE
Fix weather page state and blog filter issues

### DIFF
--- a/app/extremes/page.tsx
+++ b/app/extremes/page.tsx
@@ -14,7 +14,7 @@
  * Report issues: https://github.com/deephouse23/Weather-application-/issues
  */
 
-import { useState, useEffect, useRef } from "react"
+import { useCallback, useState, useEffect, useRef } from "react"
 import PageWrapper from "@/components/page-wrapper"
 import { TrendingUp, TrendingDown, MapPin, RefreshCw, Thermometer } from "lucide-react"
 import { ExtremesData, LocationTemperature } from "@/lib/extremes/extremes-data"
@@ -26,19 +26,25 @@ import { Skeleton } from "@/components/ui/skeleton"
 // Client-side cache management
 const CACHE_KEY = '16bit-weather-extremes-cache';
 const CACHE_DURATION = 30 * 60 * 1000; // 30 minutes
+type Coordinates = { lat: number; lon: number }
 
-function getCachedExtremesClient(): ExtremesData | null {
+function getExtremesCacheKey(coords: Coordinates | null): string {
+  if (!coords) return `${CACHE_KEY}:global`
+  return `${CACHE_KEY}:${coords.lat.toFixed(3)},${coords.lon.toFixed(3)}`
+}
+
+function getCachedExtremesClient(cacheKey: string): ExtremesData | null {
   if (typeof window === 'undefined') return null;
 
   try {
-    const cached = localStorage.getItem(CACHE_KEY);
+    const cached = localStorage.getItem(cacheKey);
     if (!cached) return null;
 
     const data = JSON.parse(cached);
     const age = Date.now() - data.lastUpdated;
 
     if (age > CACHE_DURATION) {
-      localStorage.removeItem(CACHE_KEY);
+      localStorage.removeItem(cacheKey);
       return null;
     }
 
@@ -49,11 +55,11 @@ function getCachedExtremesClient(): ExtremesData | null {
   }
 }
 
-function setCachedExtremesClient(data: ExtremesData): void {
+function setCachedExtremesClient(cacheKey: string, data: ExtremesData): void {
   if (typeof window === 'undefined') return;
 
   try {
-    localStorage.setItem(CACHE_KEY, JSON.stringify(data));
+    localStorage.setItem(cacheKey, JSON.stringify(data));
   } catch (error) {
     console.error('Error setting cache:', error);
   }
@@ -63,7 +69,7 @@ export default function ExtremesPage() {
   const [data, setData] = useState<ExtremesData | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
-  const [userCoords, setUserCoords] = useState<{ lat: number; lon: number } | null>(null)
+  const [userCoords, setUserCoords] = useState<Coordinates | null>(null)
   const [autoRefresh, setAutoRefresh] = useState(true)
   const [selectedLocation, setSelectedLocation] = useState<LocationTemperature | null>(null)
   const refreshIntervalRef = useRef<NodeJS.Timeout | null>(null)
@@ -74,15 +80,16 @@ export default function ExtremesPage() {
   }
 
   // Fetch extremes data (abort in-flight request when a newer one starts — geolocation vs initial load)
-  const fetchData = async (skipCache = false) => {
+  const fetchData = useCallback(async (skipCache = false, coords: Coordinates | null = null) => {
     fetchAbortRef.current?.abort()
     const controller = new AbortController()
     fetchAbortRef.current = controller
+    const cacheKey = getExtremesCacheKey(coords)
 
     try {
       // Check client-side cache first
       if (!skipCache) {
-        const cached = getCachedExtremesClient();
+        const cached = getCachedExtremesClient(cacheKey);
         if (cached) {
           setData(cached);
           setLoading(false);
@@ -94,8 +101,8 @@ export default function ExtremesPage() {
       setError(null)
 
       let url = '/api/extremes'
-      if (userCoords) {
-        url += `?lat=${userCoords.lat}&lon=${userCoords.lon}`
+      if (coords) {
+        url += `?lat=${coords.lat}&lon=${coords.lon}`
       }
 
       const response = await fetch(url, { signal: controller.signal })
@@ -108,7 +115,7 @@ export default function ExtremesPage() {
       if (controller.signal.aborted) return
 
       setData(responseData)
-      setCachedExtremesClient(responseData) // Cache on client side
+      setCachedExtremesClient(cacheKey, responseData) // Cache on client side
     } catch (err) {
       if ((err as Error).name === 'AbortError') return
       console.error('Error fetching extremes:', err)
@@ -118,7 +125,7 @@ export default function ExtremesPage() {
         setLoading(false)
       }
     }
-  }
+  }, [])
 
   // Get user location
   const getUserLocation = () => {
@@ -140,24 +147,24 @@ export default function ExtremesPage() {
   // Initial fetch + request browser location (second fetch runs when userCoords is set)
   useEffect(() => {
     getUserLocation()
-    void fetchData()
+    void fetchData(false, null)
     return () => {
       fetchAbortRef.current?.abort()
     }
-  }, [])
+  }, [fetchData])
 
   // Re-fetch when user coords change
   useEffect(() => {
     if (userCoords) {
-      fetchData(true) // Skip cache when user location changes
+      fetchData(true, userCoords) // Skip cache when user location changes
     }
-  }, [userCoords])
+  }, [fetchData, userCoords])
 
   // Auto-refresh every 30 minutes
   useEffect(() => {
     if (autoRefresh) {
       refreshIntervalRef.current = setInterval(() => {
-        fetchData(true) // Skip cache for refresh
+        fetchData(true, userCoords) // Skip cache for refresh
       }, 30 * 60 * 1000) // 30 minutes
     }
 
@@ -166,7 +173,7 @@ export default function ExtremesPage() {
         clearInterval(refreshIntervalRef.current)
       }
     }
-  }, [autoRefresh, userCoords])
+  }, [autoRefresh, fetchData, userCoords])
 
   // Thermometer visualization component with theme colors
   const ThermometerViz = ({ temp, max = 140, min = -100 }: { temp: number; max?: number; min?: number }) => {

--- a/app/weather/[city]/client.tsx
+++ b/app/weather/[city]/client.tsx
@@ -12,7 +12,7 @@
 
 
 import type { JSX } from 'react'
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { fetchWeatherData } from '@/lib/weather'
 import { useAuth } from '@/lib/auth'
@@ -59,10 +59,13 @@ export default function CityWeatherClient({ city, citySlug }: CityWeatherClientP
   const [error, setError] = useState<string>("")
   const [selectedDay, setSelectedDay] = useState<number | null>(null)
   const [precipitation, setPrecipitation] = useState<{rain24h: number; snow24h: number} | null>(null)
+  const weatherRequestRef = useRef(0)
+  const weatherLatitude = weather?.coordinates?.lat
+  const weatherLongitude = weather?.coordinates?.lon
 
   // Fetch 24h precipitation data when weather loads
   useEffect(() => {
-    if (!weather?.coordinates) return
+    if (weatherLatitude == null || weatherLongitude == null) return
 
     // Clear stale data immediately on city transition
     setPrecipitation(null)
@@ -70,7 +73,7 @@ export default function CityWeatherClient({ city, citySlug }: CityWeatherClientP
     // AbortController to prevent race conditions when switching cities quickly
     const controller = new AbortController()
 
-    fetch(`/api/weather/precipitation-history?lat=${weather.coordinates.lat}&lon=${weather.coordinates.lon}`, {
+    fetch(`/api/weather/precipitation-history?lat=${weatherLatitude}&lon=${weatherLongitude}`, {
       signal: controller.signal
     })
       .then(res => res.ok ? res.json() : null)
@@ -87,7 +90,7 @@ export default function CityWeatherClient({ city, citySlug }: CityWeatherClientP
       })
 
     return () => controller.abort()
-  }, [weather?.coordinates?.lat, weather?.coordinates?.lon])
+  }, [weatherLatitude, weatherLongitude])
 
   // Helper: normalize "San Ramon, CA" -> "san-ramon-ca"
   const toSlug = (input: string) =>
@@ -99,25 +102,34 @@ export default function CityWeatherClient({ city, citySlug }: CityWeatherClientP
       .replace(/[^a-z0-9-]/g, '')
 
   // Load weather data for the specific city
-  const loadCityWeather = async () => {
+  const loadCityWeather = useCallback(async () => {
+    const requestId = weatherRequestRef.current + 1
+    weatherRequestRef.current = requestId
+
     try {
       setLoading(true)
       setError("")
 
       const unitSystem: 'metric' | 'imperial' = preferences?.temperature_unit === 'celsius' ? 'metric' : 'imperial'
       const weatherData = await fetchWeatherData(city.searchTerm, unitSystem)
+
+      if (requestId !== weatherRequestRef.current) return
+
       setWeather(weatherData)
 
       // Update location context with city data
       setLocationInput(city.searchTerm)
       setCurrentLocation(weatherData.location || city.searchTerm)
     } catch (err) {
+      if (requestId !== weatherRequestRef.current) return
       console.error('Error loading city weather:', err)
       setError(err instanceof Error ? err.message : 'Failed to load weather data')
     } finally {
-      setLoading(false)
+      if (requestId === weatherRequestRef.current) {
+        setLoading(false)
+      }
     }
-  }
+  }, [city.searchTerm, preferences?.temperature_unit, setCurrentLocation, setLocationInput])
 
   // CLEAR local state whenever the route/citySlug changes (prevents ghost data)
   useEffect(() => {
@@ -129,22 +141,20 @@ export default function CityWeatherClient({ city, citySlug }: CityWeatherClientP
     // Then set the current city as the location
     setLocationInput(city.searchTerm)
     setCurrentLocation(city.searchTerm)
-  }, [citySlug])
+  }, [city.searchTerm, citySlug, clearLocationState, setCurrentLocation, setLocationInput])
 
   // Existing effect: load weather for this page's city (runs after reset above)
   useEffect(() => {
     setShouldClearOnRouteChange(false)
 
-    if (city) {
-      // Load city-specific weather data first (city pages should show city data, not user location)
-      loadCityWeather()
-    }
+    // Load city-specific weather data first (city pages should show city data, not user location)
+    loadCityWeather()
 
     // Cleanup: enable route change clearing when leaving city pages
     return () => {
       setShouldClearOnRouteChange(true)
     }
-  }, [city?.searchTerm, setShouldClearOnRouteChange])
+  }, [loadCityWeather, setShouldClearOnRouteChange])
 
   // REPLACE handleSearch to navigate instead of only setting local weather
   const handleSearch = async (locationInput: string) => {


### PR DESCRIPTION
## Summary
- Refetch city weather when the user temperature unit changes and guard against stale city weather responses.
- Scope extremes-page localStorage cache entries by global vs rounded user coordinates.
- Close the blog filter popover after selecting filters, and move key-term link helpers into a client-safe module.

## Tests
- npm run lint
- npm test -- --runInBand __tests__/blog-index-layout.test.tsx __tests__/blog-key-terms.test.tsx
- npm run build (fails locally: missing optional native module `lightningcss.darwin-arm64.node` in node_modules)

## Notes
- No test files were modified in this branch.
- Local git hooks skipped secret scanning because `gitleaks` is not installed in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced blog tag filtering with bucket-based organization and improved filter UI.
  * Added two new weather metrics: supercell and cape definitions.

* **Bug Fixes**
  * Improved location-aware data caching for extremes feature.
  * Fixed race conditions when rapidly switching between weather cities.
  * Added validation for glossary term links in blog content.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jelrod27/Weather-application-/pull/403?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->