### PR TITLE
Make news grid cards clickable and recover blocked feed images

### DIFF
--- a/__tests__/news-card.test.tsx
+++ b/__tests__/news-card.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * Unit tests for NewsCard (default variant) interactivity.
+ *
+ * Pins the grid-card fixes: the whole card opens the article (it was only the
+ * READ button before), the READ button does not open a second tab, and an
+ * image that fails to load falls back to the text layout instead of leaving a
+ * blank banner.
+ */
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+jest.mock('@/components/theme-provider', () => ({
+  useTheme: () => ({ theme: 'nord' }),
+}));
+
+jest.mock('@/lib/theme-utils', () => ({
+  getComponentStyles: () => ({
+    background: '',
+    headerText: '',
+    text: '',
+    accentText: '',
+    borderColor: '',
+  }),
+}));
+
+import NewsCard from '@/components/news/NewsCard';
+import type { RSSItem } from '@/lib/services/rss/rssAggregator';
+
+function makeItem(overrides: Partial<RSSItem> = {}): RSSItem {
+  return {
+    id: 'src-1-1',
+    title: 'Severe thunderstorm warning issued for the metro area',
+    description: 'A line of storms is moving east.',
+    url: 'https://example.com/article',
+    source: 'Example News',
+    sourceId: 'src',
+    category: 'weather',
+    priority: 'medium',
+    timestamp: new Date(),
+    imageUrl: 'https://cdn.example.com/a.jpg',
+    ...overrides,
+  } as RSSItem;
+}
+
+describe('NewsCard default variant', () => {
+  let openSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    openSpy = jest.spyOn(window, 'open').mockImplementation(() => null);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('opens the article when the card body is clicked', () => {
+    render(<NewsCard item={makeItem()} />);
+
+    fireEvent.click(screen.getByRole('link'));
+
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    expect(openSpy).toHaveBeenCalledWith('https://example.com/article', '_blank', 'noopener,noreferrer');
+  });
+
+  it('opens exactly once when the READ button is clicked (no double tab)', () => {
+    render(<NewsCard item={makeItem()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /read full article/i }));
+
+    expect(openSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('is keyboard activatable as a link', () => {
+    render(<NewsCard item={makeItem()} />);
+
+    fireEvent.keyDown(screen.getByRole('link'), { key: 'Enter' });
+
+    expect(openSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to the text layout when the image fails to load', () => {
+    render(<NewsCard item={makeItem()} />);
+
+    const img = screen.getByAltText(/severe thunderstorm warning/i);
+    fireEvent.error(img);
+
+    // After an image error the banner is gone and the inline priority
+    // indicator (only shown without an image) appears.
+    expect(screen.queryByAltText(/severe thunderstorm warning/i)).toBeNull();
+  });
+});

--- a/__tests__/safe-url.test.ts
+++ b/__tests__/safe-url.test.ts
@@ -1,4 +1,4 @@
-import { safeExternalUrl } from '@/lib/safe-url';
+import { safeExternalUrl, upgradeImageUrl } from '@/lib/safe-url';
 
 describe('safeExternalUrl', () => {
   test('drops javascript: URI', () => {
@@ -41,5 +41,33 @@ describe('safeExternalUrl', () => {
     expect(safeExternalUrl('://no-scheme')).toBe('://no-scheme');
     // `https://` (no host) makes the URL constructor throw → returns null.
     expect(safeExternalUrl('https://')).toBeNull();
+  });
+});
+
+describe('upgradeImageUrl', () => {
+  test('upgrades http:// to https:// so CSP img-src does not block it', () => {
+    expect(upgradeImageUrl('http://cdn.example.com/a.jpg')).toBe('https://cdn.example.com/a.jpg');
+  });
+
+  test('leaves https:// unchanged', () => {
+    expect(upgradeImageUrl('https://cdn.example.com/a.jpg')).toBe('https://cdn.example.com/a.jpg');
+  });
+
+  test('leaves protocol-relative, relative, and data URLs unchanged', () => {
+    expect(upgradeImageUrl('//cdn.example.com/a.jpg')).toBe('//cdn.example.com/a.jpg');
+    expect(upgradeImageUrl('/local/a.jpg')).toBe('/local/a.jpg');
+    expect(upgradeImageUrl('data:image/png;base64,iVBOR')).toBe('data:image/png;base64,iVBOR');
+  });
+
+  test('only rewrites the leading scheme, not http in the path or query', () => {
+    expect(upgradeImageUrl('http://host/redirect?to=http://other.com/x.jpg')).toBe(
+      'https://host/redirect?to=http://other.com/x.jpg'
+    );
+  });
+
+  test('round-trips through safeExternalUrl to a renderable https URL', () => {
+    expect(safeExternalUrl(upgradeImageUrl('http://cdn.example.com/a.jpg'))).toBe(
+      'https://cdn.example.com/a.jpg'
+    );
   });
 });

--- a/components/news/NewsCard.tsx
+++ b/components/news/NewsCard.tsx
@@ -149,18 +149,29 @@ export default function NewsCard({ item, variant = 'default', className }: NewsC
     );
   }
 
-  // Default variant
+  // Default variant. The whole card is the link (matching NewsHero and the
+  // compact variant); the READ button stops propagation so it doesn't open a
+  // second tab. `showImage` collapses to the text layout when there is no
+  // image or it failed to load, so an errored image never leaves a blank banner
+  // and a missing priority indicator.
+  const showImage = Boolean(item.imageUrl) && !imageError;
+
   return (
     <Card
       className={cn(
-        'border-2 transition-all hover:shadow-lg overflow-hidden group flex flex-col h-full',
+        'border-2 transition-all hover:shadow-lg overflow-hidden group flex flex-col h-full cursor-pointer card-interactive',
         priorityBorderClass,
         themeClasses.background,
         className
       )}
+      onClick={openSafeUrl}
+      onKeyDown={handleKeyDown}
+      role="link"
+      tabIndex={0}
+      aria-label={`${item.title} from ${item.source}, ${timeAgo}. Opens in new tab`}
     >
       {/* Image */}
-      {item.imageUrl && !imageError && (
+      {showImage && (
         <div className="relative w-full h-48 overflow-hidden">
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
@@ -179,7 +190,7 @@ export default function NewsCard({ item, variant = 'default', className }: NewsC
       <CardHeader className="flex-1">
         <div className="flex gap-2 mb-2 flex-wrap">
           <CategoryBadge category={item.category} />
-          {!item.imageUrl && <PriorityIndicator priority={item.priority} showLabel size="sm" />}
+          {!showImage && <PriorityIndicator priority={item.priority} showLabel size="sm" />}
           {/* Magnitude badge for earthquakes */}
           {item.magnitude && (
             <span className={cn(
@@ -231,7 +242,10 @@ export default function NewsCard({ item, variant = 'default', className }: NewsC
           variant="outline"
           size="sm"
           className={cn('font-mono font-bold text-xs border-2 flex-shrink-0', themeClasses.accentText)}
-          onClick={openSafeUrl}
+          onClick={(e) => {
+            e.stopPropagation();
+            openSafeUrl();
+          }}
           aria-label={`Read full article: ${item.title}`}
         >
           READ <ExternalLink className="w-3 h-3 ml-1" aria-hidden="true" />

--- a/lib/safe-url.ts
+++ b/lib/safe-url.ts
@@ -19,3 +19,18 @@ export function safeExternalUrl(url: unknown): string | null {
     return null;
   }
 }
+
+/**
+ * Upgrade an `http://` image URL to `https://`.
+ *
+ * Our pages are served over HTTPS and the CSP `img-src` directive only allows
+ * `https:` (see middleware.ts), so an `http://` image — common in RSS feed
+ * items even when the feed itself is HTTPS — is blocked as mixed content and
+ * never renders. Most image CDNs serve the same asset over HTTPS, so a scheme
+ * upgrade recovers the bulk of them; anything that genuinely lacks HTTPS still
+ * fails to load and the caller falls back. Non-`http://` inputs (https,
+ * protocol-relative, relative, data:) are returned unchanged.
+ */
+export function upgradeImageUrl(url: string): string {
+  return url.startsWith('http://') ? `https://${url.slice('http://'.length)}` : url;
+}

--- a/lib/services/rss/rssAggregator.ts
+++ b/lib/services/rss/rssAggregator.ts
@@ -11,7 +11,7 @@ import * as Sentry from '@sentry/nextjs';
 import { XMLParser } from 'fast-xml-parser';
 import { FEED_SOURCES, FeedSource, FeedCategory, CATEGORY_CONFIG } from './feedSources';
 import { decodeHtmlEntities } from './html-utils';
-import { safeExternalUrl } from '@/lib/safe-url';
+import { safeExternalUrl, upgradeImageUrl } from '@/lib/safe-url';
 
 export interface RSSItem {
   id: string;
@@ -292,7 +292,9 @@ function buildItem(
     depth?: number;
   }
 ): RSSItem {
-  const safeImage = fields.rawImage ? safeExternalUrl(fields.rawImage) : null;
+  // Upgrade http -> https before the scheme guard: CSP img-src only allows
+  // https, so an http feed image would otherwise be dropped or blocked.
+  const safeImage = fields.rawImage ? safeExternalUrl(upgradeImageUrl(fields.rawImage)) : null;
   return {
     id: `${source.id}-${simpleHash(fields.safeLink + index.toString())}-${index}`,
     title: cleanHtml(fields.title),


### PR DESCRIPTION
## Summary

Fixes two bugs in the news section grid. Neither is theme-specific; both affect every theme.

## 1. Grid cards were not clickable

`NewsGrid` renders `NewsCard` with the default variant. Unlike `NewsHero` and the compact `NewsCard` variant (both fully clickable), the default variant had no click handler, so only the small "READ" button in the footer opened the article.

Fix: make the whole card the link (`onClick`, `role="link"`, `tabIndex`, keyboard handler, `cursor-pointer`), matching the hero/compact pattern, and `e.stopPropagation()` on the READ button so it does not open a second tab.

## 2. Most feed images did not load

The CSP `img-src` directive (`middleware.ts`) only allows `https:`. RSS image URLs (`media:thumbnail`, `enclosure`, inline `<img>`) are frequently `http://` even when the feed itself is HTTPS, so the browser blocked them as mixed content and they never rendered.

Fix: add `upgradeImageUrl()` and apply it in the aggregator's `buildItem` before the scheme guard, rewriting `http://` image URLs to `https://`. Most image CDNs serve the same asset over HTTPS, so this recovers the bulk of them. When an image still fails, the default card now collapses to the text layout (`showImage`) instead of leaving a blank banner and dropping the priority indicator.

## Test plan

- `__tests__/safe-url.test.ts`: `upgradeImageUrl` scheme handling (http upgrade, https/protocol-relative/relative/data untouched, only leading scheme rewritten, round-trips through `safeExternalUrl`).
- `__tests__/news-card.test.tsx`: default-variant interactivity (card click opens once with correct args, READ button opens exactly once, keyboard Enter activation, image-error fallback removes the banner).
- Full unit suite green (69 suites / 445 tests), `tsc --noEmit` clean, ESLint clean on changed files.

## Notes

- Image upgrade is a scheme rewrite only, not a proxy: hosts that genuinely lack HTTPS still fail and fall back to the text layout. A `/api/news/image` proxy was considered and deferred as heavier (route, bandwidth, caching).

🤖 Generated with [Claude Code](https://claude.com/claude-code)