### PR TITLE
feat(radar): Phase 1 storm-watch reliability (MRMS + RainViewer)

### DIFF
--- a/__tests__/radar-timestamps.test.ts
+++ b/__tests__/radar-timestamps.test.ts
@@ -1,0 +1,64 @@
+import {
+  buildRadarTimestamps,
+  minutesSinceFrame,
+  quantizeRadarTime,
+  stormWatchStartIndex,
+} from '@/lib/radar/radar-timestamps'
+import { parseRainViewerMapsPayload, rainViewerTileUrl } from '@/lib/radar/rainviewer-types'
+
+describe('radar timestamps', () => {
+  it('should quantize to 5-minute boundaries', () => {
+    const ms = new Date('2026-05-22T14:07:30.000Z').getTime()
+    const quantized = quantizeRadarTime(ms, 5)
+    expect(new Date(quantized).toISOString()).toBe('2026-05-22T14:05:00.000Z')
+  })
+
+  it('should build 49 frames for default 4-hour US window', () => {
+    const now = new Date('2026-05-22T15:00:00.000Z').getTime()
+    const frames = buildRadarTimestamps({ nowMs: now })
+    expect(frames).toHaveLength(49)
+    expect(frames[0]).toBe(now - 48 * 5 * 60 * 1000)
+    expect(frames[frames.length - 1]).toBe(now)
+  })
+
+  it('should compute minutes since latest frame', () => {
+    const frame = Date.now() - 8 * 60 * 1000
+    expect(minutesSinceFrame(frame)).toBe(8)
+  })
+
+  it('should compute storm watch start index for 2 hours', () => {
+    expect(stormWatchStartIndex(49, 24)).toBe(24)
+    expect(stormWatchStartIndex(10, 24)).toBe(0)
+  })
+})
+
+describe('rainviewer parsing', () => {
+  it('should parse public API shape', () => {
+    const parsed = parseRainViewerMapsPayload({
+      host: 'https://tilecache.rainviewer.com',
+      radar: {
+        past: [
+          { time: 1000, path: '/v2/radar/1000/256/{z}/{x}/{y}/2/1_1.png' },
+          { time: 2000, path: '/v2/radar/2000/256/{z}/{x}/{y}/2/1_1.png' },
+        ],
+      },
+    })
+
+    expect(parsed?.host).toBe('https://tilecache.rainviewer.com')
+    expect(parsed?.past).toHaveLength(2)
+    expect(parsed?.past[0]?.time).toBe(1000)
+  })
+
+  it('should build tile URLs from path templates', () => {
+    const url = rainViewerTileUrl(
+      'https://tilecache.rainviewer.com',
+      '/v2/radar/1000/256/{z}/{x}/{y}/2/1_1.png',
+      8,
+      41,
+      23
+    )
+    expect(url).toBe(
+      'https://tilecache.rainviewer.com/v2/radar/1000/256/8/41/23/2/1_1.png'
+    )
+  })
+})

