### PR TITLE
test(e2e): add smoke coverage for 5 uncovered routes

### DIFF
--- a/tests/e2e/earth-sciences.spec.ts
+++ b/tests/e2e/earth-sciences.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect } from './fixtures';
+
+/**
+ * Smoke coverage for /earth-sciences (live global earthquakes).
+ *
+ * The client fetches /api/earth-sciences/earthquakes on mount and on filter
+ * change. The page exposes stable data-testids for its loading / empty /
+ * populated states, so we drive both an empty and a populated response and
+ * assert the corresponding state plus the static shell (heading, filters).
+ */
+const SAMPLE_QUAKE = {
+  magnitude: 5.2,
+  location: '120km SW of Testville',
+  time: '2026-05-01T00:00:00.000Z',
+  depth: 10,
+  id: 'test-quake-1',
+  url: 'https://earthquake.usgs.gov/test',
+  latitude: 1.23,
+  longitude: 4.56,
+  tsunami: false,
+};
+
+test.describe('empty state', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/api/earth-sciences/earthquakes**', route =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ earthquakes: [], count: 0, minMagnitude: 2.5 }),
+      })
+    );
+    await page.goto('/earth-sciences', { waitUntil: 'domcontentloaded' });
+  });
+
+  test('renders the shell and magnitude filters', async ({ page }) => {
+    await expect(page).toHaveTitle(/Earth Sciences/i);
+    await expect(
+      page.getByRole('heading', { name: /Recent Earthquakes/i }).first()
+    ).toBeVisible({ timeout: 30000 });
+    await expect(page.getByText(/M2\.5\+/i).first()).toBeVisible({ timeout: 30000 });
+    await expect(page.getByText(/M4\.5\+/i).first()).toBeVisible();
+    await expect(page.getByText(/M6\+/i).first()).toBeVisible();
+  });
+
+  test('shows the empty state when no quakes are returned', async ({ page }) => {
+    await expect(page.getByTestId('earthquakes-empty')).toBeVisible({ timeout: 30000 });
+  });
+});
+
+test.describe('populated state', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/api/earth-sciences/earthquakes**', route =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ earthquakes: [SAMPLE_QUAKE], count: 1, minMagnitude: 2.5 }),
+      })
+    );
+    await page.goto('/earth-sciences', { waitUntil: 'domcontentloaded' });
+  });
+
+  test('renders quake rows when data is returned', async ({ page }) => {
+    await expect(page.getByTestId('earthquakes-tbody')).toBeVisible({ timeout: 30000 });
+    await expect(page.getByText(/Testville/i).first()).toBeVisible({ timeout: 30000 });
+  });
+});

--- a/tests/e2e/news.spec.ts
+++ b/tests/e2e/news.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from './fixtures';
+
+/**
+ * Smoke coverage for /news (Earth & Space News).
+ *
+ * The page fetches its feed from /api/news/rss on mount. We stub both the
+ * main feed and the featured request with empty payloads for determinism and
+ * assert on the static shell (title, heading, category filter, search input).
+ */
+test.beforeEach(async ({ page }) => {
+  await page.route('**/api/news/rss**', route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ items: [], articles: [] }),
+    })
+  );
+  await page.goto('/news', { waitUntil: 'domcontentloaded' });
+});
+
+test('renders the Earth & Space News shell', async ({ page }) => {
+  await expect(page).toHaveTitle(/Weather News/i);
+  await expect(
+    page.getByRole('heading', { name: /EARTH & SPACE NEWS/i }).first()
+  ).toBeVisible({ timeout: 30000 });
+});
+
+test('exposes category filters', async ({ page }) => {
+  // The filter bar always renders the canonical categories.
+  await expect(page.getByText(/QUAKES/i).first()).toBeVisible({ timeout: 30000 });
+  await expect(page.getByText(/VOLCANOES/i).first()).toBeVisible({ timeout: 30000 });
+});

--- a/tests/e2e/space-weather.spec.ts
+++ b/tests/e2e/space-weather.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from './fixtures';
+
+/**
+ * Smoke coverage for /space-weather.
+ *
+ * The page fetches 7 NOAA space-weather endpoints in parallel on mount
+ * (Promise.allSettled, so individual failures don't block render). We stub
+ * them all with minimal payloads for determinism and assert on the static
+ * shell heading, which renders independently of the fetch results.
+ */
+test.beforeEach(async ({ page }) => {
+  await page.route('**/api/space-weather/**', route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({}),
+    })
+  );
+  await page.goto('/space-weather', { waitUntil: 'domcontentloaded' });
+});
+
+test('renders the Space Weather shell', async ({ page }) => {
+  await expect(page).toHaveTitle(/Space Weather/i);
+  await expect(
+    page.getByRole('heading', { level: 1, name: /SPACE WEATHER/i }).first()
+  ).toBeVisible({ timeout: 30000 });
+});

