### PR TITLE
Treat NOAA SIGMET/AIRMET timeout aborts as transient, not Sentry errors

### DIFF
--- a/__tests__/aviation-noaa-alerts.test.ts
+++ b/__tests__/aviation-noaa-alerts.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Pins how fetchAviationAlertsFromNOAA classifies upstream failures.
+ *
+ * Regression guard for Sentry issue JAVASCRIPT-NEXTJS-10
+ * ("NOAA AIRMET fetch failed: This operation was aborted"): our own
+ * AbortController timeout firing against a slow NOAA endpoint is expected
+ * transient noise and must NOT open a Sentry issue, while a genuine NOAA
+ * failure (non-ok HTTP, network error) must still be captured.
+ */
+import { fetchAviationAlertsFromNOAA } from '@/lib/services/aviation-noaa-service';
+import * as Sentry from '@sentry/nextjs';
+
+jest.mock('@sentry/nextjs', () => ({
+  captureException: jest.fn(),
+  captureMessage: jest.fn(),
+  addBreadcrumb: jest.fn(),
+}));
+
+const mockedSentry = Sentry as jest.Mocked<typeof Sentry>;
+
+/** Mirrors the DOMException undici throws when AbortController.abort() fires. */
+function abortError(): Error {
+  const err = new Error('This operation was aborted');
+  err.name = 'AbortError';
+  return err;
+}
+
+describe('fetchAviationAlertsFromNOAA upstream failure classification', () => {
+  const realFetch = global.fetch;
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    global.fetch = realFetch;
+  });
+
+  it('does not open a Sentry issue when our own timeout aborts the request', async () => {
+    global.fetch = jest.fn().mockRejectedValue(abortError());
+
+    const alerts = await fetchAviationAlertsFromNOAA();
+
+    expect(alerts).toEqual([]);
+    expect(mockedSentry.captureException).not.toHaveBeenCalled();
+    // The transient timeout is recorded as a breadcrumb for later context.
+    expect(mockedSentry.addBreadcrumb).toHaveBeenCalled();
+  });
+
+  it('captures a Sentry error when NOAA returns a non-ok HTTP status', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 503 });
+
+    const alerts = await fetchAviationAlertsFromNOAA();
+
+    expect(alerts).toEqual([]);
+    expect(mockedSentry.captureException).toHaveBeenCalled();
+  });
+
+  it('captures a Sentry error on a genuine (non-abort) network failure', async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+
+    const alerts = await fetchAviationAlertsFromNOAA();
+
+    expect(alerts).toEqual([]);
+    expect(mockedSentry.captureException).toHaveBeenCalled();
+  });
+});

--- a/lib/error-utils.ts
+++ b/lib/error-utils.ts
@@ -221,6 +221,41 @@ export function captureError(
 }
 
 /**
+ * True when an error is a fetch aborted by our own AbortController timeout
+ * rather than a genuine failure. The abort reason surfaces as an AbortError
+ * (a DOMException in some runtimes, an Error in others), so match on `name`
+ * instead of `instanceof Error`. These are transient upstream-latency events,
+ * not defects, and callers that already degrade gracefully should treat them
+ * as noise rather than opening a Sentry issue.
+ */
+export function isAbortError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'name' in error &&
+    (error as { name?: unknown }).name === 'AbortError'
+  )
+}
+
+/**
+ * Record a transient upstream timeout as a Sentry breadcrumb (warning level)
+ * instead of capturing it as an exception. Use for expected third-party
+ * slowness that the caller already handles gracefully — it keeps the context
+ * for any later error without manufacturing an issue per timeout.
+ */
+export function captureUpstreamTimeout(
+  context: string,
+  extra?: Record<string, unknown>
+): void {
+  Sentry.addBreadcrumb({
+    category: 'upstream-timeout',
+    level: 'warning',
+    message: context,
+    data: extra,
+  })
+}
+
+/**
  * Capture a database error with structured context
  */
 export function captureDbError(

--- a/lib/services/aviation-noaa-service.ts
+++ b/lib/services/aviation-noaa-service.ts
@@ -11,7 +11,7 @@
  * still serve other callers (FlightConditionsTerminal, AI context, etc.).
  */
 import type { MetarObservation } from '@/app/api/aviation/metar/route';
-import { captureError } from '@/lib/error-utils';
+import { captureError, captureUpstreamTimeout, isAbortError } from '@/lib/error-utils';
 
 const NOAA_METAR_BASE = 'https://aviationweather.gov/api/data/metar';
 const NOAA_AIRSIGMET = 'https://aviationweather.gov/api/data/airsigmet';
@@ -267,6 +267,16 @@ export async function fetchAviationAlertsFromNOAA(): Promise<NoaaAlert[]> {
     fallbackHi: number,
   ) {
     if (settled.status !== 'fulfilled' || !settled.value.ok) {
+      // Our own fetchWithTimeout aborting a slow NOAA endpoint is expected
+      // transient upstream noise, not a defect — the panel still degrades to
+      // all-clear. Record a breadcrumb for context but don't open a Sentry
+      // issue per timeout. Genuine failures (non-ok HTTP, network errors)
+      // still surface as captured exceptions below.
+      if (settled.status === 'rejected' && isAbortError(settled.reason)) {
+        console.warn('[aviation-noaa-service]', `${type} fetch timed out after ${DEFAULT_TIMEOUT_MS}ms`);
+        captureUpstreamTimeout(`NOAA ${type} fetch timed out`, { type, timeoutMs: DEFAULT_TIMEOUT_MS });
+        return;
+      }
       // A dead/erroring AWC endpoint here means an all-clear aviation panel.
       // Surface it instead of dropping the result silently.
       const reason = settled.status === 'rejected'


### PR DESCRIPTION
## Summary

Stops `fetchAviationAlertsFromNOAA` from opening a Sentry issue every time our own `fetchWithTimeout` aborts a slow NOAA AWC request after 10s. That abort is expected upstream latency that the aviation panel already degrades around (it falls back to all-clear), so it should be context, not an alert.

Addresses Sentry issue JAVASCRIPT-NEXTJS-10: "NOAA AIRMET fetch failed: This operation was aborted".

## Root cause

`consume()` captured every non-ok / rejected advisory fetch as a Sentry exception, with no distinction between a genuine NOAA failure and our own AbortController firing on timeout. A transient upstream timeout therefore created an error issue despite being handled gracefully.

## Change

- Add `isAbortError(error)` and `captureUpstreamTimeout(context, extra)` to `lib/error-utils.ts`. `isAbortError` matches on `name === 'AbortError'` (the abort surfaces as a DOMException in some runtimes, an Error in others) rather than `instanceof Error`.
- In `consume()`, a rejected result that is an abort is logged at warn level and recorded as a warning breadcrumb instead of a captured exception. Genuine failures (non-ok HTTP, network errors, parse failures) still capture exactly as before.

This is a signal-quality fix, not a Sentry mute: real NOAA outages still page.

## Test plan

- New `__tests__/aviation-noaa-alerts.test.ts` pins the classification:
  - timeout abort does NOT capture an exception and DOES record a breadcrumb
  - non-ok HTTP (503) DOES capture
  - non-abort network error DOES capture
- Full unit suite green (68 suites / 436 tests), `tsc --noEmit` clean.

## Deliberately left for later

`fetchMetarsBulk` in the same file has the same abort-as-error pattern but is a separate code path and not the captured issue. Left out to keep this change to one root cause; worth a follow-up if METAR timeout noise shows up in Sentry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)