--- a/__tests__/radar-timestamps.test.ts
+++ b/__tests__/radar-timestamps.test.ts
@@ -1,3 +1,4 @@
+import { RADAR_STEP_MINUTES, US_RADAR_SOURCE_ID, INTL_RADAR_SOURCE_ID } from '@/lib/radar/radar-config'
 import {
   buildRadarTimestamps,
   minutesSinceFrame,
@@ -5,6 +6,14 @@ import {
   stormWatchStartIndex,
 } from '@/lib/radar/radar-timestamps'
 import { parseRainViewerMapsPayload, rainViewerTileUrl } from '@/lib/radar/rainviewer-types'
+
+describe('radar config', () => {
+  it('should expose stable US and international source ids', () => {
+    expect(US_RADAR_SOURCE_ID).toBe('iowa-wms-t')
+    expect(INTL_RADAR_SOURCE_ID).toBe('rainviewer')
+    expect(RADAR_STEP_MINUTES).toBe(5)
+  })
+})
 
 describe('radar timestamps', () => {
   it('should quantize to 5-minute boundaries', () => {

--- a/__tests__/radar-timestamps.test.ts
+++ b/__tests__/radar-timestamps.test.ts
@@ -39,6 +39,17 @@ describe('radar timestamps', () => {
     expect(stormWatchStartIndex(49, 24)).toBe(24)
     expect(stormWatchStartIndex(10, 24)).toBe(0)
   })
+
+  it('should fall back to defaults for invalid step and past options', () => {
+    const now = new Date('2026-05-22T15:00:00.000Z').getTime()
+    const frames = buildRadarTimestamps({
+      nowMs: now,
+      stepMinutes: 0,
+      pastSteps: -5,
+    })
+    expect(frames).toHaveLength(49)
+    expect(frames.every((frame) => Number.isFinite(frame))).toBe(true)
+  })
 })
 
 describe('rainviewer parsing', () => {

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -47,7 +47,7 @@ function Accordion({ title, icon: Icon, children, defaultOpen = false }: {
 }
 
 const modules = [
-  { href: "/radar", label: "Radar", desc: "Real-time NOAA MRMS radar with animated playback", icon: Map },
+  { href: "/radar", label: "Radar", desc: "Animated US NEXRAD composite and global RainViewer radar", icon: Map },
   { href: "/warnings", label: "Warnings Command Center", desc: "Live NWS alerts with WIS score, SPC outlook, alert polygons, and storm reports", icon: AlertTriangle },
   { href: "/severe", label: "Severe Weather", desc: "Active tornado, thunderstorm, and flood warnings", icon: CloudLightning },
   { href: "/travel", label: "Travel Hub", desc: "Will your trip suck? Airport delay risk, road conditions, and a personal trip score for fly or drive", icon: Route },
@@ -155,7 +155,7 @@ export default function AboutPage() {
                   { icon: Database, label: "DATA LAYER", value: "Supabase PostgreSQL + Row-Level Security" },
                   { icon: CloudLightning, label: "WEATHER DATA", value: "OpenWeatherMap + NOAA + NWS + USGS + NASA" },
                   { icon: Sparkles, label: "AI ENGINE", value: "Vercel AI SDK + Claude (Anthropic)" },
-                  { icon: Globe, label: "RADAR", value: "NOAA MRMS + Iowa NEXRAD via OpenLayers" },
+                  { icon: Globe, label: "RADAR", value: "Iowa NEXRAD (US) + RainViewer (intl) via OpenLayers" },
                   { icon: Gauge, label: "MONITORING", value: "Sentry + Lighthouse CI (score >= 85)" },
                   { icon: Gamepad2, label: "AESTHETIC", value: "Tailwind CSS v4 + 5 retro themes" },
                   { icon: Shield, label: "DEPLOYMENT", value: "Vercel Edge + GitHub Actions CI/CD" },

--- a/app/api/weather/geocoding/route.ts
+++ b/app/api/weather/geocoding/route.ts
@@ -67,6 +67,8 @@ interface NominatimResult {
     village?: string
     suburb?: string
     hamlet?: string
+    municipality?: string
+    county?: string
     state?: string
     country?: string
     country_code?: string

--- a/app/api/weather/geocoding/route.ts
+++ b/app/api/weather/geocoding/route.ts
@@ -106,7 +106,16 @@ const mapNominatimResult = (r: NominatimResult): GeocodingResponse | null => {
   if (Number.isNaN(lat) || Number.isNaN(lon)) return null
 
   const addr = r.address || {}
-  const name = addr.city || addr.town || addr.village || addr.suburb || addr.hamlet || ''
+  const name =
+    addr.city ||
+    addr.town ||
+    addr.village ||
+    addr.suburb ||
+    addr.hamlet ||
+    addr.municipality ||
+    addr.county?.replace(/\s+County$/i, '') ||
+    r.display_name?.split(',')[0]?.trim() ||
+    ''
   if (!name) return null
 
   const country = (addr.country_code || '').toUpperCase() || 'XX'

--- a/app/api/weather/noaa-wms/route.ts
+++ b/app/api/weather/noaa-wms/route.ts
@@ -4,7 +4,10 @@ import { tileProxyOriginHeaders } from '@/lib/services/tile-proxy-cors'
 
 export const runtime = 'nodejs'
 
-// Proxy NOAA MRMS WMS tiles to bypass CORS restrictions
+// Proxy NOAA MRMS WMS tiles to bypass CORS restrictions.
+// NOTE (2026-05): upstream nowCOAST endpoint returns CloudFront 403 for server
+// and browser fetches. US radar uses Iowa IEM direct until mapservices MRMS WMS
+// is validated. Tile proxy also shares the 30 req/5min burst rate limit.
 // GET /api/weather/noaa-wms?REQUEST=GetMap&SERVICE=WMS&...
 export async function GET(request: NextRequest) {
   try {

--- a/app/api/weather/pollen/route.ts
+++ b/app/api/weather/pollen/route.ts
@@ -31,10 +31,12 @@ export async function GET(request: NextRequest) {
     const googlePollenApiKey = process.env.GOOGLE_POLLEN_API_KEY
     
     if (!openWeatherApiKey) {
-      return NextResponse.json(
-        { error: 'OpenWeather API key not configured' },
-        { status: 500 }
-      )
+      return NextResponse.json({
+        tree: { 'Tree': 'No Data' },
+        grass: { 'Grass': 'No Data' },
+        weed: { 'Weed': 'No Data' },
+        source: 'unavailable',
+      }, { headers: rateLimit.headers })
     }
 
     // Extract query parameters

--- a/app/api/weather/rainviewer/maps/route.ts
+++ b/app/api/weather/rainviewer/maps/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { rateLimitRequest } from '@/lib/services/weather-rate-limiter'
+import { tileProxyOriginHeaders } from '@/lib/services/tile-proxy-cors'
+import { parseRainViewerMapsPayload } from '@/lib/radar/rainviewer-types'
+
+export const runtime = 'nodejs'
+
+const RAINVIEWER_PUBLIC_API = 'https://api.rainviewer.com/public/weather-maps.json'
+
+/** Proxy RainViewer metadata for international radar animation (CORS + cache). */
+export async function GET(request: NextRequest) {
+  try {
+    const rateLimit = await rateLimitRequest(request)
+    if (!rateLimit.allowed) return rateLimit.response
+
+    const response = await fetch(RAINVIEWER_PUBLIC_API, {
+      headers: { 'User-Agent': '16-Bit-Weather/rainviewer-maps-proxy' },
+      signal: AbortSignal.timeout(10_000),
+      next: { revalidate: 120 },
+    })
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { error: 'RainViewer metadata unavailable' },
+        { status: 502, headers: tileProxyOriginHeaders(request) }
+      )
+    }
+
+    const data: unknown = await response.json()
+    const parsed = parseRainViewerMapsPayload(data)
+
+    if (!parsed) {
+      return NextResponse.json(
+        { error: 'RainViewer metadata parse failed' },
+        { status: 502, headers: tileProxyOriginHeaders(request) }
+      )
+    }
+
+    return NextResponse.json(parsed, {
+      headers: {
+        'Cache-Control': 'public, max-age=120, s-maxage=120, stale-while-revalidate=60',
+        ...tileProxyOriginHeaders(request),
+      },
+    })
+  } catch (error) {
+    console.error('[RainViewer maps proxy]', error)
+    return NextResponse.json(
+      { error: 'RainViewer metadata fetch failed' },
+      { status: 502, headers: tileProxyOriginHeaders(request) }
+    )
+  }
+}
+
+export async function OPTIONS(request: NextRequest) {
+  return new NextResponse(null, {
+    status: 204,
+    headers: {
+      ...tileProxyOriginHeaders(request),
+      'Access-Control-Max-Age': '86400',
+    },
+  })
+}

--- a/app/api/weather/rainviewer/maps/route.ts
+++ b/app/api/weather/rainviewer/maps/route.ts
@@ -52,11 +52,19 @@ export async function GET(request: NextRequest) {
 }
 
 export async function OPTIONS(request: NextRequest) {
-  return new NextResponse(null, {
-    status: 204,
-    headers: {
-      ...tileProxyOriginHeaders(request),
-      'Access-Control-Max-Age': '86400',
-    },
-  })
+  try {
+    return new NextResponse(null, {
+      status: 204,
+      headers: {
+        ...tileProxyOriginHeaders(request),
+        'Access-Control-Max-Age': '86400',
+      },
+    })
+  } catch (error) {
+    console.error('[RainViewer maps proxy]', error)
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500, headers: tileProxyOriginHeaders(request) }
+    )
+  }
 }

--- a/app/radar/layout.tsx
+++ b/app/radar/layout.tsx
@@ -1,6 +1,6 @@
 /**
  * 16-Bit Weather Platform - Radar Page Layout
- * SEO metadata for NOAA MRMS weather radar
+ * SEO metadata for live animated radar (US NEXRAD + global RainViewer)
  */
 
 import type { Metadata } from 'next'
@@ -12,7 +12,7 @@ const radarJsonLd = {
   "@context": "https://schema.org",
   "@type": "WebApplication",
   "name": "Live Weather Radar",
-  "description": "Real-time NOAA MRMS weather radar with precipitation overlays.",
+  "description": "Animated US NEXRAD composite radar and global RainViewer precipitation overlays.",
   "url": "https://www.16bitweather.co/radar",
   "applicationCategory": "WeatherApplication",
   "operatingSystem": "Any",
@@ -24,17 +24,17 @@ const radarJsonLd = {
 }
 
 export const metadata: Metadata = {
-  title: 'Live Weather Radar Map - NOAA MRMS Radar | 16 Bit Weather',
-  description: 'Real-time NOAA MRMS weather radar with high-resolution precipitation tracking. View live rain, snow, and storm data across the United States in retro terminal style.',
-  keywords: 'weather radar, NOAA radar, MRMS radar, live radar, precipitation map, rain radar, storm tracker, doppler radar, US weather radar, real-time radar',
+  title: 'Live Weather Radar Map - NEXRAD + RainViewer | 16 Bit Weather',
+  description: 'Animated US NEXRAD composite radar with 4-hour playback and live refresh. Global precipitation via RainViewer outside the US. Storm-watch controls in retro terminal style.',
+  keywords: 'weather radar, NEXRAD radar, live radar, precipitation map, rain radar, storm tracker, doppler radar, US weather radar, RainViewer, real-time radar',
   openGraph: {
     title: 'Live Weather Radar - 16 Bit Weather',
-    description: 'Real-time NOAA MRMS weather radar with high-resolution precipitation tracking across the US.',
+    description: 'Animated US NEXRAD composite radar with 4-hour playback. Global RainViewer coverage outside the US.',
     url: 'https://www.16bitweather.co/radar',
     siteName: '16 Bit Weather',
     images: [
       {
-        url: '/api/og?title=Live+Weather+Radar&subtitle=NOAA+MRMS+Precipitation+Map',
+        url: '/api/og?title=Live+Weather+Radar&subtitle=NEXRAD+%2B+RainViewer',
         width: 1200,
         height: 630,
         alt: 'Live Weather Radar - 16 Bit Weather',
@@ -46,8 +46,8 @@ export const metadata: Metadata = {
   twitter: {
     card: 'summary_large_image',
     title: 'Live Weather Radar - 16 Bit Weather',
-    description: 'Real-time NOAA MRMS weather radar with precipitation tracking',
-    images: ['/api/og?title=Live+Weather+Radar&subtitle=NOAA+MRMS+Precipitation+Map'],
+    description: 'Animated US NEXRAD composite radar with global RainViewer coverage',
+    images: ['/api/og?title=Live+Weather+Radar&subtitle=NEXRAD+%2B+RainViewer'],
   },
   alternates: {
     canonical: 'https://www.16bitweather.co/radar',

--- a/app/radar/page.tsx
+++ b/app/radar/page.tsx
@@ -230,7 +230,7 @@ export default function MapPage() {
         <ShareButtons
           config={{
             title: 'Live Weather Radar',
-            text: 'Live NOAA MRMS weather radar at 16bitweather.co',
+            text: 'Animated NEXRAD and RainViewer radar at 16bitweather.co',
             url: 'https://www.16bitweather.co/radar',
           }}
         />

--- a/components/weather-map-openlayers.tsx
+++ b/components/weather-map-openlayers.tsx
@@ -100,7 +100,7 @@ const WeatherMapOpenLayers = ({
   }, [isMounted])
 
   const isUSLocation = useMemo(() => {
-    if (!latitude || !longitude) return false
+    if (latitude == null || longitude == null) return false
     return isInMRMSCoverage(latitude, longitude)
   }, [latitude, longitude])
 
@@ -178,8 +178,8 @@ const WeatherMapOpenLayers = ({
   useEffect(() => {
     if (!mapRef.current || mapInstanceRef.current) return
 
-    const centerLon = longitude || -98.5795
-    const centerLat = latitude || 39.8283
+    const centerLon = longitude ?? -98.5795
+    const centerLat = latitude ?? 39.8283
 
     const baseLayer = new TileLayer({
       source: new XYZ({
@@ -221,13 +221,13 @@ const WeatherMapOpenLayers = ({
   }, [])
 
   useEffect(() => {
-    if (!mapInstanceRef.current || !latitude || !longitude) return
+    if (!mapInstanceRef.current || latitude == null || longitude == null) return
     mapInstanceRef.current.getView().setCenter(fromLonLat([longitude, latitude]))
     mapInstanceRef.current.getView().setZoom(10)
   }, [latitude, longitude])
 
   useEffect(() => {
-    if (!mapInstanceRef.current || !latitude || !longitude) return
+    if (!mapInstanceRef.current || latitude == null || longitude == null) return
 
     const map = mapInstanceRef.current
     const existingMarker = map.getLayers().getArray().find((layer) => layer.get('name') === 'marker')
@@ -425,10 +425,6 @@ const WeatherMapOpenLayers = ({
     })
     xyz.refresh()
   }, [frameIndex, activeTimestamps, isUSLocation, rainViewerData])
-
-  useEffect(() => {
-    preloadCacheRef.current.clear()
-  }, [latitude, longitude])
 
   const preloadFrame = useCallback(
     (index: number) => {

--- a/components/weather-map-openlayers.tsx
+++ b/components/weather-map-openlayers.tsx
@@ -1,14 +1,33 @@
 'use client'
-// Build: v6 - Enhanced smoothness, dark base map, animated marker, radar legend
-// Phase 1: Smoother playback (500ms transition, 500ms interval), tile preloading, CSS easing
-// Phase 2: CartoDB Dark Matter base map, precipitation legend, pulse marker animation
+// Build: v7 - Phase 1 radar modernization (MRMS proxy, RainViewer intl, live refresh)
 
 import { useEffect, useRef, useState, useMemo, useCallback } from 'react'
-import { Play, Pause, SkipBack, SkipForward, Layers, ChevronDown, Loader2 } from 'lucide-react'
+import { Play, Pause, SkipBack, SkipForward, Layers, ChevronDown, Loader2, Info } from 'lucide-react'
 import { isInMRMSCoverage } from '@/lib/utils/location-utils'
 import { ThemeType } from '@/lib/theme-config'
+import {
+  BASE_ANIMATION_INTERVAL_MS,
+  CARTO_DARK_MATTER_URL,
+  IOWA_NEXRAD_LAYER,
+  IOWA_NEXRAD_WMS_URL,
+  MRMS_TILE_ERROR_FALLBACK_THRESHOLD,
+  MRMS_WMS_LAYER,
+  MRMS_WMS_PROXY_PATH,
+  PRELOAD_FRAMES_AHEAD,
+  RADAR_LEGEND,
+  RADAR_REFRESH_MS,
+  RAINVIEWER_MAPS_API,
+  STORM_WATCH_FRAMES,
+  TILE_TRANSITION_MS,
+  type UsRadarProvider,
+} from '@/lib/radar/radar-config'
+import {
+  buildRadarTimestamps,
+  minutesSinceFrame,
+  stormWatchStartIndex,
+} from '@/lib/radar/radar-timestamps'
+import { rainViewerTileUrl, type RainViewerMapsResponse } from '@/lib/radar/rainviewer-types'
 
-// OpenLayers imports
 import 'ol/ol.css'
 import Map from 'ol/Map'
 import View from 'ol/View'
@@ -22,30 +41,6 @@ import VectorLayer from 'ol/layer/Vector'
 import VectorSource from 'ol/source/Vector'
 import { Style, Icon } from 'ol/style'
 
-// CORRECT WMS-T endpoint that supports TIME parameter
-// Reference: https://mesonet.agron.iastate.edu/ogc/
-// The n0q.cgi endpoint does NOT support TIME - must use n0q-t.cgi
-const NEXRAD_WMS_URL = 'https://mesonet.agron.iastate.edu/cgi-bin/wms/nexrad/n0q-t.cgi'
-const NEXRAD_LAYER = 'nexrad-n0q-wmst'
-
-// Animation tuning constants
-const TILE_TRANSITION_MS = 500 // Smooth crossfade between frames
-const BASE_ANIMATION_INTERVAL_MS = 500 // Fluid playback speed
-const PRELOAD_FRAMES_AHEAD = 3 // Number of frames to preload during playback
-
-// CartoDB Dark Matter base map for better radar contrast
-// Note: Removed {r} (Leaflet retina placeholder) - OpenLayers XYZ doesn't support it
-const CARTO_DARK_MATTER_URL = 'https://{a-d}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png'
-
-// NEXRAD radar reflectivity legend (dBZ values) - industry standard scale
-const RADAR_LEGEND = [
-  { color: '#00ffc8', label: 'Light', dbz: '5-20' },
-  { color: '#00c800', label: 'Moderate', dbz: '20-35' },
-  { color: '#ffff00', label: 'Heavy', dbz: '35-50' },
-  { color: '#ff8c00', label: 'Very Heavy', dbz: '50-65' },
-  { color: '#ff0000', label: 'Extreme', dbz: '65+' },
-]
-
 interface WeatherMapProps {
   latitude?: number
   longitude?: number
@@ -57,87 +52,149 @@ interface WeatherMapProps {
 const WeatherMapOpenLayers = ({
   latitude,
   longitude,
-  locationName,
   theme = 'nord',
-  displayMode = 'full-page'
+  displayMode = 'full-page',
 }: WeatherMapProps) => {
   const mapRef = useRef<HTMLDivElement>(null)
   const mapInstanceRef = useRef<Map | null>(null)
-  const radarLayerRef = useRef<TileLayer<TileWMS> | null>(null)
-  const radarSourceRef = useRef<TileWMS | null>(null)
+  const radarLayerRef = useRef<TileLayer<TileWMS | XYZ> | null>(null)
+  const radarSourceRef = useRef<TileWMS | XYZ | null>(null)
 
-  const [activeLayers, setActiveLayers] = useState<Record<string, boolean>>({
-    precipitation: true,
-    clouds: false,
-    wind: false,
-    pressure: false,
-    temperature: false,
-  })
-
+  const [precipitationOn, setPrecipitationOn] = useState(true)
   const [opacity, setOpacity] = useState(0.85)
   const [layerMenuOpen, setLayerMenuOpen] = useState(false)
+  const [showNightTip, setShowNightTip] = useState(false)
 
-  // Animation state
   const [isPlaying, setIsPlaying] = useState(false)
   const [frameIndex, setFrameIndex] = useState(0)
   const [speed, setSpeed] = useState<0.5 | 1 | 2>(1)
   const [isLoading, setIsLoading] = useState(false)
-  const [radarVisible, setRadarVisible] = useState(false) // For fade-in animation
+  const [radarVisible, setRadarVisible] = useState(false)
   const timerRef = useRef<number | null>(null)
-  const preloadCacheRef = useRef<Set<string>>(new Set()) // Track preloaded frames
+  const preloadCacheRef = useRef<Set<string>>(new Set())
 
-  // NEXRAD configuration
-  const NEXRAD_STEP_MINUTES = 5
-  const NEXRAD_PAST_STEPS = 48 // 4 hours past (5 min * 48 = 240 min = 4 hours)
-
-  // Track client-side mount to prevent hydration mismatch with Date.now()
   const [isMounted, setIsMounted] = useState(false)
+  const [clockTick, setClockTick] = useState(0)
+  const [usProvider, setUsProvider] = useState<UsRadarProvider>('mrms')
+  const [tileError, setTileError] = useState<string | null>(null)
+  const [rainViewerData, setRainViewerData] = useState<RainViewerMapsResponse | null>(null)
+  const [rainViewerLoading, setRainViewerLoading] = useState(false)
+  const [rainViewerFailed, setRainViewerFailed] = useState(false)
+
   useEffect(() => {
     setIsMounted(true)
+    setClockTick(Date.now())
   }, [])
 
-  // Check if location is in US
+  useEffect(() => {
+    if (!isMounted) return
+
+    const refreshClock = () => setClockTick(Date.now())
+    const intervalId = window.setInterval(refreshClock, RADAR_REFRESH_MS)
+    const onVisibility = () => {
+      if (document.visibilityState === 'visible') refreshClock()
+    }
+    document.addEventListener('visibilitychange', onVisibility)
+
+    return () => {
+      window.clearInterval(intervalId)
+      document.removeEventListener('visibilitychange', onVisibility)
+    }
+  }, [isMounted])
+
   const isUSLocation = useMemo(() => {
     if (!latitude || !longitude) return false
     return isInMRMSCoverage(latitude, longitude)
   }, [latitude, longitude])
 
-  // Generate NEXRAD timestamps - only after client mount to prevent hydration mismatch
-  const timestamps = useMemo(() => {
-    if (!isUSLocation || !isMounted) return []
+  const usTimestamps = useMemo(() => {
+    if (!isUSLocation || !isMounted || clockTick === 0) return []
+    return buildRadarTimestamps({ nowMs: clockTick })
+  }, [isUSLocation, isMounted, clockTick])
 
-    const now = Date.now()
-    const quantize = (ms: number) => Math.floor(ms / (NEXRAD_STEP_MINUTES * 60 * 1000)) * (NEXRAD_STEP_MINUTES * 60 * 1000)
-    const base = quantize(now)
-    const times: number[] = []
-
-    for (let i = NEXRAD_PAST_STEPS; i >= 0; i -= 1) {
-      times.push(base - i * NEXRAD_STEP_MINUTES * 60 * 1000)
+  useEffect(() => {
+    if (isUSLocation || !isMounted) {
+      setRainViewerData(null)
+      setRainViewerFailed(false)
+      return
     }
 
-    return times
-  }, [isUSLocation, isMounted])
+    let cancelled = false
+    setRainViewerLoading(true)
+    setRainViewerFailed(false)
 
-  // Initialize map
+    fetch(RAINVIEWER_MAPS_API)
+      .then(async (res) => {
+        if (!res.ok) throw new Error('RainViewer metadata failed')
+        return res.json() as Promise<RainViewerMapsResponse>
+      })
+      .then((data) => {
+        if (cancelled) return
+        if (!data?.past?.length) {
+          setRainViewerFailed(true)
+          setRainViewerData(null)
+          return
+        }
+        setRainViewerData(data)
+        setFrameIndex(data.past.length - 1)
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setRainViewerFailed(true)
+          setRainViewerData(null)
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setRainViewerLoading(false)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [isUSLocation, isMounted, clockTick])
+
+  const intlTimestamps = useMemo(
+    () => rainViewerData?.past.map((frame) => frame.time * 1000) ?? [],
+    [rainViewerData]
+  )
+
+  const activeTimestamps = isUSLocation ? usTimestamps : intlTimestamps
+  const hasRadarAnimation = activeTimestamps.length > 0
+
+  const wasLiveRef = useRef(true)
+  useEffect(() => {
+    wasLiveRef.current =
+      activeTimestamps.length > 0 && frameIndex >= activeTimestamps.length - 1
+  }, [frameIndex, activeTimestamps.length])
+
+  useEffect(() => {
+    if (wasLiveRef.current && activeTimestamps.length > 0) {
+      setFrameIndex(activeTimestamps.length - 1)
+    }
+  }, [activeTimestamps])
+
+  useEffect(() => {
+    setUsProvider('mrms')
+    setTileError(null)
+    preloadCacheRef.current.clear()
+  }, [latitude, longitude])
+
   useEffect(() => {
     if (!mapRef.current || mapInstanceRef.current) return
 
     const centerLon = longitude || -98.5795
     const centerLat = latitude || 39.8283
 
-
-    // Create base layer (CartoDB Dark Matter - better radar visibility)
-    // Dark base map provides excellent contrast for precipitation colors
     const baseLayer = new TileLayer({
       source: new XYZ({
         url: CARTO_DARK_MATTER_URL,
-        attributions: '&copy; <a href="https://carto.com/">CARTO</a> &copy; <a href="https://www.openstreetmap.org/copyright">OSM</a>',
+        attributions:
+          '&copy; <a href="https://carto.com/">CARTO</a> &copy; <a href="https://www.openstreetmap.org/copyright">OSM</a>',
         crossOrigin: 'anonymous',
       }),
       opacity: 0.9,
     })
 
-    // Create map
     const map = new Map({
       target: mapRef.current,
       layers: [baseLayer],
@@ -149,95 +206,57 @@ const WeatherMapOpenLayers = ({
 
     mapInstanceRef.current = map
 
-    // Fix for production: force map to recalculate size multiple times
-    // Sometimes the container size isn't ready immediately
-    const updateMapSize = () => {
-      if (mapInstanceRef.current) {
-        mapInstanceRef.current.updateSize()
-      }
-    }
-
-    // Initial update
+    const updateMapSize = () => mapInstanceRef.current?.updateSize()
     setTimeout(updateMapSize, 0)
     setTimeout(updateMapSize, 100)
     setTimeout(updateMapSize, 500)
-    setTimeout(updateMapSize, 1000)
 
-    // Use ResizeObserver for robust container size detection
-    const resizeObserver = new ResizeObserver(() => {
-      updateMapSize()
-    })
-
-    if (mapRef.current) {
-      resizeObserver.observe(mapRef.current)
-    }
-
-    // Also update on window resize
-    const handleResize = () => updateMapSize()
-    window.addEventListener('resize', handleResize)
+    const resizeObserver = new ResizeObserver(updateMapSize)
+    if (mapRef.current) resizeObserver.observe(mapRef.current)
+    window.addEventListener('resize', updateMapSize)
 
     return () => {
-      window.removeEventListener('resize', handleResize)
+      window.removeEventListener('resize', updateMapSize)
       resizeObserver.disconnect()
       map.setTarget(undefined)
-      // Match the cleanup pattern used by every other OpenLayers consumer
-      // (TurbulenceMap, TravelCorridorMap, SPCOutlookMap, warnings-alert-map).
-      // Without dispose() the map's tile sources, listeners, and any retained
-      // workers leak across SPA navigations.
       map.dispose()
       mapInstanceRef.current = null
     }
   }, [])
 
-  // Update map center when location changes
   useEffect(() => {
     if (!mapInstanceRef.current || !latitude || !longitude) return
-
     mapInstanceRef.current.getView().setCenter(fromLonLat([longitude, latitude]))
     mapInstanceRef.current.getView().setZoom(10)
   }, [latitude, longitude])
 
-  // Add location marker
   useEffect(() => {
     if (!mapInstanceRef.current || !latitude || !longitude) return
 
     const map = mapInstanceRef.current
+    const existingMarker = map.getLayers().getArray().find((layer) => layer.get('name') === 'marker')
+    if (existingMarker) map.removeLayer(existingMarker)
 
-    // Remove existing marker layer
-    const existingMarker = map.getLayers().getArray().find(layer =>
-      layer.get('name') === 'marker'
-    )
-    if (existingMarker) {
-      map.removeLayer(existingMarker)
-    }
-
-    // Create marker feature
-    const markerFeature = new Feature({
-      geometry: new Point(fromLonLat([longitude, latitude])),
-    })
-
-    // Create animated marker with pulse effect using CSS animation in SVG
     const pulseMarkerSvg = `
       <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48">
         <style>
-          @keyframes pulse {
-            0%, 100% { opacity: 0.4; r: 18; }
-            50% { opacity: 0; r: 24; }
-          }
+          @keyframes pulse { 0%, 100% { opacity: 0.4; r: 18; } 50% { opacity: 0; r: 24; } }
           .pulse-ring { animation: pulse 2s ease-out infinite; }
         </style>
-        <!-- Pulse ring effect -->
         <circle class="pulse-ring" cx="24" cy="20" r="18" fill="none" stroke="#00d4ff" stroke-width="2"/>
         <circle class="pulse-ring" cx="24" cy="20" r="14" fill="none" stroke="#00d4ff" stroke-width="1" style="animation-delay: 0.5s"/>
-        <!-- Main marker pin -->
         <path d="M33 20c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z" fill="#00d4ff" stroke="#000" stroke-width="2"/>
         <circle cx="24" cy="20" r="3" fill="#000"/>
       </svg>
     `
-    
+
     const markerLayer = new VectorLayer({
       source: new VectorSource({
-        features: [markerFeature],
+        features: [
+          new Feature({
+            geometry: new Point(fromLonLat([longitude, latitude])),
+          }),
+        ],
       }),
       style: new Style({
         image: new Icon({
@@ -253,94 +272,116 @@ const WeatherMapOpenLayers = ({
     map.addLayer(markerLayer)
   }, [latitude, longitude])
 
-  // Initialize SINGLE radar layer with WMS-T support
   useEffect(() => {
-    if (!mapInstanceRef.current || !isUSLocation || !activeLayers.precipitation) {
-      // Remove radar layer if it exists
-      if (radarLayerRef.current && mapInstanceRef.current) {
-        mapInstanceRef.current.removeLayer(radarLayerRef.current)
+    const map = mapInstanceRef.current
+    if (!map || !precipitationOn || !hasRadarAnimation) {
+      if (radarLayerRef.current && map) {
+        map.removeLayer(radarLayerRef.current)
         radarLayerRef.current = null
         radarSourceRef.current = null
       }
       return
     }
 
-    const map = mapInstanceRef.current
-
-    // Remove existing radar layer if any
     if (radarLayerRef.current) {
       map.removeLayer(radarLayerRef.current)
+      radarLayerRef.current = null
+      radarSourceRef.current = null
     }
 
-    // Reset fade-in state for new layer (fixes Cursor BugBot issue)
     setRadarVisible(false)
 
-    // Create WMS source with TIME support
-    // Key insight: n0q-t.cgi supports the TIME parameter, n0q.cgi does NOT
-    const radarSource = new TileWMS({
-      url: NEXRAD_WMS_URL,
-      params: {
-        'LAYERS': NEXRAD_LAYER,
-        'FORMAT': 'image/png',
-        'TRANSPARENT': 'true',
-        'VERSION': '1.1.1',
-        // TIME will be set via updateParams()
-      },
-      serverType: 'mapserver',
-      transition: TILE_TRANSITION_MS, // Smooth cross-fade between frames
-      crossOrigin: 'anonymous',
-    })
-
-    // Track loading state - use a counter to handle concurrent tile loads
     let loadingTileCount = 0
     let initialLoadComplete = false
+    let tileErrorCount = 0
 
-    radarSource.on('tileloadstart', () => {
-      loadingTileCount++
-      // Only show loading indicator when not playing (to avoid button flicker)
-      if (!isPlaying && loadingTileCount === 1) {
-        setIsLoading(true)
-      }
-    })
-
-    radarSource.on('tileloadend', () => {
-      loadingTileCount = Math.max(0, loadingTileCount - 1)
-      if (loadingTileCount === 0) {
-        setIsLoading(false)
-        // Trigger fade-in on first complete load
-        if (!initialLoadComplete) {
-          initialLoadComplete = true
-          setRadarVisible(true)
+    const attachLoadHandlers = (source: TileWMS | XYZ) => {
+      source.on('tileloadstart', () => {
+        loadingTileCount++
+        if (!isPlaying && loadingTileCount === 1) setIsLoading(true)
+      })
+      source.on('tileloadend', () => {
+        loadingTileCount = Math.max(0, loadingTileCount - 1)
+        if (loadingTileCount === 0) {
+          setIsLoading(false)
+          if (!initialLoadComplete) {
+            initialLoadComplete = true
+            setRadarVisible(true)
+          }
         }
+      })
+      source.on('tileloaderror', () => {
+        loadingTileCount = Math.max(0, loadingTileCount - 1)
+        if (loadingTileCount === 0) setIsLoading(false)
+        tileErrorCount++
+        if (isUSLocation && usProvider === 'mrms' && tileErrorCount >= MRMS_TILE_ERROR_FALLBACK_THRESHOLD) {
+          setUsProvider('iowa-fallback')
+          setTileError('MRMS unavailable — showing NEXRAD fallback')
+        } else if (tileErrorCount >= 3) {
+          setTileError('Radar tiles temporarily unavailable — retrying…')
+        }
+      })
+    }
+
+    if (isUSLocation) {
+      const wmsUrl = usProvider === 'mrms' ? MRMS_WMS_PROXY_PATH : IOWA_NEXRAD_WMS_URL
+      const isMrms = usProvider === 'mrms'
+
+      const radarSource = new TileWMS({
+        url: wmsUrl,
+        params: {
+          LAYERS: isMrms ? MRMS_WMS_LAYER : IOWA_NEXRAD_LAYER,
+          FORMAT: 'image/png',
+          TRANSPARENT: 'true',
+          VERSION: isMrms ? '1.3.0' : '1.1.1',
+          ...(isMrms ? { CRS: 'EPSG:3857' } : {}),
+        },
+        serverType: 'mapserver',
+        transition: TILE_TRANSITION_MS,
+        crossOrigin: 'anonymous',
+      })
+
+      attachLoadHandlers(radarSource)
+
+      const radarLayer = new TileLayer({
+        source: radarSource,
+        opacity,
+        zIndex: 500,
+      })
+      radarLayer.set('name', 'us-radar')
+      map.addLayer(radarLayer)
+      radarLayerRef.current = radarLayer
+      radarSourceRef.current = radarSource
+
+      if (activeTimestamps.length > 0) {
+        const liveIndex = activeTimestamps.length - 1
+        radarSource.updateParams({ TIME: new Date(activeTimestamps[liveIndex]).toISOString() })
+        setFrameIndex(liveIndex)
       }
-    })
+    } else if (rainViewerData) {
+      const frame = rainViewerData.past[Math.min(frameIndex, rainViewerData.past.length - 1)]
+      const radarSource = new XYZ({
+        crossOrigin: 'anonymous',
+        maxZoom: 12,
+        tileUrlFunction: (tileCoord) => {
+          const z = tileCoord[0]
+          const x = tileCoord[1]
+          const y = tileCoord[2]
+          return rainViewerTileUrl(rainViewerData.host, frame.path, z, x, y)
+        },
+      })
 
-    radarSource.on('tileloaderror', () => {
-      loadingTileCount = Math.max(0, loadingTileCount - 1)
-      if (loadingTileCount === 0) {
-        setIsLoading(false)
-      }
-      console.warn('⚠️ [v6] Tile load error')
-    })
+      attachLoadHandlers(radarSource)
 
-    const radarLayer = new TileLayer({
-      source: radarSource,
-      opacity: opacity,
-      zIndex: 500,
-    })
-
-    radarLayer.set('name', 'nexrad-radar')
-    map.addLayer(radarLayer)
-
-    radarLayerRef.current = radarLayer
-    radarSourceRef.current = radarSource
-
-    // Set initial time to most recent
-    if (timestamps.length > 0) {
-      const initialIndex = timestamps.length - 1
-      const initialTime = new Date(timestamps[initialIndex]).toISOString()
-      radarSource.updateParams({ 'TIME': initialTime })
-      setFrameIndex(initialIndex)
+      const radarLayer = new TileLayer({
+        source: radarSource,
+        opacity,
+        zIndex: 500,
+      })
+      radarLayer.set('name', 'intl-radar')
+      map.addLayer(radarLayer)
+      radarLayerRef.current = radarLayer
+      radarSourceRef.current = radarSource
     }
 
     return () => {
@@ -350,146 +391,145 @@ const WeatherMapOpenLayers = ({
         radarSourceRef.current = null
       }
     }
-  }, [isUSLocation, activeLayers.precipitation, timestamps.length > 0])
+    // Intentionally omit frameIndex/isPlaying — TIME/URL updates happen in a separate effect.
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- provider swap + data availability only
+  }, [
+    isUSLocation,
+    precipitationOn,
+    hasRadarAnimation,
+    usProvider,
+    rainViewerData,
+    activeTimestamps.length,
+    opacity,
+  ])
 
-  // Update opacity when it changes
   useEffect(() => {
-    if (radarLayerRef.current) {
-      radarLayerRef.current.setOpacity(opacity)
-    }
+    if (!radarLayerRef.current) return
+    radarLayerRef.current.setOpacity(opacity)
   }, [opacity])
 
-  // Update TIME parameter when frame changes - THIS IS THE KEY FIX
   useEffect(() => {
-    if (!radarSourceRef.current || timestamps.length === 0) return
+    if (!radarSourceRef.current || activeTimestamps.length === 0) return
 
-    const currentTimestamp = timestamps[frameIndex]
+    const currentTimestamp = activeTimestamps[frameIndex]
     if (!currentTimestamp) return
 
-    const timeISO = new Date(currentTimestamp).toISOString()
+    if (isUSLocation) {
+      const wms = radarSourceRef.current as TileWMS
+      wms.updateParams({ TIME: new Date(currentTimestamp).toISOString() })
+      return
+    }
 
-    // This is the correct way to animate WMS-T layers in OpenLayers
-    // updateParams() triggers a re-fetch with the new TIME value
-    radarSourceRef.current.updateParams({ 'TIME': timeISO })
-  }, [frameIndex, timestamps])
+    if (!rainViewerData) return
+    const xyz = radarSourceRef.current as XYZ
+    const frame = rainViewerData.past[frameIndex]
+    if (!frame) return
 
-  // Clear preload cache when location changes (fixes CodeRabbit memory leak issue)
+    xyz.setTileUrlFunction((tileCoord) => {
+      const z = tileCoord[0]
+      const x = tileCoord[1]
+      const y = tileCoord[2]
+      return rainViewerTileUrl(rainViewerData.host, frame.path, z, x, y)
+    })
+    xyz.refresh()
+  }, [frameIndex, activeTimestamps, isUSLocation, rainViewerData])
+
   useEffect(() => {
     preloadCacheRef.current.clear()
-  }, [latitude, longitude])
+  }, [latitude, longitude, usProvider])
 
-  // Preload upcoming frames for smoother playback
-  const preloadFrame = useCallback((index: number) => {
-    if (!timestamps[index] || !radarSourceRef.current || !mapInstanceRef.current) return
-    
-    // Limit cache size to prevent memory bloat (fixes CodeRabbit issue)
-    if (preloadCacheRef.current.size > 100) {
-      preloadCacheRef.current.clear()
-    }
-    
-    const timeISO = new Date(timestamps[index]).toISOString()
-    const cacheKey = `${timeISO}`
-    
-    if (preloadCacheRef.current.has(cacheKey)) return
-    preloadCacheRef.current.add(cacheKey)
-    
-    // Get current map extent for more effective preloading
-    const view = mapInstanceRef.current.getView()
-    const size = mapInstanceRef.current.getSize()
-    let bbox = '-10000000,4000000,-9000000,5000000' // Default fallback
-    
-    if (size) {
-      try {
-        const extent = view.calculateExtent(size)
-        bbox = extent.join(',')
-      } catch {
-        // Use fallback bbox if extent calculation fails
+  const preloadFrame = useCallback(
+    (index: number) => {
+      if (!activeTimestamps[index] || !mapInstanceRef.current || !isUSLocation) return
+
+      if (preloadCacheRef.current.size > 100) preloadCacheRef.current.clear()
+
+      const timeISO = new Date(activeTimestamps[index]).toISOString()
+      if (preloadCacheRef.current.has(timeISO)) return
+      preloadCacheRef.current.add(timeISO)
+
+      const view = mapInstanceRef.current.getView()
+      const size = mapInstanceRef.current.getSize()
+      let bbox = '-10000000,4000000,-9000000,5000000'
+      if (size) {
+        try {
+          bbox = view.calculateExtent(size).join(',')
+        } catch {
+          // use fallback bbox
+        }
       }
-    }
-    
-    // Create a hidden image to preload the tile
-    const preloadUrl = `${NEXRAD_WMS_URL}?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetMap&LAYERS=${NEXRAD_LAYER}&TIME=${encodeURIComponent(timeISO)}&FORMAT=image/png&TRANSPARENT=true&WIDTH=256&HEIGHT=256&SRS=EPSG:3857&BBOX=${bbox}`
-    const img = new Image()
-    img.crossOrigin = 'anonymous'
-    img.src = preloadUrl
-  }, [timestamps, latitude, longitude])
 
-  // Animation playback with preloading
+      const isMrms = usProvider === 'mrms'
+      const baseUrl = isMrms ? MRMS_WMS_PROXY_PATH : IOWA_NEXRAD_WMS_URL
+      const layer = isMrms ? MRMS_WMS_LAYER : IOWA_NEXRAD_LAYER
+      const version = isMrms ? '1.3.0' : '1.1.1'
+      const crs = isMrms ? '&CRS=EPSG:3857' : '&SRS=EPSG:3857'
+
+      const img = new Image()
+      img.crossOrigin = 'anonymous'
+      img.src = `${baseUrl}?SERVICE=WMS&VERSION=${version}&REQUEST=GetMap&LAYERS=${layer}&TIME=${encodeURIComponent(timeISO)}&FORMAT=image/png&TRANSPARENT=true&WIDTH=256&HEIGHT=256${crs}&BBOX=${bbox}`
+    },
+    [activeTimestamps, isUSLocation, usProvider]
+  )
+
   useEffect(() => {
-    if (!isPlaying || timestamps.length === 0) return
+    if (!isPlaying || activeTimestamps.length === 0) return
 
     const interval = BASE_ANIMATION_INTERVAL_MS / speed
-
     const handle = window.setInterval(() => {
       setFrameIndex((idx) => {
-        const nextIdx = (idx + 1) % timestamps.length
-        
-        // Preload upcoming frames during playback
+        const nextIdx = (idx + 1) % activeTimestamps.length
         for (let i = 1; i <= PRELOAD_FRAMES_AHEAD; i++) {
-          const preloadIdx = (nextIdx + i) % timestamps.length
-          preloadFrame(preloadIdx)
+          preloadFrame((nextIdx + i) % activeTimestamps.length)
         }
-        
         return nextIdx
       })
     }, interval)
 
     timerRef.current = handle as unknown as number
-
     return () => {
-      if (timerRef.current) {
-        window.clearInterval(timerRef.current)
-        timerRef.current = null
-      }
+      if (timerRef.current) window.clearInterval(timerRef.current)
     }
-  }, [isPlaying, speed, timestamps.length, preloadFrame])
+  }, [isPlaying, speed, activeTimestamps.length, preloadFrame])
 
-  // Keyboard controls
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if (!isUSLocation || !activeLayers.precipitation) return
-
-      // Don't intercept keys when user is typing in an input field
-      const activeElement = document.activeElement as HTMLElement
-      if (activeElement && (activeElement.tagName === 'INPUT' || activeElement.tagName === 'TEXTAREA')) {
-        return
-      }
+      if (!hasRadarAnimation || !precipitationOn) return
+      const active = document.activeElement as HTMLElement | null
+      if (active && (active.tagName === 'INPUT' || active.tagName === 'TEXTAREA')) return
 
       if (e.code === 'Space') {
         e.preventDefault()
-        setIsPlaying(prev => !prev)
+        setIsPlaying((prev) => !prev)
       } else if (e.code === 'ArrowLeft') {
         e.preventDefault()
         setIsPlaying(false)
-        setFrameIndex(prev => Math.max(0, prev - 1))
+        setFrameIndex((prev) => Math.max(0, prev - 1))
       } else if (e.code === 'ArrowRight') {
         e.preventDefault()
         setIsPlaying(false)
-        setFrameIndex(prev => Math.min(timestamps.length - 1, prev + 1))
+        setFrameIndex((prev) => Math.min(activeTimestamps.length - 1, prev + 1))
       }
     }
 
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
-  }, [isUSLocation, activeLayers.precipitation, timestamps.length])
+  }, [hasRadarAnimation, precipitationOn, activeTimestamps.length])
 
-  const currentTime = timestamps[frameIndex]
-  const humanTime = currentTime ? new Date(currentTime).toUTCString().replace(' GMT', '') : ''
+  const latestTimestamp = activeTimestamps[activeTimestamps.length - 1]
+  const currentTime = activeTimestamps[frameIndex]
+  const isLiveFrame = frameIndex === activeTimestamps.length - 1
+  const dataAgeMinutes = latestTimestamp ? minutesSinceFrame(latestTimestamp, clockTick || Date.now()) : 0
 
-  // Check if current frame is the most recent (LIVE)
-  const isLiveFrame = frameIndex === timestamps.length - 1
-
-  // Calculate relative time for better UX
   const relativeTime = useMemo(() => {
     if (!currentTime) return ''
-    const now = Date.now()
-    const diff = currentTime - now
-    const diffMinutes = Math.round(diff / 60000)
+    const diffMinutes = Math.round((currentTime - (clockTick || Date.now())) / 60_000)
 
-    // Within 3 minutes of now = LIVE
-    if (Math.abs(diffMinutes) < 3) return 'LIVE'
+    if (isLiveFrame) {
+      if (dataAgeMinutes <= 1) return 'LIVE'
+      return `LIVE · ${dataAgeMinutes}m old`
+    }
 
-    // Past frames
     if (diffMinutes < 0) {
       const absDiff = Math.abs(diffMinutes)
       const hours = Math.floor(absDiff / 60)
@@ -498,9 +538,16 @@ const WeatherMapOpenLayers = ({
       return `${mins}m ago`
     }
 
-    // Future frames (shouldn't happen with current config)
-    return humanTime
-  }, [currentTime, humanTime])
+    return new Date(currentTime).toUTCString().replace(' GMT', '')
+  }, [currentTime, clockTick, isLiveFrame, dataAgeMinutes])
+
+  const providerLabel = isUSLocation
+    ? usProvider === 'mrms'
+      ? 'NOAA MRMS'
+      : 'NEXRAD FALLBACK'
+    : rainViewerData
+      ? 'RAINVIEWER'
+      : 'RADAR'
 
   const themeStyles = useMemo(() => {
     switch (theme) {
@@ -511,22 +558,26 @@ const WeatherMapOpenLayers = ({
     }
   }, [theme])
 
-  // Handler for play/pause with loading feedback
-  const handlePlayPause = useCallback(() => {
-    setIsPlaying(prev => !prev)
-  }, [])
+  const handlePlayPause = useCallback(() => setIsPlaying((prev) => !prev), [])
 
-  // Jump to start
   const handleSkipToStart = useCallback(() => {
     setIsPlaying(false)
     setFrameIndex(0)
   }, [])
 
-  // Jump to end (live)
   const handleSkipToEnd = useCallback(() => {
     setIsPlaying(false)
-    setFrameIndex(timestamps.length - 1)
-  }, [timestamps.length])
+    setFrameIndex(Math.max(0, activeTimestamps.length - 1))
+  }, [activeTimestamps.length])
+
+  const handlePlayLastTwoHours = useCallback(() => {
+    const start = stormWatchStartIndex(activeTimestamps.length, STORM_WATCH_FRAMES)
+    setFrameIndex(start)
+    setIsPlaying(true)
+  }, [activeTimestamps.length])
+
+  const showRadarOverlay = precipitationOn && (isUSLocation || !!rainViewerData)
+  const showUnavailable = precipitationOn && !isUSLocation && !rainViewerData && !rainViewerLoading
 
   return (
     <div
@@ -534,270 +585,287 @@ const WeatherMapOpenLayers = ({
       className={`flex gap-2 w-full rounded-lg ${themeStyles.container}`}
       style={{ height: '100%', minHeight: '350px' }}
     >
-      {/* Main Map Area */}
       <div className="relative flex-1 overflow-visible">
-      {/* Map Container - explicit dimensions for production */}
-      <div
-        ref={mapRef}
-        className="w-full bg-gray-900 rounded-lg overflow-hidden"
-        style={{ zIndex: 1, height: '100%', minHeight: '350px', position: 'relative' }}
-      />
-
-      {/* Loading Indicator - Skeleton placeholder with shimmer effect */}
-      {isLoading && !isPlaying && (
-        <div className="absolute inset-0 z-[1999] pointer-events-none">
-          {/* Semi-transparent overlay with shimmer */}
-          <div className="absolute inset-0 bg-gradient-to-r from-transparent via-cyan-500/10 to-transparent animate-shimmer" 
-               style={{ backgroundSize: '200% 100%' }} />
-          {/* Loading badge */}
-          <div className="absolute top-4 left-1/2 -translate-x-1/2">
-            <div className="flex items-center gap-2 px-4 py-2 bg-gray-900/95 text-cyan-400 rounded-md font-mono text-xs shadow-lg shadow-cyan-500/20 backdrop-blur-sm">
-              <Loader2 className="w-4 h-4 animate-spin" />
-              <span className="animate-pulse">LOADING RADAR DATA</span>
-            </div>
-          </div>
-        </div>
-      )}
-      
-      {/* Radar fade-in overlay - stays in DOM and animates opacity (fixes Bugbot transition issue) */}
-      {isUSLocation && activeLayers.precipitation && (
-        <div 
-          className={`absolute inset-0 bg-gray-900 z-[1998] transition-opacity duration-500 pointer-events-none ${radarVisible ? 'opacity-0' : 'opacity-100'}`}
-        />
-      )}
-
-      {/* Status Badge */}
-      <div className={`absolute top-4 left-4 px-3 py-1.5 rounded-md font-mono text-xs font-bold z-[2000] ${themeStyles.badge}`}>
-        {isUSLocation ? (
-          <span>
-            {isPlaying ? '▶️' : isLiveFrame ? '🔴 LIVE' : '🎬'} NEXRAD RADAR • 4 HOUR HISTORY
-          </span>
-        ) : (
-          <span>🌎 US LOCATIONS ONLY</span>
-        )}
-      </div>
-
-      {/* Layer Controls */}
-      <div className="absolute top-4 right-4 z-[2000]">
-        <button
-          onClick={() => setLayerMenuOpen(!layerMenuOpen)}
-          className="flex items-center gap-2 px-3 py-1.5 bg-gray-900/90 text-white rounded-md font-mono text-xs font-bold hover:bg-gray-700 transition-colors shadow-xl backdrop-blur-sm"
-        >
-          <Layers className="w-4 h-4" />
-          LAYERS
-          <ChevronDown className={`w-4 h-4 transition-transform ${layerMenuOpen ? 'rotate-180' : ''}`} />
-        </button>
-
-        {layerMenuOpen && (
-          <div className="absolute top-full right-0 mt-2 w-48 bg-gray-900/95 rounded-md overflow-hidden shadow-xl backdrop-blur-sm">
-            <div className="p-2 border-b border-gray-600 font-mono text-xs font-bold text-white">
-              RADAR LAYERS
-            </div>
-            <button
-              onClick={() => setActiveLayers(prev => ({ ...prev, precipitation: !prev.precipitation }))}
-              className={`w-full px-3 py-2 text-left font-mono text-xs hover:bg-gray-700 transition-colors ${activeLayers.precipitation ? 'bg-cyan-600/30 text-cyan-300' : 'text-gray-300'
-                }`}
-            >
-              {activeLayers.precipitation ? '✓' : '○'} Precipitation {isUSLocation ? '(NEXRAD)' : ''}
-            </button>
-
-            {/* Opacity slider */}
-            {activeLayers.precipitation && (
-              <div className="px-3 py-2 border-t border-gray-600">
-                <div className="font-mono text-xs text-gray-400 mb-1">OPACITY: {Math.round(opacity * 100)}%</div>
-                <input
-                  type="range"
-                  min="0.1"
-                  max="1"
-                  step="0.05"
-                  value={opacity}
-                  onChange={(e) => setOpacity(parseFloat(e.target.value))}
-                  className="w-full h-2 bg-gray-700 rounded-lg appearance-none cursor-pointer"
-                />
-              </div>
-            )}
-          </div>
-        )}
-      </div>
-
-      {/* Animation Controls - Position varies by display mode: top for full-page, bottom for widget */}
-      {isUSLocation && activeLayers.precipitation && timestamps.length > 0 && (
         <div
-          className={`absolute left-1/2 -translate-x-1/2 flex flex-col items-center pointer-events-auto ${
-            displayMode === 'widget' ? 'bottom-2 gap-1' : 'top-16 gap-2'
-          }`}
-          style={{ zIndex: 2000 }}
-        >
-          {/* Compact Controls Bar - smaller in widget mode */}
-          <div className={`flex items-center bg-gray-900/95 rounded-md border-2 border-cyan-500 shadow-2xl backdrop-blur-sm ${
-            displayMode === 'widget' ? 'gap-1 px-2 py-1' : 'gap-2 px-3 py-2'
-          }`}>
-            <button
-              onClick={handleSkipToStart}
-              className={`bg-gray-700 border border-gray-500 rounded text-white hover:bg-gray-600 transition-colors ${
-                displayMode === 'widget' ? 'px-1 py-0.5' : 'px-2 py-1.5 border-2'
-              }`}
-              title="Go to start (4 hours ago)"
-            >
-              <SkipBack className={displayMode === 'widget' ? 'w-3 h-3' : 'w-4 h-4'} />
-            </button>
+          ref={mapRef}
+          className="w-full bg-gray-900 rounded-lg overflow-hidden"
+          style={{ zIndex: 1, height: '100%', minHeight: '350px', position: 'relative' }}
+        />
 
-            <button
-              onClick={handlePlayPause}
-              className={`border rounded text-white font-mono font-bold transition-colors ${
-                displayMode === 'widget'
-                  ? 'px-2 py-0.5 text-[10px] min-w-[60px] border'
-                  : 'px-4 py-1.5 text-xs min-w-[90px] border-2'
-              } ${isPlaying
-                ? 'bg-yellow-600 border-yellow-400 hover:bg-yellow-500'
-                : 'bg-cyan-600 border-cyan-400 hover:bg-cyan-500'
-                }`}
-            >
-              {isPlaying ? (
-                <><Pause className={`inline mr-0.5 ${displayMode === 'widget' ? 'w-3 h-3' : 'w-4 h-4'}`} /> PAUSE</>
-              ) : (
-                <><Play className={`inline mr-0.5 ${displayMode === 'widget' ? 'w-3 h-3' : 'w-4 h-4'}`} /> PLAY</>
-              )}
-            </button>
-
-            <button
-              onClick={handleSkipToEnd}
-              className={`bg-gray-700 border border-gray-500 rounded text-white hover:bg-gray-600 transition-colors ${
-                displayMode === 'widget' ? 'px-1 py-0.5' : 'px-2 py-1.5 border-2'
-              }`}
-              title="Go to end (now)"
-            >
-              <SkipForward className={displayMode === 'widget' ? 'w-3 h-3' : 'w-4 h-4'} />
-            </button>
-
-            {/* Speed Controls */}
-            <div className={`flex border-l border-gray-600 ${
-              displayMode === 'widget' ? 'gap-0.5 ml-0.5 pl-1' : 'gap-1 ml-1 border-l-2 pl-2'
-            }`}>
-              {[0.5, 1, 2].map((s) => (
-                <button
-                  key={s}
-                  onClick={() => setSpeed(s as 0.5 | 1 | 2)}
-                  className={`border rounded font-mono font-bold transition-colors ${
-                    displayMode === 'widget'
-                      ? 'px-1 py-0.5 text-[10px] border'
-                      : 'px-2 py-1 text-xs border-2'
-                  } ${speed === s
-                    ? 'bg-cyan-600 border-cyan-400 text-white'
-                    : 'bg-gray-700 border-gray-500 text-gray-300 hover:bg-gray-600'
-                    }`}
-                >
-                  {s}x
-                </button>
-              ))}
-            </div>
-
-            {/* Time Display */}
-            <div className={`border-l border-gray-600 text-center ${
-              displayMode === 'widget' ? 'ml-1 pl-1 min-w-[50px]' : 'ml-2 border-l-2 pl-2 min-w-[80px]'
-            }`}>
-              <span className={`font-mono font-bold ${
-                displayMode === 'widget' ? 'text-[10px]' : 'text-xs'
-              } ${isLiveFrame ? 'text-red-400 animate-pulse' : 'text-cyan-400'}`}>
-                {relativeTime}
-              </span>
+        {isLoading && !isPlaying && (
+          <div className="absolute inset-0 z-[1999] pointer-events-none">
+            <div
+              className="absolute inset-0 bg-gradient-to-r from-transparent via-cyan-500/10 to-transparent animate-shimmer"
+              style={{ backgroundSize: '200% 100%' }}
+            />
+            <div className="absolute top-4 left-1/2 -translate-x-1/2">
+              <div className="flex items-center gap-2 px-4 py-2 bg-gray-900/95 text-cyan-400 rounded-md font-mono text-xs shadow-lg shadow-cyan-500/20 backdrop-blur-sm">
+                <Loader2 className="w-4 h-4 animate-spin" />
+                <span className="animate-pulse">LOADING RADAR DATA</span>
+              </div>
             </div>
           </div>
+        )}
 
-          {/* Timeline Slider with Enhanced Progress */}
-          {/* Safe progress calculation: when only 1 frame, maxIndex=0 and progress=100% (fixes Bugbot mismatch) */}
-          {(() => {
-            const maxIndex = timestamps.length - 1
-            // Progress: if only 1 frame (maxIndex=0), show 100%; otherwise calculate based on frameIndex
-            const progress = maxIndex > 0 ? (frameIndex / maxIndex) * 100 : 100
-            return (
-          <div className={`max-w-[90vw] bg-gray-900/95 rounded-md shadow-xl backdrop-blur-sm ${
-            displayMode === 'widget' ? 'w-[280px] px-2 py-1' : 'w-[500px] px-3 py-2'
-          }`}>
-            {/* Progress bar background */}
-            <div className={`relative bg-gray-800 rounded-full overflow-hidden border border-gray-700 ${
-              displayMode === 'widget' ? 'h-2' : 'h-3'
-            }`}>
-              {/* Animated progress fill */}
+        {showRadarOverlay && (
+          <div
+            className={`absolute inset-0 bg-gray-900 z-[1998] transition-opacity duration-500 pointer-events-none ${radarVisible ? 'opacity-0' : 'opacity-100'}`}
+          />
+        )}
+
+        {tileError && (
+          <div className="absolute top-14 left-4 right-4 z-[2001] pointer-events-none">
+            <div className="bg-amber-900/90 text-amber-100 px-3 py-2 rounded-md font-mono text-xs border border-amber-600">
+              {tileError}
+            </div>
+          </div>
+        )}
+
+        <div className={`absolute top-4 left-4 px-3 py-1.5 rounded-md font-mono text-xs font-bold z-[2000] ${themeStyles.badge}`}>
+          {hasRadarAnimation ? (
+            <span>
+              {isPlaying ? '▶️' : isLiveFrame ? '🔴' : '🎬'} {providerLabel} • 4 HR HISTORY
+              {isLiveFrame && dataAgeMinutes > 0 ? ` • updated ${dataAgeMinutes}m ago` : ''}
+            </span>
+          ) : rainViewerLoading ? (
+            <span>Loading global radar…</span>
+          ) : showUnavailable ? (
+            <span>Radar unavailable for this region</span>
+          ) : (
+            <span>Set a location to view radar</span>
+          )}
+        </div>
+
+        <div className="absolute top-4 right-4 z-[2000]">
+          <button
+            onClick={() => setLayerMenuOpen(!layerMenuOpen)}
+            className="flex items-center gap-2 px-3 py-1.5 bg-gray-900/90 text-white rounded-md font-mono text-xs font-bold hover:bg-gray-700 transition-colors shadow-xl backdrop-blur-sm"
+          >
+            <Layers className="w-4 h-4" />
+            LAYERS
+            <ChevronDown className={`w-4 h-4 transition-transform ${layerMenuOpen ? 'rotate-180' : ''}`} />
+          </button>
+
+          {layerMenuOpen && (
+            <div className="absolute top-full right-0 mt-2 w-56 bg-gray-900/95 rounded-md overflow-hidden shadow-xl backdrop-blur-sm">
+              <div className="p-2 border-b border-gray-600 font-mono text-xs font-bold text-white">RADAR</div>
+              <button
+                onClick={() => setPrecipitationOn((prev) => !prev)}
+                className={`w-full px-3 py-2 text-left font-mono text-xs hover:bg-gray-700 transition-colors ${
+                  precipitationOn ? 'bg-cyan-600/30 text-cyan-300' : 'text-gray-300'
+                }`}
+              >
+                {precipitationOn ? '✓' : '○'} Precipitation reflectivity
+              </button>
+              {precipitationOn && (
+                <div className="px-3 py-2 border-t border-gray-600">
+                  <div className="font-mono text-xs text-gray-400 mb-1">OPACITY: {Math.round(opacity * 100)}%</div>
+                  <input
+                    type="range"
+                    min="0.1"
+                    max="1"
+                    step="0.05"
+                    value={opacity}
+                    onChange={(e) => setOpacity(parseFloat(e.target.value))}
+                    className="w-full h-2 bg-gray-700 rounded-lg appearance-none cursor-pointer"
+                  />
+                </div>
+              )}
+              <div className="px-3 py-2 border-t border-gray-600 text-[10px] text-gray-400 font-mono leading-snug">
+                US: NOAA MRMS via nowCOAST
+                <br />
+                Intl:{' '}
+                <a href="https://www.rainviewer.com/" className="text-cyan-400 underline" target="_blank" rel="noopener noreferrer">
+                  RainViewer
+                </a>
+              </div>
+            </div>
+          )}
+        </div>
+
+        {hasRadarAnimation && precipitationOn && (
+          <div
+            className={`absolute left-1/2 -translate-x-1/2 flex flex-col items-center pointer-events-auto ${
+              displayMode === 'widget' ? 'bottom-2 gap-1' : 'top-16 gap-2'
+            }`}
+            style={{ zIndex: 2000 }}
+          >
+            <div
+              className={`flex items-center bg-gray-900/95 rounded-md border-2 border-cyan-500 shadow-2xl backdrop-blur-sm ${
+                displayMode === 'widget' ? 'gap-1 px-2 py-1 flex-wrap justify-center' : 'gap-2 px-3 py-2'
+              }`}
+            >
+              <button
+                onClick={handleSkipToStart}
+                className={`bg-gray-700 border border-gray-500 rounded text-white hover:bg-gray-600 transition-colors ${
+                  displayMode === 'widget' ? 'px-1 py-0.5' : 'px-2 py-1.5 border-2'
+                }`}
+                title="Go to start"
+              >
+                <SkipBack className={displayMode === 'widget' ? 'w-3 h-3' : 'w-4 h-4'} />
+              </button>
+
+              <button
+                onClick={handlePlayLastTwoHours}
+                className={`bg-gray-700 border border-gray-500 rounded text-cyan-300 hover:bg-gray-600 transition-colors font-mono font-bold ${
+                  displayMode === 'widget' ? 'px-1.5 py-0.5 text-[9px]' : 'px-2 py-1 text-[10px] border-2'
+                }`}
+                title="Play last 2 hours"
+              >
+                LAST 2H
+              </button>
+
+              <button
+                onClick={handlePlayPause}
+                className={`border rounded text-white font-mono font-bold transition-colors ${
+                  displayMode === 'widget'
+                    ? 'px-2 py-0.5 text-[10px] min-w-[60px] border'
+                    : 'px-4 py-1.5 text-xs min-w-[90px] border-2'
+                } ${isPlaying ? 'bg-yellow-600 border-yellow-400 hover:bg-yellow-500' : 'bg-cyan-600 border-cyan-400 hover:bg-cyan-500'}`}
+              >
+                {isPlaying ? (
+                  <>
+                    <Pause className={`inline mr-0.5 ${displayMode === 'widget' ? 'w-3 h-3' : 'w-4 h-4'}`} /> PAUSE
+                  </>
+                ) : (
+                  <>
+                    <Play className={`inline mr-0.5 ${displayMode === 'widget' ? 'w-3 h-3' : 'w-4 h-4'}`} /> PLAY
+                  </>
+                )}
+              </button>
+
+              <button
+                onClick={handleSkipToEnd}
+                className={`bg-gray-700 border border-gray-500 rounded text-white hover:bg-gray-600 transition-colors ${
+                  displayMode === 'widget' ? 'px-1 py-0.5' : 'px-2 py-1.5 border-2'
+                }`}
+                title="Go to live frame"
+              >
+                <SkipForward className={displayMode === 'widget' ? 'w-3 h-3' : 'w-4 h-4'} />
+              </button>
+
               <div
-                className="absolute inset-y-0 left-0 bg-gradient-to-r from-cyan-600 to-cyan-400 rounded-full transition-all duration-150 ease-out"
-                style={{ width: `${progress}%` }}
-              />
-              {/* Tick marks for time intervals */}
-              <div className="absolute inset-0 flex justify-between px-1">
-                {[0, 1, 2, 3, 4].map((i) => (
-                  <div key={i} className="w-px h-full bg-gray-600/50" />
+                className={`flex border-l border-gray-600 ${
+                  displayMode === 'widget' ? 'gap-0.5 ml-0.5 pl-1' : 'gap-1 ml-1 border-l-2 pl-2'
+                }`}
+              >
+                {[0.5, 1, 2].map((s) => (
+                  <button
+                    key={s}
+                    onClick={() => setSpeed(s as 0.5 | 1 | 2)}
+                    className={`border rounded font-mono font-bold transition-colors ${
+                      displayMode === 'widget' ? 'px-1 py-0.5 text-[10px] border' : 'px-2 py-1 text-xs border-2'
+                    } ${speed === s ? 'bg-cyan-600 border-cyan-400 text-white' : 'bg-gray-700 border-gray-500 text-gray-300 hover:bg-gray-600'}`}
+                  >
+                    {s}x
+                  </button>
                 ))}
               </div>
-              {/* Slider input overlaid - clamp max to at least 0 */}
-              <input
-                type="range"
-                min="0"
-                max={Math.max(0, maxIndex)}
-                value={Math.min(frameIndex, Math.max(0, maxIndex))}
-                onChange={(e) => {
-                  setIsPlaying(false)
-                  setFrameIndex(parseInt(e.target.value))
-                }}
-                className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
-                style={{
-                  WebkitAppearance: 'none',
-                  appearance: 'none'
-                }}
-              />
-              {/* Custom thumb indicator */}
-              <div
-                className={`absolute top-1/2 -translate-y-1/2 bg-white border-2 border-cyan-400 rounded-full shadow-lg shadow-cyan-400/50 pointer-events-none transition-all duration-150 ease-out ${
-                  displayMode === 'widget' ? 'w-3 h-3' : 'w-4 h-4'
-                }`}
-                style={{ left: `calc(${progress}% - ${displayMode === 'widget' ? '6px' : '8px'})` }}
-              />
-            </div>
-            {/* Time labels */}
-            <div className={`flex justify-between items-center font-mono ${
-              displayMode === 'widget' ? 'mt-0.5 text-[8px]' : 'mt-1.5 text-[10px]'
-            }`}>
-              <span className="text-gray-500">-4h</span>
-              <div className="flex items-center gap-1">
-                <span className="text-gray-400">Frame</span>
-                <span className="text-cyan-400 font-bold">{frameIndex + 1}</span>
-                <span className="text-gray-500">/ {timestamps.length}</span>
-              </div>
-              <span className={isLiveFrame ? 'text-red-400 font-bold animate-pulse' : 'text-gray-500'}>
-                {isLiveFrame ? 'LIVE' : 'NOW'}
-              </span>
-            </div>
-          </div>
-            )
-          })()}
-        </div>
-      )}
 
-      {/* No Radar Message for International */}
-      {!isUSLocation && activeLayers.precipitation && (
-        <div className="absolute inset-0 flex items-center justify-center z-[2000] pointer-events-none">
-          <div className="bg-gray-800/95 rounded-lg p-6 max-w-md text-center shadow-xl">
-            <div className="text-2xl font-mono font-bold text-white mb-2">
-              HIGH-RESOLUTION RADAR UNAVAILABLE
+              <div
+                className={`border-l border-gray-600 text-center ${
+                  displayMode === 'widget' ? 'ml-1 pl-1 min-w-[50px]' : 'ml-2 border-l-2 pl-2 min-w-[80px]'
+                }`}
+              >
+                <span
+                  className={`font-mono font-bold ${
+                    displayMode === 'widget' ? 'text-[10px]' : 'text-xs'
+                  } ${isLiveFrame ? 'text-red-400 animate-pulse' : 'text-cyan-400'}`}
+                >
+                  {relativeTime}
+                </span>
+              </div>
             </div>
-            <div className="text-sm text-gray-300 mb-4">
-              Animated radar is only available for US locations.
-            </div>
-            <div className="text-xs text-gray-400">
-              Current conditions and forecasts are still available above.
+
+            {(() => {
+              const maxIndex = activeTimestamps.length - 1
+              const progress = maxIndex > 0 ? (frameIndex / maxIndex) * 100 : 100
+              return (
+                <div
+                  className={`max-w-[90vw] bg-gray-900/95 rounded-md shadow-xl backdrop-blur-sm ${
+                    displayMode === 'widget' ? 'w-[280px] px-2 py-1' : 'w-[500px] px-3 py-2'
+                  }`}
+                >
+                  <div
+                    className={`relative bg-gray-800 rounded-full overflow-hidden border border-gray-700 ${
+                      displayMode === 'widget' ? 'h-2' : 'h-3'
+                    }`}
+                  >
+                    <div
+                      className="absolute inset-y-0 left-0 bg-gradient-to-r from-cyan-600 to-cyan-400 rounded-full transition-all duration-150 ease-out"
+                      style={{ width: `${progress}%` }}
+                    />
+                    <input
+                      type="range"
+                      min="0"
+                      max={Math.max(0, maxIndex)}
+                      value={Math.min(frameIndex, Math.max(0, maxIndex))}
+                      onChange={(e) => {
+                        setIsPlaying(false)
+                        setFrameIndex(parseInt(e.target.value, 10))
+                      }}
+                      className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
+                    />
+                    <div
+                      className={`absolute top-1/2 -translate-y-1/2 bg-white border-2 border-cyan-400 rounded-full shadow-lg pointer-events-none ${
+                        displayMode === 'widget' ? 'w-3 h-3' : 'w-4 h-4'
+                      }`}
+                      style={{ left: `calc(${progress}% - ${displayMode === 'widget' ? '6px' : '8px'})` }}
+                    />
+                  </div>
+                  <div
+                    className={`flex justify-between items-center font-mono ${
+                      displayMode === 'widget' ? 'mt-0.5 text-[8px]' : 'mt-1.5 text-[10px]'
+                    }`}
+                  >
+                    <span className="text-gray-500">-4h</span>
+                    <span className="text-gray-400">
+                      Frame {frameIndex + 1}/{activeTimestamps.length}
+                    </span>
+                    <span className={isLiveFrame ? 'text-red-400 font-bold animate-pulse' : 'text-gray-500'}>
+                      {isLiveFrame ? 'LIVE' : 'SCRUB'}
+                    </span>
+                  </div>
+                </div>
+              )
+            })()}
+          </div>
+        )}
+
+        {showUnavailable && (
+          <div className="absolute inset-0 flex items-center justify-center z-[2000] pointer-events-none">
+            <div className="bg-gray-800/95 rounded-lg p-6 max-w-md text-center shadow-xl">
+              <div className="text-2xl font-mono font-bold text-white mb-2">RADAR UNAVAILABLE</div>
+              <div className="text-sm text-gray-300 mb-4">
+                No RainViewer feed for this area right now. Forecast data is still available above.
+              </div>
+              {rainViewerFailed && (
+                <div className="text-xs text-amber-300 font-mono">RainViewer metadata could not be loaded.</div>
+              )}
             </div>
           </div>
-        </div>
-      )}
+        )}
       </div>
 
-      {/* Radar Reflectivity Legend - Right Side, Outside Map */}
-      {isUSLocation && activeLayers.precipitation && radarVisible && (
+      {showRadarOverlay && radarVisible && (
         <div className="flex-shrink-0 self-center">
           <div className="bg-gray-900/95 rounded-md p-1.5 backdrop-blur-sm shadow-xl">
-            <div className="font-mono text-[8px] text-gray-400 mb-1 uppercase tracking-wide text-center">
-              dBZ
+            <div className="flex items-center justify-between gap-1 mb-1">
+              <span className="font-mono text-[8px] text-gray-400 uppercase tracking-wide">dBZ</span>
+              <button
+                type="button"
+                onClick={() => setShowNightTip((v) => !v)}
+                className="text-gray-400 hover:text-cyan-300"
+                title="About night-time radar artifacts"
+              >
+                <Info className="w-3 h-3" />
+              </button>
             </div>
+            {showNightTip && (
+              <p className="font-mono text-[8px] text-gray-400 mb-1 max-w-[88px] leading-snug">
+                Reflectivity can show non-storm echoes at night (birds, clutter, AP).
+              </p>
+            )}
             <div className="flex flex-col gap-0.5">
               {RADAR_LEGEND.map((item) => (
                 <div key={item.dbz} className="flex items-center gap-1">

--- a/components/weather-map-openlayers.tsx
+++ b/components/weather-map-openlayers.tsx
@@ -8,9 +8,11 @@ import { ThemeType } from '@/lib/theme-config'
 import {
   BASE_ANIMATION_INTERVAL_MS,
   CARTO_DARK_MATTER_URL,
+  INTL_RADAR_SOURCE_ID,
   IOWA_NEXRAD_LAYER,
   IOWA_NEXRAD_WMS_URL,
   PRELOAD_FRAMES_AHEAD,
+  US_RADAR_SOURCE_ID,
   RADAR_LEGEND,
   RADAR_REFRESH_MS,
   RAINVIEWER_MAPS_API,
@@ -564,6 +566,8 @@ const WeatherMapOpenLayers = ({
   return (
     <div
       data-radar-container
+      data-radar-us-source={isUSLocation ? US_RADAR_SOURCE_ID : undefined}
+      data-radar-intl-source={!isUSLocation && rainViewerData ? INTL_RADAR_SOURCE_ID : undefined}
       className={`flex gap-2 w-full rounded-lg ${themeStyles.container}`}
       style={{ height: '100%', minHeight: '350px' }}
     >

--- a/components/weather-map-openlayers.tsx
+++ b/components/weather-map-openlayers.tsx
@@ -1,5 +1,5 @@
 'use client'
-// Build: v7 - Phase 1 radar modernization (MRMS proxy, RainViewer intl, live refresh)
+// Build: v7.1 - Phase 1 radar (Iowa NEXRAD US primary, RainViewer intl, live refresh)
 
 import { useEffect, useRef, useState, useMemo, useCallback } from 'react'
 import { Play, Pause, SkipBack, SkipForward, Layers, ChevronDown, Loader2, Info } from 'lucide-react'
@@ -10,16 +10,12 @@ import {
   CARTO_DARK_MATTER_URL,
   IOWA_NEXRAD_LAYER,
   IOWA_NEXRAD_WMS_URL,
-  MRMS_TILE_ERROR_FALLBACK_THRESHOLD,
-  MRMS_WMS_LAYER,
-  MRMS_WMS_PROXY_PATH,
   PRELOAD_FRAMES_AHEAD,
   RADAR_LEGEND,
   RADAR_REFRESH_MS,
   RAINVIEWER_MAPS_API,
   STORM_WATCH_FRAMES,
   TILE_TRANSITION_MS,
-  type UsRadarProvider,
 } from '@/lib/radar/radar-config'
 import {
   buildRadarTimestamps,
@@ -75,7 +71,6 @@ const WeatherMapOpenLayers = ({
 
   const [isMounted, setIsMounted] = useState(false)
   const [clockTick, setClockTick] = useState(0)
-  const [usProvider, setUsProvider] = useState<UsRadarProvider>('mrms')
   const [tileError, setTileError] = useState<string | null>(null)
   const [rainViewerData, setRainViewerData] = useState<RainViewerMapsResponse | null>(null)
   const [rainViewerLoading, setRainViewerLoading] = useState(false)
@@ -174,7 +169,6 @@ const WeatherMapOpenLayers = ({
   }, [activeTimestamps])
 
   useEffect(() => {
-    setUsProvider('mrms')
     setTileError(null)
     preloadCacheRef.current.clear()
   }, [latitude, longitude])
@@ -308,33 +302,30 @@ const WeatherMapOpenLayers = ({
             initialLoadComplete = true
             setRadarVisible(true)
           }
+          if (tileErrorCount > 0) {
+            tileErrorCount = 0
+            setTileError(null)
+          }
         }
       })
       source.on('tileloaderror', () => {
         loadingTileCount = Math.max(0, loadingTileCount - 1)
         if (loadingTileCount === 0) setIsLoading(false)
         tileErrorCount++
-        if (isUSLocation && usProvider === 'mrms' && tileErrorCount >= MRMS_TILE_ERROR_FALLBACK_THRESHOLD) {
-          setUsProvider('iowa-fallback')
-          setTileError('MRMS unavailable — showing NEXRAD fallback')
-        } else if (tileErrorCount >= 3) {
-          setTileError('Radar tiles temporarily unavailable — retrying…')
+        if (tileErrorCount >= 8) {
+          setTileError('Some radar tiles failed to load — try refreshing or zooming in.')
         }
       })
     }
 
     if (isUSLocation) {
-      const wmsUrl = usProvider === 'mrms' ? MRMS_WMS_PROXY_PATH : IOWA_NEXRAD_WMS_URL
-      const isMrms = usProvider === 'mrms'
-
       const radarSource = new TileWMS({
-        url: wmsUrl,
+        url: IOWA_NEXRAD_WMS_URL,
         params: {
-          LAYERS: isMrms ? MRMS_WMS_LAYER : IOWA_NEXRAD_LAYER,
+          LAYERS: IOWA_NEXRAD_LAYER,
           FORMAT: 'image/png',
           TRANSPARENT: 'true',
-          VERSION: isMrms ? '1.3.0' : '1.1.1',
-          ...(isMrms ? { CRS: 'EPSG:3857' } : {}),
+          VERSION: '1.1.1',
         },
         serverType: 'mapserver',
         transition: TILE_TRANSITION_MS,
@@ -397,7 +388,6 @@ const WeatherMapOpenLayers = ({
     isUSLocation,
     precipitationOn,
     hasRadarAnimation,
-    usProvider,
     rainViewerData,
     activeTimestamps.length,
     opacity,
@@ -436,7 +426,7 @@ const WeatherMapOpenLayers = ({
 
   useEffect(() => {
     preloadCacheRef.current.clear()
-  }, [latitude, longitude, usProvider])
+  }, [latitude, longitude])
 
   const preloadFrame = useCallback(
     (index: number) => {
@@ -459,17 +449,11 @@ const WeatherMapOpenLayers = ({
         }
       }
 
-      const isMrms = usProvider === 'mrms'
-      const baseUrl = isMrms ? MRMS_WMS_PROXY_PATH : IOWA_NEXRAD_WMS_URL
-      const layer = isMrms ? MRMS_WMS_LAYER : IOWA_NEXRAD_LAYER
-      const version = isMrms ? '1.3.0' : '1.1.1'
-      const crs = isMrms ? '&CRS=EPSG:3857' : '&SRS=EPSG:3857'
-
       const img = new Image()
       img.crossOrigin = 'anonymous'
-      img.src = `${baseUrl}?SERVICE=WMS&VERSION=${version}&REQUEST=GetMap&LAYERS=${layer}&TIME=${encodeURIComponent(timeISO)}&FORMAT=image/png&TRANSPARENT=true&WIDTH=256&HEIGHT=256${crs}&BBOX=${bbox}`
+      img.src = `${IOWA_NEXRAD_WMS_URL}?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetMap&LAYERS=${IOWA_NEXRAD_LAYER}&TIME=${encodeURIComponent(timeISO)}&FORMAT=image/png&TRANSPARENT=true&WIDTH=256&HEIGHT=256&SRS=EPSG:3857&BBOX=${bbox}`
     },
-    [activeTimestamps, isUSLocation, usProvider]
+    [activeTimestamps, isUSLocation]
   )
 
   useEffect(() => {
@@ -542,9 +526,7 @@ const WeatherMapOpenLayers = ({
   }, [currentTime, clockTick, isLiveFrame, dataAgeMinutes])
 
   const providerLabel = isUSLocation
-    ? usProvider === 'mrms'
-      ? 'NOAA MRMS'
-      : 'NEXRAD FALLBACK'
+    ? 'NEXRAD'
     : rainViewerData
       ? 'RAINVIEWER'
       : 'RADAR'
@@ -672,7 +654,7 @@ const WeatherMapOpenLayers = ({
                 </div>
               )}
               <div className="px-3 py-2 border-t border-gray-600 text-[10px] text-gray-400 font-mono leading-snug">
-                US: NOAA MRMS via nowCOAST
+                US: Iowa State NEXRAD composite
                 <br />
                 Intl:{' '}
                 <a href="https://www.rainviewer.com/" className="text-cyan-400 underline" target="_blank" rel="noopener noreferrer">

--- a/lib/radar/radar-config.ts
+++ b/lib/radar/radar-config.ts
@@ -1,0 +1,35 @@
+/** Shared radar animation and provider constants (Phase 1). */
+
+export const RADAR_STEP_MINUTES = 5
+export const RADAR_PAST_STEPS = 48 // 4 hours at 5-minute steps
+export const RADAR_REFRESH_MS = RADAR_STEP_MINUTES * 60 * 1000
+export const STORM_WATCH_HOURS = 2
+export const STORM_WATCH_FRAMES = (STORM_WATCH_HOURS * 60) / RADAR_STEP_MINUTES
+
+export const TILE_TRANSITION_MS = 500
+export const BASE_ANIMATION_INTERVAL_MS = 500
+export const PRELOAD_FRAMES_AHEAD = 3
+export const MRMS_TILE_ERROR_FALLBACK_THRESHOLD = 5
+
+export const MRMS_WMS_PROXY_PATH = '/api/weather/noaa-wms'
+export const MRMS_WMS_LAYER = '1'
+
+export const IOWA_NEXRAD_WMS_URL =
+  'https://mesonet.agron.iastate.edu/cgi-bin/wms/nexrad/n0q-t.cgi'
+export const IOWA_NEXRAD_LAYER = 'nexrad-n0q-wmst'
+
+export const RAINVIEWER_MAPS_API = '/api/weather/rainviewer/maps'
+
+export const CARTO_DARK_MATTER_URL =
+  'https://{a-d}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png'
+
+export type UsRadarProvider = 'mrms' | 'iowa-fallback'
+export type RadarRegion = 'us' | 'international' | 'unavailable'
+
+export const RADAR_LEGEND = [
+  { color: '#00ffc8', label: 'Light', dbz: '5-20' },
+  { color: '#00c800', label: 'Moderate', dbz: '20-35' },
+  { color: '#ffff00', label: 'Heavy', dbz: '35-50' },
+  { color: '#ff8c00', label: 'Very Heavy', dbz: '50-65' },
+  { color: '#ff0000', label: 'Extreme', dbz: '65+' },
+] as const

--- a/lib/radar/radar-config.ts
+++ b/lib/radar/radar-config.ts
@@ -9,21 +9,21 @@ export const STORM_WATCH_FRAMES = (STORM_WATCH_HOURS * 60) / RADAR_STEP_MINUTES
 export const TILE_TRANSITION_MS = 500
 export const BASE_ANIMATION_INTERVAL_MS = 500
 export const PRELOAD_FRAMES_AHEAD = 3
-export const MRMS_TILE_ERROR_FALLBACK_THRESHOLD = 5
 
-export const MRMS_WMS_PROXY_PATH = '/api/weather/noaa-wms'
-export const MRMS_WMS_LAYER = '1'
-
+/** US primary: Iowa IEM NEXRAD WMS-T (direct browser fetch; CSP-allowed). */
 export const IOWA_NEXRAD_WMS_URL =
   'https://mesonet.agron.iastate.edu/cgi-bin/wms/nexrad/n0q-t.cgi'
 export const IOWA_NEXRAD_LAYER = 'nexrad-n0q-wmst'
+
+/** Deferred: nowCOAST MRMS WMS returns CloudFront 403; proxy also hits tile rate limits. */
+export const MRMS_WMS_PROXY_PATH = '/api/weather/noaa-wms'
+export const MRMS_WMS_LAYER = '1'
 
 export const RAINVIEWER_MAPS_API = '/api/weather/rainviewer/maps'
 
 export const CARTO_DARK_MATTER_URL =
   'https://{a-d}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png'
 
-export type UsRadarProvider = 'mrms' | 'iowa-fallback'
 export type RadarRegion = 'us' | 'international' | 'unavailable'
 
 export const RADAR_LEGEND = [

--- a/lib/radar/radar-config.ts
+++ b/lib/radar/radar-config.ts
@@ -11,9 +11,13 @@ export const BASE_ANIMATION_INTERVAL_MS = 500
 export const PRELOAD_FRAMES_AHEAD = 3
 
 /** US primary: Iowa IEM NEXRAD WMS-T (direct browser fetch; CSP-allowed). */
+export const US_RADAR_SOURCE_ID = 'iowa-wms-t'
 export const IOWA_NEXRAD_WMS_URL =
   'https://mesonet.agron.iastate.edu/cgi-bin/wms/nexrad/n0q-t.cgi'
 export const IOWA_NEXRAD_LAYER = 'nexrad-n0q-wmst'
+
+/** International: RainViewer via app proxy. */
+export const INTL_RADAR_SOURCE_ID = 'rainviewer'
 
 /** Deferred: nowCOAST MRMS WMS returns CloudFront 403; proxy also hits tile rate limits. */
 export const MRMS_WMS_PROXY_PATH = '/api/weather/noaa-wms'

--- a/lib/radar/radar-timestamps.ts
+++ b/lib/radar/radar-timestamps.ts
@@ -6,12 +6,25 @@ export interface BuildRadarTimestampsOptions {
   pastSteps?: number
 }
 
+function normalizeStepMinutes(stepMinutes: number): number {
+  if (Number.isFinite(stepMinutes) && stepMinutes > 0) return stepMinutes
+  return RADAR_STEP_MINUTES
+}
+
+function normalizePastSteps(pastSteps: number): number {
+  if (!Number.isFinite(pastSteps)) return RADAR_PAST_STEPS
+  const floored = Math.floor(pastSteps)
+  if (floored < 0) return RADAR_PAST_STEPS
+  return floored
+}
+
 /** Quantize a timestamp down to the nearest radar frame boundary. */
 export function quantizeRadarTime(
   ms: number,
   stepMinutes: number = RADAR_STEP_MINUTES
 ): number {
-  const stepMs = stepMinutes * 60 * 1000
+  const safeStepMinutes = normalizeStepMinutes(stepMinutes)
+  const stepMs = safeStepMinutes * 60 * 1000
   return Math.floor(ms / stepMs) * stepMs
 }
 
@@ -19,8 +32,8 @@ export function quantizeRadarTime(
 export function buildRadarTimestamps(
   options: BuildRadarTimestampsOptions = {}
 ): number[] {
-  const stepMinutes = options.stepMinutes ?? RADAR_STEP_MINUTES
-  const pastSteps = options.pastSteps ?? RADAR_PAST_STEPS
+  const stepMinutes = normalizeStepMinutes(options.stepMinutes ?? RADAR_STEP_MINUTES)
+  const pastSteps = normalizePastSteps(options.pastSteps ?? RADAR_PAST_STEPS)
   const base = quantizeRadarTime(options.nowMs ?? Date.now(), stepMinutes)
   const stepMs = stepMinutes * 60 * 1000
   const times: number[] = []

--- a/lib/radar/radar-timestamps.ts
+++ b/lib/radar/radar-timestamps.ts
@@ -1,0 +1,47 @@
+import { RADAR_PAST_STEPS, RADAR_STEP_MINUTES } from './radar-config'
+
+export interface BuildRadarTimestampsOptions {
+  nowMs?: number
+  stepMinutes?: number
+  pastSteps?: number
+}
+
+/** Quantize a timestamp down to the nearest radar frame boundary. */
+export function quantizeRadarTime(
+  ms: number,
+  stepMinutes: number = RADAR_STEP_MINUTES
+): number {
+  const stepMs = stepMinutes * 60 * 1000
+  return Math.floor(ms / stepMs) * stepMs
+}
+
+/** Build ascending UTC frame timestamps ending at the latest quantized "now". */
+export function buildRadarTimestamps(
+  options: BuildRadarTimestampsOptions = {}
+): number[] {
+  const stepMinutes = options.stepMinutes ?? RADAR_STEP_MINUTES
+  const pastSteps = options.pastSteps ?? RADAR_PAST_STEPS
+  const base = quantizeRadarTime(options.nowMs ?? Date.now(), stepMinutes)
+  const stepMs = stepMinutes * 60 * 1000
+  const times: number[] = []
+
+  for (let i = pastSteps; i >= 0; i -= 1) {
+    times.push(base - i * stepMs)
+  }
+
+  return times
+}
+
+/** Minutes between frame time and real now (for "Updated X ago"). */
+export function minutesSinceFrame(frameMs: number, nowMs: number = Date.now()): number {
+  return Math.max(0, Math.round((nowMs - frameMs) / 60_000))
+}
+
+/** Frame index to start a "last N hours" playback ending at live. */
+export function stormWatchStartIndex(
+  frameCount: number,
+  framesBack: number = (2 * 60) / RADAR_STEP_MINUTES
+): number {
+  if (frameCount <= 0) return 0
+  return Math.max(0, frameCount - 1 - framesBack)
+}

--- a/lib/radar/rainviewer-types.ts
+++ b/lib/radar/rainviewer-types.ts
@@ -1,0 +1,54 @@
+export interface RainViewerFrame {
+  time: number
+  path: string
+}
+
+export interface RainViewerMapsResponse {
+  host: string
+  past: RainViewerFrame[]
+}
+
+/** Normalize RainViewer public API JSON into frame list for animation. */
+export function parseRainViewerMapsPayload(data: unknown): RainViewerMapsResponse | null {
+  if (!data || typeof data !== 'object') return null
+
+  const record = data as Record<string, unknown>
+  const host = typeof record.host === 'string' ? record.host : 'https://tilecache.rainviewer.com'
+  const radar = record.radar
+
+  if (!radar || typeof radar !== 'object') return null
+
+  const pastRaw = (radar as Record<string, unknown>).past
+  if (!Array.isArray(pastRaw)) return null
+
+  const past: RainViewerFrame[] = pastRaw
+    .map((item) => {
+      if (!item || typeof item !== 'object') return null
+      const frame = item as Record<string, unknown>
+      const time = frame.time
+      const path = frame.path
+      if (typeof time !== 'number' || typeof path !== 'string') return null
+      return { time, path }
+    })
+    .filter((f): f is RainViewerFrame => f !== null)
+    .sort((a, b) => a.time - b.time)
+
+  if (past.length === 0) return null
+
+  return { host, past }
+}
+
+/** Build a tile URL for a RainViewer frame at z/x/y. */
+export function rainViewerTileUrl(
+  host: string,
+  pathTemplate: string,
+  z: number,
+  x: number,
+  y: number
+): string {
+  const path = pathTemplate
+    .replace('{z}', String(z))
+    .replace('{x}', String(x))
+    .replace('{y}', String(y))
+  return `${host.replace(/\/$/, '')}${path}`
+}

--- a/planning/prds/PRD-radar-modernization.md
+++ b/planning/prds/PRD-radar-modernization.md
@@ -135,12 +135,20 @@ flowchart TB
 - When user is on live frame, **auto-advance** to new latest after refresh
 - Display **"Updated Xm ago"** based on latest frame time vs `Date.now()`
 
-### 7.2 US provider switch
+### 7.2 US provider (revised after preview testing)
 
-- Point WMS `TileWMS` at `/api/weather/noaa-wms`
-- Params: `LAYERS=1`, `VERSION=1.3.0`, `CRS=EPSG:3857`, `TIME` animation
-- After **5 consecutive tile errors**, fall back to Iowa `n0q-t.cgi` for session
-- Badge: `MRMS` or `NEXRAD (fallback)`
+**Original plan:** MRMS via `/api/weather/noaa-wms` with Iowa fallback.
+
+**Preview regression (2026-05-23):** MRMS path degraded UX vs pre-Phase-1 Iowa direct.
+
+| Finding | Detail |
+|---------|--------|
+| nowCOAST MRMS WMS | Returns **HTTP 403** (CloudFront) — upstream unavailable |
+| Tile proxy rate limit | **30 requests / 5 min burst** — one zoomed-out view exhausts limit → 429 → tile errors |
+| Fallback behavior | Swapping providers mid-session **recreated the radar layer** → flash, blue/cyan artifact, broken zoom |
+| Iowa IEM direct | **HTTP 200**, CORS allowed in CSP, no app rate limit — pre-Phase-1 behavior |
+
+**Shipped fix:** US radar uses **Iowa IEM `n0q-t.cgi` direct** (same as pre-Phase-1). MRMS proxy kept in repo for future mapservices.noaa.gov migration. No automatic provider swap.
 
 ### 7.3 International RainViewer
 

--- a/planning/prds/PRD-radar-modernization.md
+++ b/planning/prds/PRD-radar-modernization.md
@@ -1,0 +1,275 @@
+# PRD: Radar Modernization — Storm Watch & Global Coverage
+
+**Version:** 1.0  
+**Date:** 2026-05-22  
+**Author:** Justin Elrod / AI-assisted analysis  
+**Project:** 16-Bit Weather (16bitweather.co)  
+**Branch:** `feat/radar-phase-1` (Phase 1), future phases on follow-up branches  
+**Priority:** Medium (personal storm-watch quality; low traffic site)  
+**Cost target:** $0/month at current usage (<5 radar sessions/week)
+
+---
+
+## Table of Contents
+
+1. [Executive Summary](#1-executive-summary)
+2. [Problem Statement](#2-problem-statement)
+3. [Goals & Non-Goals](#3-goals--non-goals)
+4. [Current State](#4-current-state)
+5. [User Stories](#5-user-stories)
+6. [Provider Architecture](#6-provider-architecture)
+7. [Phase 1 — Core Reliability (this branch)](#7-phase-1--core-reliability-this-branch)
+8. [Phase 2 — Dashboard UX (future)](#8-phase-2--dashboard-ux-future)
+9. [Phase 3 — Polish & Resilience (future)](#9-phase-3--polish--resilience-future)
+10. [Technical Design](#10-technical-design)
+11. [Testing Strategy](#11-testing-strategy)
+12. [Success Metrics](#12-success-metrics)
+13. [Risks & Mitigations](#13-risks--mitigations)
+14. [References](#14-references)
+
+---
+
+## 1. Executive Summary
+
+Replace the hacked-together Iowa NEXRAD-only radar with a **reliable storm-watch experience**: live-accurate animation, NOAA MRMS in the US (with Iowa fallback), RainViewer tiles internationally where feeds exist, honest UX about radar limitations at night, and storm-watch-friendly controls.
+
+Phase 1 ships on `feat/radar-phase-1` with **$0 infrastructure cost**. Later phases add a static homepage widget and day/night basemap without changing providers.
+
+---
+
+## 2. Problem Statement
+
+| Issue | Impact |
+|-------|--------|
+| Timestamps computed once at mount | "LIVE" frame goes stale if map stays open; timeline drifts from real time |
+| Iowa raw NEXRAD composite (not MRMS) | Night patches (AP, birds, clutter) shown as precipitation |
+| Marketing says MRMS; code hits Iowa direct | Debugging confusion; unused secured proxies |
+| US-only hard stop | No radar for international locations despite free global options |
+| Dead layer toggles (clouds/wind/etc.) | Broken controls erode trust |
+| Silent tile failures | Empty or patchy map with no explanation |
+
+**User need:** Open 16bitweather.co instead of weather.com or AccuWeather for **local animated radar and storm tracking**, even on a low-traffic personal site.
+
+---
+
+## 3. Goals & Non-Goals
+
+### Goals
+
+- True **animated reflectivity** (dBZ-style loops), not just forecast POP
+- **US:** NOAA MRMS via existing `/api/weather/noaa-wms` proxy
+- **International:** RainViewer where coverage exists
+- **Live frame stays current** during long sessions (5-minute refresh)
+- **Storm-watch defaults:** latest frame, quick "play last 2 hours", clear attribution
+- **$0/month** at current traffic
+
+### Non-Goals (Phase 1)
+
+- Self-hosted MRMS tile pipeline
+- Paid commercial radar APIs (Xweather, Tomorrow.io, OpenWeather Maps 2.0 paid tiers)
+- Static RadMap homepage widget (Phase 2)
+- Day/night basemap switching (Phase 3)
+- MRMS QPE alternate layer toggle
+- SPC/warnings deep integration (separate features exist)
+
+---
+
+## 4. Current State
+
+**Live path:** `components/weather-map-openlayers.tsx` → Iowa IEM `n0q-t.cgi` WMS-T (browser direct).
+
+**Unused infrastructure:**
+
+- `/api/weather/noaa-wms` — NOAA MRMS WMS proxy (CORS, rate limit, adaptive cache)
+- `/api/weather/iowa-nexrad` — static Iowa WMS
+- `/api/weather/iowa-nexrad-tiles` — Iowa XYZ tiles
+- `/api/weather/radar/[layer]` — OpenWeather (precip returns 410)
+
+**Coverage gate:** `isInMRMSCoverage()` in `lib/utils/location-utils.ts` — US territories only.
+
+---
+
+## 5. User Stories
+
+1. **As a storm watcher in the US**, I open `/radar` and see the **latest MRMS loop** without refreshing the tab after an hour.
+2. **As a user abroad**, I see **RainViewer radar** when available instead of a dead-end message.
+3. **As a user at night**, I understand that **non-storm echoes** may appear on reflectivity maps.
+4. **As a developer**, provider choice matches **SEO/copy (MRMS)** and uses **existing proxies** where possible.
+
+---
+
+## 6. Provider Architecture
+
+```mermaid
+flowchart TB
+  User["User /radar"]
+  Map["weather-map-openlayers.tsx"]
+  US{"US territory?"}
+  MRMS["NOAA MRMS WMS<br/>/api/weather/noaa-wms"]
+  Iowa["Iowa IEM fallback<br/>n0q-t.cgi"]
+  Intl{"RainViewer<br/>coverage?"}
+  RV["RainViewer XYZ tiles<br/>via /api/weather/rainviewer/maps"]
+  None["Graceful unavailable message"]
+
+  User --> Map --> US
+  US -->|yes| MRMS
+  MRMS -->|tile errors| Iowa
+  US -->|no| Intl
+  Intl -->|yes| RV
+  Intl -->|no| None
+```
+
+| Region | Primary | Fallback | Cost |
+|--------|---------|----------|------|
+| US + territories | NOAA MRMS (proxy) | Iowa WMS-T | $0 |
+| International | RainViewer | Message if no data | $0 |
+| All | Carto dark basemap | — | $0 |
+
+---
+
+## 7. Phase 1 — Core Reliability (this branch)
+
+### 7.1 Timestamp refresh
+
+- Rebuild frame index every **5 minutes** (aligned to radar cadence)
+- When user is on live frame, **auto-advance** to new latest after refresh
+- Display **"Updated Xm ago"** based on latest frame time vs `Date.now()`
+
+### 7.2 US provider switch
+
+- Point WMS `TileWMS` at `/api/weather/noaa-wms`
+- Params: `LAYERS=1`, `VERSION=1.3.0`, `CRS=EPSG:3857`, `TIME` animation
+- After **5 consecutive tile errors**, fall back to Iowa `n0q-t.cgi` for session
+- Badge: `MRMS` or `NEXRAD (fallback)`
+
+### 7.3 International RainViewer
+
+- New route: `GET /api/weather/rainviewer/maps` — proxies RainViewer JSON, caches 2 min
+- Client uses RainViewer `past` frame list for animation (10-min steps typical)
+- OpenLayers `XYZ` tile URL from RainViewer path template
+- Attribution link to rainviewer.com
+
+### 7.4 Storm-watch UX
+
+- Default: **latest frame**, not playing
+- **"Last 2h"** button: jump to ~2 hours ago and play to live
+- Remove non-functional layer toggles; keep precipitation on/off + opacity
+- Night artifact **tooltip** on legend area
+- Tile error banner after repeated failures
+
+### 7.5 Files (Phase 1)
+
+| File | Action |
+|------|--------|
+| `planning/prds/PRD-radar-modernization.md` | Create (this doc) |
+| `planning/prds/README.md` | Index entry |
+| `lib/radar/radar-config.ts` | Constants |
+| `lib/radar/radar-timestamps.ts` | Frame index builder + refresh hook |
+| `lib/radar/rainviewer-types.ts` | Types |
+| `app/api/weather/rainviewer/maps/route.ts` | RainViewer metadata proxy |
+| `components/weather-map-openlayers.tsx` | Provider logic + UX |
+| `middleware.ts` | CSP for RainViewer if needed |
+| `__tests__/radar-timestamps.test.ts` | Unit tests |
+
+---
+
+## 8. Phase 2 — Dashboard UX (future)
+
+- Restore **static latest-frame** widget on homepage (`displayMode: widget`)
+- Full animated map on `/radar` only
+- Optional: link to SPC outlook when warnings active
+
+---
+
+## 9. Phase 3 — Polish & Resilience (future)
+
+- Day/night basemap toggle (Carto dark / Positron)
+- E2E assertion that radar tiles return 200
+- `/radar-diagnostic` update for MRMS + RainViewer
+- Consider self-hosted MRMS→R2 only if traffic exceeds free proxy comfort
+
+---
+
+## 10. Technical Design
+
+### 10.1 Timestamp generation
+
+```typescript
+buildRadarTimestamps({
+  stepMinutes: 5,
+  pastSteps: 48, // 4 hours (US MRMS)
+  nowMs: Date.now(),
+}): number[]
+```
+
+Refresh: `setInterval(5 * 60 * 1000)` + `document.visibilitychange` catch-up.
+
+### 10.2 MRMS WMS (US)
+
+- Proxy: `app/api/weather/noaa-wms/route.ts` (existing)
+- Upstream: `nowcoast.noaa.gov/.../radar_meteo_imagery_nexrad_time/MapServer/WMSServer`
+- Layer ID: `1` (MRMS composite reflectivity)
+
+### 10.3 RainViewer (international)
+
+- Metadata: `https://api.rainviewer.com/public/weather-maps.json`
+- Tiles: `{host}{path}` with `{z}/{x}/{y}` substitution
+- Server cache: `Cache-Control: public, max-age=120`
+
+### 10.4 CSP
+
+Add to `connect-src`: RainViewer API (if client fetch) — prefer server proxy only.  
+`img-src` already allows `https:` broadly.
+
+---
+
+## 11. Testing Strategy
+
+### Unit
+
+- `buildRadarTimestamps` — count, ordering, 5-min quantization
+- RainViewer response parsing (mock JSON)
+
+### E2E (existing)
+
+- `tests/e2e/radar.spec.ts` — map loads, controls visible, theme z-index
+- Update badge regex to accept `MRMS` / `RAINVIEWER`
+
+### Manual
+
+- US city (e.g. Dallas): MRMS loads, LIVE stays fresh after 6+ min
+- International city (e.g. London): RainViewer tiles visible
+- Disable network briefly: error banner, fallback if MRMS down
+
+---
+
+## 12. Success Metrics
+
+| Metric | Target |
+|--------|--------|
+| Live frame age (US) | ≤ 10 min while tab open 30+ min |
+| US provider | MRMS primary; Iowa fallback on failure |
+| International | RainViewer tiles when API returns past frames |
+| Cost | $0/month at current traffic |
+| Personal use | Prefer 16bitweather over weather.com for radar |
+
+---
+
+## 13. Risks & Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| NOAA WMS outage | Iowa fallback; transparent error UX |
+| RainViewer API changes/shutdown | Graceful message; US unaffected; revisit in Phase 3 |
+| MRMS TIME format mismatch | Test with OpenLayers; match archived working params |
+| Low traffic hides bugs | Unit tests + manual storm-season checklist |
+
+---
+
+## 14. References
+
+- Internal archive: `_archive/legacy/radar/`
+- Iowa OGC: https://mesonet.agron.iastate.edu/ogc/
+- NOAA MRMS WMS: nowCOAST `radar_meteo_imagery_nexrad_time`
+- RainViewer API: https://www.rainviewer.com/api.html
+- Existing proxy: `app/api/weather/noaa-wms/route.ts`

--- a/planning/prds/README.md
+++ b/planning/prds/README.md
@@ -9,6 +9,7 @@ Canonical location for **long-form product specs** used by humans and AI agents.
 | [PRD-open-meteo-migration.md](./PRD-open-meteo-migration.md) | Migrating primary weather source from OpenWeatherMap to Open-Meteo |
 | [PRD-stargazer.md](./PRD-stargazer.md) | Astrophotography forecast page (Stargazer) |
 | [PRD-newsletter-redesign.md](./PRD-newsletter-redesign.md) | Weekly newsletter generator redesign |
+| [PRD-radar-modernization.md](./PRD-radar-modernization.md) | Radar storm-watch reliability: MRMS, RainViewer, timestamp refresh |
 
 ## Referenced elsewhere but not in this tree
 

--- a/tests/e2e/radar.spec.ts
+++ b/tests/e2e/radar.spec.ts
@@ -1,6 +1,22 @@
 import { test, expect } from './fixtures';
 import { setupStableApp, navigateToMapPage, waitForRadarToLoad, checkRadarVisibility, setTheme } from '../fixtures/utils';
 
+function isIowaNexradRequest(url: string): boolean {
+  try {
+    return new URL(url).hostname === 'mesonet.agron.iastate.edu';
+  } catch {
+    return false;
+  }
+}
+
+function isMrmsProxyRequest(url: string): boolean {
+  try {
+    return new URL(url).pathname.startsWith('/api/weather/noaa-wms');
+  } catch {
+    return false;
+  }
+}
+
 test.describe('Radar Map', () => {
   test.beforeEach(async ({ page }) => {
     await setupStableApp(page);
@@ -8,66 +24,44 @@ test.describe('Radar Map', () => {
 
   test('radar map loads successfully', async ({ page }) => {
     await navigateToMapPage(page);
-    
-    // Wait for radar to load
     await waitForRadarToLoad(page);
-    
-    // Verify radar container exists
-    const radarContainer = page.locator('[data-radar-container], [class*="map"], [class*="Map"]').first();
+
+    const radarContainer = page.locator('[data-radar-container]').first();
     await expect(radarContainer).toBeVisible({ timeout: 15000 });
   });
 
   test('radar visible in synthwave theme', async ({ page }) => {
     await setTheme(page, 'synthwave84');
-    // Wait for theme to be fully applied
-    await page.waitForTimeout(300);
-    
     await navigateToMapPage(page);
-    
     await waitForRadarToLoad(page);
-    
-    // Wait a bit more for radar to fully render
-    await page.waitForTimeout(1000);
-    
-    // Check that radar container has proper z-index
+
     const isVisible = await checkRadarVisibility(page);
     expect(isVisible).toBeTruthy();
-    
-    // Verify radar container is above scanlines (z-index >= 10000)
+
     const radarContainer = page.locator('[data-radar-container]').first();
     if (await radarContainer.count() > 0) {
       const zIndex = await radarContainer.evaluate((el) => {
         return window.getComputedStyle(el).zIndex;
       });
-      
-      // Should be 10000 or higher to be above theme overlays
+
       expect(parseInt(zIndex) >= 10000 || zIndex === 'auto').toBeTruthy();
     }
   });
 
   test('radar visible in matrix theme', async ({ page }) => {
     await setTheme(page, 'matrix');
-    // Wait for theme to be fully applied
-    await page.waitForTimeout(300);
-    
     await navigateToMapPage(page);
-    
     await waitForRadarToLoad(page);
-    
-    // Wait a bit more for radar to fully render
-    await page.waitForTimeout(1000);
-    
-    // Check that radar container has proper z-index
+
     const isVisible = await checkRadarVisibility(page);
     expect(isVisible).toBeTruthy();
-    
-    // Verify radar container is above CRT scanlines
+
     const radarContainer = page.locator('[data-radar-container]').first();
     if (await radarContainer.count() > 0) {
       const zIndex = await radarContainer.evaluate((el) => {
         return window.getComputedStyle(el).zIndex;
       });
-      
+
       expect(parseInt(zIndex) >= 10000 || zIndex === 'auto').toBeTruthy();
     }
   });
@@ -75,49 +69,29 @@ test.describe('Radar Map', () => {
   test('radar visible in default dark theme', async ({ page }) => {
     await setTheme(page, 'dark');
     await navigateToMapPage(page);
-    
     await waitForRadarToLoad(page);
-    
-    const radarContainer = page.locator('[data-radar-container], [class*="map"], [class*="Map"]').first();
+
+    const radarContainer = page.locator('[data-radar-container]').first();
     await expect(radarContainer).toBeVisible({ timeout: 15000 });
   });
 
   test('radar map controls are visible', async ({ page }) => {
     await navigateToMapPage(page);
     await waitForRadarToLoad(page);
-    
-    // Wait for controls to render (they may load after the map)
-    await page.waitForTimeout(2000);
-    
-    // First verify the radar map is visible
+
     const isVisible = await checkRadarVisibility(page);
     expect(isVisible).toBeTruthy();
-    
-    // Check for layer controls, buttons, or status badge
-    // Look for common control patterns in the radar component
-    const controls = page.locator('button, [class*="badge"], [class*="control"], [class*="Control"], [role="button"]');
-    const controlCount = await controls.count();
-    
-    // Should have at least some controls (play/pause, layer menu, etc.)
-    // Controls are optional - main thing is that the map is visible
-    if (controlCount > 0) {
-      expect(controlCount).toBeGreaterThan(0);
-    }
+
+    await expect(page.getByRole('button', { name: /layers/i })).toBeVisible({ timeout: 10000 });
   });
 
   test('radar map displays status badge', async ({ page }) => {
     await navigateToMapPage(page);
     await waitForRadarToLoad(page);
-    
-    // Look for status badge with radar info
-    const statusBadge = page.locator('[class*="badge"], [class*="status"]').filter({ 
-      hasText: /(RADAR|NEXRAD|RAINVIEWER|LIVE|unavailable)/i 
+
+    await expect(page.getByText(/NEXRAD|RAINVIEWER|RADAR unavailable|Set a location/i).first()).toBeVisible({
+      timeout: 10000,
     });
-    
-    // Status badge may or may not exist depending on location
-    if (await statusBadge.count() > 0) {
-      await expect(statusBadge.first()).toBeVisible({ timeout: 5000 });
-    }
   });
 
   test('US radar uses Iowa NEXRAD WMS directly (not MRMS proxy)', async ({ page }) => {
@@ -126,33 +100,29 @@ test.describe('Radar Map', () => {
 
     page.on('request', (request) => {
       const url = request.url();
-      if (url.includes('mesonet.agron.iastate.edu')) {
+      if (isIowaNexradRequest(url)) {
         iowaTileUrls.push(url);
       }
-      if (url.includes('/api/weather/noaa-wms')) {
+      if (isMrmsProxyRequest(url)) {
         mrmsProxyUrls.push(url);
       }
     });
 
     await navigateToMapPage(page);
     await waitForRadarToLoad(page);
-    await page.waitForTimeout(4000);
 
     const radarContainer = page.locator('[data-radar-container]').first();
     await expect(radarContainer).toHaveAttribute('data-radar-us-source', 'iowa-wms-t');
     await expect(page.getByText(/NEXRAD/i).first()).toBeVisible({ timeout: 10000 });
 
-    expect(iowaTileUrls.length).toBeGreaterThan(0);
+    await expect.poll(() => iowaTileUrls.length, { timeout: 15000 }).toBeGreaterThan(0);
     expect(mrmsProxyUrls.length).toBe(0);
   });
 
   test('radar canvas is not affected by synthwave theme filters', async ({ page }) => {
     await setTheme(page, 'synthwave84');
-    await page.waitForTimeout(300);
-
     await navigateToMapPage(page);
     await waitForRadarToLoad(page);
-    await page.waitForTimeout(3000);
 
     const tileSurface = page.locator('[data-radar-container] canvas, [data-radar-container] .ol-layer img').first();
     await expect(tileSurface).toBeVisible({ timeout: 15000 });
@@ -161,4 +131,3 @@ test.describe('Radar Map', () => {
     expect(surfaceFilter).toBe('none');
   });
 });
-

--- a/tests/e2e/radar.spec.ts
+++ b/tests/e2e/radar.spec.ts
@@ -111,13 +111,54 @@ test.describe('Radar Map', () => {
     
     // Look for status badge with radar info
     const statusBadge = page.locator('[class*="badge"], [class*="status"]').filter({ 
-      hasText: /(RADAR|NEXRAD|MRMS|RAINVIEWER|LIVE|unavailable)/i 
+      hasText: /(RADAR|NEXRAD|RAINVIEWER|LIVE|unavailable)/i 
     });
     
     // Status badge may or may not exist depending on location
     if (await statusBadge.count() > 0) {
       await expect(statusBadge.first()).toBeVisible({ timeout: 5000 });
     }
+  });
+
+  test('US radar uses Iowa NEXRAD WMS directly (not MRMS proxy)', async ({ page }) => {
+    const iowaTileUrls: string[] = [];
+    const mrmsProxyUrls: string[] = [];
+
+    page.on('request', (request) => {
+      const url = request.url();
+      if (url.includes('mesonet.agron.iastate.edu')) {
+        iowaTileUrls.push(url);
+      }
+      if (url.includes('/api/weather/noaa-wms')) {
+        mrmsProxyUrls.push(url);
+      }
+    });
+
+    await navigateToMapPage(page);
+    await waitForRadarToLoad(page);
+    await page.waitForTimeout(4000);
+
+    const radarContainer = page.locator('[data-radar-container]').first();
+    await expect(radarContainer).toHaveAttribute('data-radar-us-source', 'iowa-wms-t');
+    await expect(page.getByText(/NEXRAD/i).first()).toBeVisible({ timeout: 10000 });
+
+    expect(iowaTileUrls.length).toBeGreaterThan(0);
+    expect(mrmsProxyUrls.length).toBe(0);
+  });
+
+  test('radar canvas is not affected by synthwave theme filters', async ({ page }) => {
+    await setTheme(page, 'synthwave84');
+    await page.waitForTimeout(300);
+
+    await navigateToMapPage(page);
+    await waitForRadarToLoad(page);
+    await page.waitForTimeout(3000);
+
+    const tileSurface = page.locator('[data-radar-container] canvas, [data-radar-container] .ol-layer img').first();
+    await expect(tileSurface).toBeVisible({ timeout: 15000 });
+
+    const surfaceFilter = await tileSurface.evaluate((el) => window.getComputedStyle(el).filter);
+    expect(surfaceFilter).toBe('none');
   });
 });
 

--- a/tests/e2e/radar.spec.ts
+++ b/tests/e2e/radar.spec.ts
@@ -111,7 +111,7 @@ test.describe('Radar Map', () => {
     
     // Look for status badge with radar info
     const statusBadge = page.locator('[class*="badge"], [class*="status"]').filter({ 
-      hasText: /(RADAR|NEXRAD|LIVE|US LOCATIONS)/i 
+      hasText: /(RADAR|NEXRAD|MRMS|RAINVIEWER|LIVE|unavailable)/i 
     });
     
     // Status badge may or may not exist depending on location

--- a/tests/fixtures/utils.ts
+++ b/tests/fixtures/utils.ts
@@ -174,6 +174,67 @@ export async function stubWeatherApis(page: Page, opts: StubOptions = {}): Promi
       timestamp: nowIso,
     }),
   }));
+
+  const openMeteoDays = Array.from({ length: 7 }, (_, i) => {
+    const day = new Date();
+    day.setDate(day.getDate() + i);
+    return day.toISOString().split('T')[0];
+  });
+
+  await page.route(/.*\/api\/open-meteo\/forecast(?:\?.*)?$/, (route) => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({
+      latitude: o.lat,
+      longitude: o.lon,
+      generationtime_ms: 0.5,
+      utc_offset_seconds: -18000,
+      timezone: 'America/New_York',
+      timezone_abbreviation: 'EST',
+      elevation: 10,
+      current: {
+        time: `${openMeteoDays[0]}T14:00`,
+        interval: 900,
+        temperature_2m: o.tempF,
+        relative_humidity_2m: o.humidity,
+        apparent_temperature: o.tempF - 3,
+        is_day: 1,
+        precipitation: 0,
+        weather_code: 2,
+        cloud_cover: 50,
+        surface_pressure: o.pressure,
+        wind_speed_10m: 12.3,
+        wind_direction_10m: 225,
+        wind_gusts_10m: 18.7,
+        uv_index: 4.2,
+      },
+      daily: {
+        time: openMeteoDays,
+        weather_code: openMeteoDays.map(() => 2),
+        temperature_2m_max: openMeteoDays.map(() => o.tempF + 3),
+        temperature_2m_min: openMeteoDays.map(() => o.tempF - 3),
+        precipitation_probability_max: openMeteoDays.map(() => 10),
+        wind_speed_10m_max: openMeteoDays.map(() => 15),
+        uv_index_max: openMeteoDays.map(() => 5),
+        sunrise: openMeteoDays.map((day) => `${day}T06:30`),
+        sunset: openMeteoDays.map((day) => `${day}T19:45`),
+      },
+      hourly: {
+        time: [`${openMeteoDays[0]}T14:00`],
+        temperature_2m: [o.tempF],
+        weather_code: [2],
+        precipitation_probability: [10],
+      },
+    }),
+  }));
+
+  await page.route(/.*\/api\/open-meteo\/air-quality(?:\?.*)?$/, (route) => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({
+      current: { us_aqi: 30 },
+    }),
+  }));
 }
 
 export async function seedFreshWeatherCache(page: Page, opts: StubOptions = {}): Promise<void> {
@@ -651,55 +712,23 @@ export async function getCurrentTheme(page: Page): Promise<string> {
 //   RADAR MAP HELPERS
 //   ═══════════════════════════════════════════════════════════
 
-export async function navigateToMapPage(page: Page): Promise<void> {
-  await page.goto('/map', { waitUntil: 'domcontentloaded' });
+export async function navigateToMapPage(page: Page, location = 'New York, US'): Promise<void> {
+  const params = new URLSearchParams({ location });
+  await page.goto(`/radar?${params.toString()}`, { waitUntil: 'domcontentloaded' });
   // Wait for page to be fully loaded
   await page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {
     // If networkidle times out, continue anyway
   });
-  // Wait for map container to exist in DOM
-  await page.waitForSelector('[data-radar-container], [class*="map"], [class*="Map"], [class*="radar"], [class*="Radar"]', {
-    timeout: 15000,
-    state: 'attached'
-  }).catch(() => {
-    // If selector not found, that's okay - we'll check in waitForRadarToLoad
+  await page.waitForSelector('[data-radar-container]', {
+    timeout: 20000,
+    state: 'attached',
   });
 }
 
 export async function waitForRadarToLoad(page: Page): Promise<void> {
-  // Wait for radar container or map element to be attached to DOM
-  // Try multiple selectors to be more flexible
-  const selectors = [
-    '[data-radar-container]',
-    '[class*="map"]',
-    '[class*="Map"]',
-    '[class*="radar"]',
-    '[class*="Radar"]',
-  ];
+  await page.waitForSelector('[data-radar-container]', { timeout: 20000, state: 'attached' });
 
-  let found = false;
-  for (const selector of selectors) {
-    try {
-      await page.waitForSelector(selector, { timeout: 5000, state: 'attached' });
-      found = true;
-      break;
-    } catch (e) {
-      // Try next selector
-      continue;
-    }
-  }
-
-  if (!found) {
-    // If no specific selector found, wait for any div with height (map containers usually have height)
-    await page.waitForFunction(() => {
-      const containers = document.querySelectorAll('[data-radar-container], [class*="map"], [class*="Map"]');
-      return containers.length > 0;
-    }, { timeout: 10000 }).catch(() => {
-      // If still not found, that's okay - test will fail with a clear error
-    });
-  }
-
-  // Give the map a moment to render
+  // Give the map a moment to render tiles
   await page.waitForTimeout(1000);
 }
 

--- a/tests/fixtures/utils.ts
+++ b/tests/fixtures/utils.ts
@@ -727,9 +727,10 @@ export async function navigateToMapPage(page: Page, location = 'New York, US'): 
 
 export async function waitForRadarToLoad(page: Page): Promise<void> {
   await page.waitForSelector('[data-radar-container]', { timeout: 20000, state: 'attached' });
-
-  // Give the map a moment to render tiles
-  await page.waitForTimeout(1000);
+  await page.waitForSelector('[data-radar-container] canvas, [data-radar-container] .ol-layer img', {
+    state: 'visible',
+    timeout: 20000,
+  });
 }
 
 export async function checkRadarVisibility(page: Page): Promise<boolean> {


### PR DESCRIPTION
## Summary

- Phase 1 radar: animated US NEXRAD (Iowa IEM WMS-T direct) + RainViewer international coverage
- Live 5-minute frame refresh, storm-watch `LAST 2H` control, and aligned SEO/copy (NEXRAD badge matches implementation)
- MRMS proxy deferred (nowCOAST 403 + tile rate-limit regression on preview); proxy route kept for future Phase 1.5
- Pollen/geocoding API noise reduced on preview (graceful empty pollen, broader reverse-geocode fallbacks)

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm test -- radar-timestamps.test.ts`
- [x] `npm run build`
- [x] `npx playwright test tests/e2e/radar.spec.ts --project=chromium` (8 passed)
- [ ] Manual: `/radar?location=Livermore,+CA,+US` shows NEXRAD badge + Iowa tiles (`data-radar-us-source="iowa-wms-t"`)
- [ ] Manual: international location shows RainViewer tiles