### PR TITLE
fix(ci): run preview E2E with local Playwright instead of Kernel

### DIFF
--- a/.github/workflows/e2e-preview.yml
+++ b/.github/workflows/e2e-preview.yml
@@ -51,30 +51,13 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Verify Kernel SDK installed
-        run: |
-          if ! npm ls @onkernel/sdk > /dev/null 2>&1; then
-            echo "❌ @onkernel/sdk not found in dependencies"
-            exit 1
-          fi
-          echo "✅ @onkernel/sdk installed"
-
-      - name: Verify KERNEL_API_KEY is set
-        run: |
-          if [ -z "${{ secrets.KERNEL_API_KEY }}" ]; then
-            echo "❌ KERNEL_API_KEY secret is not set"
-            echo "   Please add it to repository Settings > Secrets > Actions"
-            exit 1
-          fi
-          echo "✅ KERNEL_API_KEY is configured"
-
-      # Note: No 'npx playwright install' - Kernel provides cloud browsers
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
 
       - name: Run E2E tests against Vercel preview
-        run: npm run test:e2e:ci
+        run: npx playwright test --project=chromium --reporter=github,html
         env:
           CI: true
-          KERNEL_API_KEY: ${{ secrets.KERNEL_API_KEY }}
           PLAYWRIGHT_TEST_BASE_URL: ${{ env.PREVIEW_URL }}
           PLAYWRIGHT_TEST_MODE: 'true'
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -10,15 +10,17 @@ dotenv.config({ path: path.resolve(__dirname, '.env.local') });
 /**
  * Hybrid Playwright configuration:
  *
- * LOCAL (pre-commit): No KERNEL_API_KEY
+ * LOCAL (pre-commit): No PLAYWRIGHT_TEST_BASE_URL
  * - Uses local Chromium/Firefox browsers
- * - Tests against localhost:3000
+ * - Tests against localhost:3000 (auto-starts dev server)
  * - Requires: npx playwright install
  *
- * CI (Vercel preview): KERNEL_API_KEY + PLAYWRIGHT_TEST_BASE_URL set
- * - Uses Kernel cloud browsers via CDP
- * - Tests against Vercel preview URL
- * - No local browser install needed
+ * CI (Vercel preview): PLAYWRIGHT_TEST_BASE_URL set to preview URL
+ * - Uses local Chromium on the GitHub runner
+ * - Tests against the deployed Vercel preview URL
+ *
+ * Optional Kernel mode: KERNEL_API_KEY set (legacy / opt-in)
+ * - Uses OnKernel cloud browsers via CDP instead of local install
  */
 
 const useKernelBrowsers = !!process.env.KERNEL_API_KEY;

--- a/tests/e2e/profile.spec.ts
+++ b/tests/e2e/profile.spec.ts
@@ -1,12 +1,11 @@
 import { test, expect } from './fixtures';
-import { setupStableApp, setupMockAuth, stubSupabaseProfile, stubProfileUpdate, navigateToProfile, fillProfileForm, saveProfile } from '../fixtures/utils';
+import { setupStableApp, setupMockAuth, stubSupabaseProfile, stubProfileUpdate, navigateToProfile, fillProfileForm, saveProfile, isRemotePreviewTarget } from '../fixtures/utils';
 
-// Skip profile tests in Preview/CI mode - auth mocking doesn't work with Kernel cloud browsers
-// The server-side middleware redirects to login before client-side mocking can take effect
-const useKernelBrowsers = !!process.env.KERNEL_API_KEY;
+// Skip profile tests against deployed previews — server-side auth runs before client mocks apply
+const skipAuthTests = isRemotePreviewTarget();
 
 test.describe('Profile Settings', () => {
-  test.skip(useKernelBrowsers, 'Auth mocking not supported in Kernel cloud browsers');
+  test.skip(skipAuthTests, 'Auth mocking not supported against deployed preview URLs');
 
   test.beforeEach(async ({ page }) => {
     await setupStableApp(page);

--- a/tests/e2e/themes.spec.ts
+++ b/tests/e2e/themes.spec.ts
@@ -1,8 +1,7 @@
 import { test, expect } from './fixtures';
-import { setupStableApp, setupMockAuth, stubSupabaseProfile, setTheme, getCurrentTheme, navigateToProfile, navigateToMapPage, waitForRadarToLoad, checkRadarVisibility } from '../fixtures/utils';
+import { setupStableApp, setupMockAuth, stubSupabaseProfile, setTheme, getCurrentTheme, navigateToProfile, navigateToMapPage, waitForRadarToLoad, checkRadarVisibility, isRemotePreviewTarget } from '../fixtures/utils';
 
-// Check if running in Kernel cloud browsers (Preview/CI mode)
-const useKernelBrowsers = !!process.env.KERNEL_API_KEY;
+const skipAuthTests = isRemotePreviewTarget();
 
 test.describe('Theme System', () => {
   test.beforeEach(async ({ page }) => {
@@ -11,7 +10,7 @@ test.describe('Theme System', () => {
 
   // Skip this test in Preview/CI - auth mocking doesn't work with Kernel cloud browsers
   test('can change theme via profile page', async ({ page }) => {
-    test.skip(useKernelBrowsers, 'Auth mocking not supported in Kernel cloud browsers');
+    test.skip(skipAuthTests, 'Auth mocking not supported against deployed preview URLs');
 
     await setupMockAuth(page);
     await stubSupabaseProfile(page, {
@@ -142,7 +141,7 @@ test.describe('Theme System', () => {
     // the kind of flakiness we're stamping out here. Seed mock auth so
     // ThemeProvider sees an authenticated user and leaves the premium
     // theme alone.
-    test.skip(useKernelBrowsers, 'Auth mocking not supported in Kernel cloud browsers');
+    test.skip(skipAuthTests, 'Auth mocking not supported against deployed preview URLs');
 
     await setupMockAuth(page);
     await stubSupabaseProfile(page, {

--- a/tests/fixtures/utils.ts
+++ b/tests/fixtures/utils.ts
@@ -1,5 +1,18 @@
 import { Page, expect } from '@playwright/test';
 
+/** True when E2E targets a deployed preview/prod URL (not localhost). */
+export function isRemotePreviewTarget(): boolean {
+  const baseUrl = process.env.PLAYWRIGHT_TEST_BASE_URL;
+  if (!baseUrl) return false;
+
+  try {
+    const { hostname } = new URL(baseUrl);
+    return hostname !== '127.0.0.1' && hostname !== 'localhost';
+  } catch {
+    return false;
+  }
+}
+
 type StubOptions = {
   cityName?: string;
   country?: string;


### PR DESCRIPTION
## Summary
- Switch the Vercel preview E2E workflow to local Chromium on the GitHub runner, matching the PR workflow
- Remove the OnKernel SDK/API key requirement from preview CI
- Skip auth-mocking profile/theme specs when `PLAYWRIGHT_TEST_BASE_URL` targets a deployed preview URL

## Test plan
- [ ] Wait for PR checks: Build, Lint, Unit Tests, E2E Chromium
- [ ] After Vercel preview deploys, confirm `e2e-preview` workflow passes without `KERNEL_API_KEY`
- [ ] Verify auth-dependent specs remain skipped on preview runs but still run locally


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified E2E testing infrastructure by transitioning from cloud-based browser testing to local Chromium execution on preview environments
  * Enhanced automated detection for test environment type (local vs. remote preview)
  * Updated CI/CD workflow configuration for more direct preview URL testing
  * Improved test documentation and configuration clarity

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jelrod27/Weather-application-/pull/410?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->