--- a/tests/e2e/stargazer.spec.ts
+++ b/tests/e2e/stargazer.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from './fixtures';
+
+/**
+ * Smoke coverage for /stargazer (Stargazer Command Center).
+ *
+ * The page uses geolocation (falling back to NYC) and fetches an astro
+ * forecast on mount. We mock geolocation to return immediately so the test
+ * never waits on the 10s permission timeout, stub the data endpoints, and
+ * assert on the static shell (title, heading, section tabs, search form).
+ */
+test.beforeEach(async ({ page }) => {
+  // Resolve geolocation instantly to a fixed point (avoids the 10s fallback wait).
+  await page.addInitScript(() => {
+    const coords = { latitude: 40.7128, longitude: -74.006, accuracy: 10 } as GeolocationCoordinates;
+    // @ts-expect-error - minimal mock for tests
+    navigator.geolocation = {
+      getCurrentPosition: (success: PositionCallback) =>
+        success({ coords, timestamp: 0 } as GeolocationPosition),
+      watchPosition: () => 0,
+      clearWatch: () => {},
+    };
+  });
+
+  await page.route('**/api/stargazer**', route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ conditions: {}, targets: [], events: [], launches: [] }),
+    })
+  );
+  await page.route('**/api/weather/geocoding**', route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+  );
+
+  await page.goto('/stargazer', { waitUntil: 'domcontentloaded' });
+});
+
+test('renders the Stargazer Command Center shell', async ({ page }) => {
+  await expect(page).toHaveTitle(/Stargazer/i);
+  await expect(
+    page.getByRole('heading', { name: /STARGAZER COMMAND CENTER/i }).first()
+  ).toBeVisible({ timeout: 30000 });
+});
+
+test('exposes the location search form', async ({ page }) => {
+  // The search form renders unconditionally (above the loading/data gates),
+  // so it is a stable shell assertion independent of the forecast payload.
+  await expect(page.getByLabel(/Search location/i)).toBeVisible({ timeout: 30000 });
+  await expect(page.getByRole('button', { name: /^Go$/i })).toBeVisible();
+});

--- a/tests/e2e/travel.spec.ts
+++ b/tests/e2e/travel.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from './fixtures';
+
+/**
+ * Smoke coverage for /travel (Travel Hub).
+ *
+ * The page is a client component that lazily fetches corridor forecasts.
+ * We stub that endpoint with an empty payload so the test is deterministic
+ * and assert on the static shell (title, heading, Fly/Drive controls) that
+ * renders independently of fetch state.
+ */
+test.beforeEach(async ({ page }) => {
+  await page.route('**/api/travel/corridors**', route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ corridors: [] }),
+    })
+  );
+  await page.goto('/travel', { waitUntil: 'domcontentloaded' });
+});
+
+test('renders the Travel Hub shell', async ({ page }) => {
+  await expect(page).toHaveTitle(/Travel Weather/i);
+  await expect(
+    page.getByRole('heading', { name: /Travel Hub/i }).first()
+  ).toBeVisible({ timeout: 30000 });
+});
+
+test('exposes Fly and Drive mode controls', async ({ page }) => {
+  const modeTabs = page.getByRole('tablist', { name: /Travel mode/i });
+  await expect(modeTabs).toBeVisible({ timeout: 30000 });
+  await expect(modeTabs.getByRole('tab', { name: /Fly/i })).toBeVisible();
+  await expect(modeTabs.getByRole('tab', { name: /Drive/i })).toBeVisible();
+});


### PR DESCRIPTION
## Summary

Adds Playwright E2E smoke coverage for five routes that previously had none: `/travel`, `/stargazer`, `/space-weather`, `/news`, and `/earth-sciences`. Brings the E2E spec count from 5 to 10.

## Approach
Each spec stubs the route's API dependencies with minimal payloads (via `page.route`) for determinism, then asserts on the **static shell** — page title, primary heading, and key always-rendered controls — which renders independently of fetch state. This keeps the tests fast and low-flake.

| Spec | Asserts |
|---|---|
| `travel.spec.ts` | Title + "Travel Hub" heading + Fly/Drive mode tablist |
| `stargazer.spec.ts` | Title + "STARGAZER COMMAND CENTER" heading + location search form (geolocation mocked to resolve instantly) |
| `space-weather.spec.ts` | Title + "SPACE WEATHER" heading (7 NOAA endpoints stubbed) |
| `news.spec.ts` | Title + "EARTH & SPACE NEWS" heading + category filters |
| `earth-sciences.spec.ts` | Title + "Recent Earthquakes" heading + magnitude filters; drives both empty and populated states via `data-testid` |

## Verification
- `npx playwright test --project=chromium` on the 5 new specs — **10 tests, all passing** locally.

## Notes
- Selectors prefer roles/labels/testids over brittle text.
- `earth-sciences` exercises real loading→empty and loading→populated transitions using the existing `earthquakes-empty` / `earthquakes-tbody` testids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)