### PR TITLE
Default guests to Daybreak theme instead of Nord

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -19,6 +19,7 @@ import { IBM_Plex_Sans, Inconsolata, VT323 } from "next/font/google"
 // PERFORMANCE: Analytics lazy loaded via client component wrapper
 import AnalyticsWrapper from "@/components/analytics-wrapper"
 import AppThemeProvider from "@/app/providers/ThemeProvider"
+import { DEFAULT_THEME } from "@/lib/theme-config"
 import { LocationProvider } from "@/components/location-context"
 import { AuthProvider } from "@/lib/auth"
 import { Toaster } from "@/components/ui/toaster"
@@ -149,7 +150,7 @@ export default function RootLayout({
   children: React.ReactNode
 }>) {
   return (
-    <html lang="en" data-theme="nord" suppressHydrationWarning>
+    <html lang="en" data-theme={DEFAULT_THEME} suppressHydrationWarning>
       <head>
         {/* PERFORMANCE: Preconnect to critical origins for faster resource loading */}
         <link rel="preconnect" href="https://api.openweathermap.org" />

--- a/components/theme-provider.tsx
+++ b/components/theme-provider.tsx
@@ -2,7 +2,7 @@
 
 import React, { createContext, useContext, useEffect, useRef, useState } from 'react'
 import { safeStorage } from '@/lib/safe-storage'
-import { ThemeType, THEME_LIST, FREE_THEMES, getThemeDefinition } from '@/lib/theme-config'
+import { ThemeType, THEME_LIST, FREE_THEMES, DEFAULT_THEME, getThemeDefinition } from '@/lib/theme-config'
 import { supabase } from '@/lib/supabase/client'
 import { AuthChangeEvent, Session } from '@supabase/supabase-js'
 
@@ -31,7 +31,7 @@ interface ThemeProviderProps {
 }
 
 export function ThemeProvider({ children }: ThemeProviderProps) {
-  const [theme, setThemeState] = useState<Theme>('nord')
+  const [theme, setThemeState] = useState<Theme>(DEFAULT_THEME)
   const [loading, setLoading] = useState(true)
   const [user, setUser] = useState<any>(null)
   const [isAuthenticated, setIsAuthenticated] = useState(false)
@@ -74,7 +74,7 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
         // user instead of relying on a client bundle env var.
         const current = themeRef.current
         if (!FREE_THEMES.includes(current as ThemeType)) {
-          setThemeState('nord')
+          setThemeState(DEFAULT_THEME)
         }
       }
     })
@@ -152,8 +152,8 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
     if (typeof window !== 'undefined') {
       let savedTheme = safeStorage.getItem('weather-edu-theme') as string | null
       if (savedTheme === 'miami' || savedTheme === 'dark') {
-        savedTheme = 'nord'
-        safeStorage.setItem('weather-edu-theme', 'nord')
+        savedTheme = DEFAULT_THEME
+        safeStorage.setItem('weather-edu-theme', DEFAULT_THEME)
       }
       if (savedTheme && THEME_LIST.includes(savedTheme as Theme)) {
         setThemeState(savedTheme as Theme)

--- a/components/theme-provider.tsx
+++ b/components/theme-provider.tsx
@@ -2,7 +2,7 @@
 
 import React, { createContext, useContext, useEffect, useRef, useState } from 'react'
 import { safeStorage } from '@/lib/safe-storage'
-import { ThemeType, THEME_LIST, FREE_THEMES, DEFAULT_THEME, getThemeDefinition } from '@/lib/theme-config'
+import { ThemeType, THEME_LIST, FREE_THEMES, DEFAULT_THEME } from '@/lib/theme-config'
 import { supabase } from '@/lib/supabase/client'
 import { AuthChangeEvent, Session } from '@supabase/supabase-js'
 

--- a/lib/theme-config.ts
+++ b/lib/theme-config.ts
@@ -55,6 +55,10 @@ export const THEME_DEFINITIONS: Record<ThemeType, ThemeDefinition> = {
   }
 };
 
+// Default theme applied to guests (unauthenticated users) and as the
+// fallback when a premium theme is dropped on logout. Must be a free theme.
+export const DEFAULT_THEME: ThemeType = 'daybreak';
+
 // Get list of all theme names
 export const THEME_LIST = Object.keys(THEME_DEFINITIONS) as ThemeType[];
 

--- a/tests/e2e/themes.spec.ts
+++ b/tests/e2e/themes.spec.ts
@@ -117,8 +117,12 @@ test.describe('Theme System', () => {
   });
 
   test('UI elements render correctly in nord theme', async ({ page }) => {
-    await setTheme(page, 'nord');
+    // Navigate first, THEN set the theme. setTheme writes the data-theme
+    // attribute directly; doing it before goto() is pointless because the
+    // navigation re-renders the SSR default (DEFAULT_THEME) and getCurrentTheme
+    // reads data-theme, so it would observe the default instead of nord.
     await page.goto('/', { waitUntil: 'domcontentloaded' });
+    await setTheme(page, 'nord');
 
     // Wait for theme to be applied after navigation
     await page.waitForTimeout(300);


### PR DESCRIPTION
## Summary

Makes Daybreak the default theme for all guests (unauthenticated visitors) instead of Nord.

Introduces a single `DEFAULT_THEME` constant in `lib/theme-config.ts` (set to `daybreak`) and routes every guest-facing default through it:

- `ThemeProvider` initial state
- Logout fallback when a premium theme is dropped
- Legacy localStorage migration (`miami`/`dark` -> default)
- Server-rendered `<html data-theme>` attribute

Aligning the SSR `data-theme` attribute (CSS palettes are keyed off `[data-theme="..."]`) means guests get Daybreak from first paint with no Nord flash before hydration.

## Scope

- Daybreak is already a free theme, so guests are permitted to use it.
- Authenticated users keep their saved DB preference.
- Guests who already explicitly picked a theme keep their localStorage choice.
- Authenticated-side defaults in `lib/validations/preferences.ts` and `lib/user-cache-service.ts` were left unchanged, since this targets guests specifically.

## Test plan

- `npx tsc --noEmit` passes
- Verify a fresh/incognito session loads with Daybreak
- Verify logging out from a premium theme falls back to Daybreak

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated default theme to "daybreak" for new users and after logout.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jelrod27/Weather-application-/pull/422?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->