### PR TITLE
Keep non-image feed media out of the news image slot

### DIFF
--- a/__tests__/rss-image-extraction.test.ts
+++ b/__tests__/rss-image-extraction.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Pins image extraction so non-image feed media never lands in an <img>.
+ *
+ * Regression guard: media:content can declare medium="video" (YouTube embeds)
+ * or point at .mp4 files. Rendered in <img> the browser blocks them
+ * (ERR_BLOCKED_BY_ORB) and the news card flashes a broken image. extractImage
+ * must only return URLs that are plausibly renderable images.
+ */
+import { __testing } from '@/lib/services/rss/rssAggregator';
+
+const { extractImage, isLikelyImageUrl } = __testing as {
+  extractImage: (node: Record<string, unknown>, body?: string) => string | undefined;
+  isLikelyImageUrl: (url: string) => boolean;
+};
+
+describe('isLikelyImageUrl', () => {
+  it('accepts image extensions and extensionless CDN URLs', () => {
+    expect(isLikelyImageUrl('https://cdn.example.com/a.jpg')).toBe(true);
+    expect(isLikelyImageUrl('https://www.spc.noaa.gov/products/outlook/day1otlk.png')).toBe(true);
+    expect(isLikelyImageUrl('https://assets.example.com/image/12345')).toBe(true);
+    expect(isLikelyImageUrl('https://cdn.example.com/a.jpg?w=600')).toBe(true);
+  });
+
+  it('rejects video/player URLs and non-image extensions', () => {
+    expect(isLikelyImageUrl('https://www.youtube.com/embed/fAgrztFvWyk')).toBe(false);
+    expect(isLikelyImageUrl('https://youtu.be/abc123')).toBe(false);
+    expect(isLikelyImageUrl('https://assets.example.com/clip.mp4')).toBe(false);
+    expect(isLikelyImageUrl('https://assets.example.com/clip.webm')).toBe(false);
+    expect(isLikelyImageUrl('https://example.com/article.html')).toBe(false);
+  });
+});
+
+describe('extractImage', () => {
+  it('skips a video media:content and uses a later image one', () => {
+    const node = {
+      'media:content': [
+        { '@_url': 'https://www.youtube.com/embed/fAgrztFvWyk', '@_medium': 'video' },
+        { '@_url': 'https://cdn.example.com/thumb.jpg', '@_medium': 'image' },
+      ],
+    };
+    expect(extractImage(node)).toBe('https://cdn.example.com/thumb.jpg');
+  });
+
+  it('rejects a media:content whose MIME type is not an image', () => {
+    const node = {
+      'media:content': [{ '@_url': 'https://assets.example.com/clip.mp4', '@_type': 'video/mp4' }],
+    };
+    expect(extractImage(node)).toBeUndefined();
+  });
+
+  it('rejects a YouTube embed even when no medium/type hint is present', () => {
+    const node = {
+      'media:content': [{ '@_url': 'https://www.youtube.com/embed/W0tAz8ZSFF8' }],
+    };
+    expect(extractImage(node)).toBeUndefined();
+  });
+
+  it('accepts a media:thumbnail image and rejects a video thumbnail url', () => {
+    expect(
+      extractImage({ 'media:thumbnail': { '@_url': 'https://cdn.example.com/t.jpg' } })
+    ).toBe('https://cdn.example.com/t.jpg');
+    expect(
+      extractImage({ 'media:thumbnail': { '@_url': 'https://cdn.example.com/t.mp4' } })
+    ).toBeUndefined();
+  });
+
+  it('honors the enclosure image type but rejects a bare .mp4 enclosure', () => {
+    expect(
+      extractImage({ enclosure: { '@_url': 'https://cdn.example.com/p.jpg', '@_type': 'image/jpeg' } })
+    ).toBe('https://cdn.example.com/p.jpg');
+    expect(
+      extractImage({ enclosure: { '@_url': 'https://cdn.example.com/v.mp4' } })
+    ).toBeUndefined();
+  });
+
+  it('falls back to an inline <img> in the body only when it is an image', () => {
+    expect(extractImage({}, '<p>x</p><img src="https://cdn.example.com/body.jpg" />')).toBe(
+      'https://cdn.example.com/body.jpg'
+    );
+    expect(extractImage({}, '<iframe src="https://www.youtube.com/embed/x"></iframe>')).toBeUndefined();
+  });
+
+  it('returns undefined for an imageless item', () => {
+    expect(extractImage({}, 'Magnitude 4.5 earthquake near Anchorage')).toBeUndefined();
+  });
+});

--- a/lib/services/rss/rssAggregator.ts
+++ b/lib/services/rss/rssAggregator.ts
@@ -246,30 +246,64 @@ function atomLinkHref(node: XmlNode): string | undefined {
   return nodeText(chosen['@_href']) ?? nodeText(chosen.href);
 }
 
+// Hosts that serve players/embeds, not images. A feed's media:content can
+// point at a YouTube embed (medium="video"); shoved into <img> the browser
+// blocks it (ERR_BLOCKED_BY_ORB) and the card flashes a broken image.
+const NON_IMAGE_HOSTS = ['youtube.com/embed', 'youtu.be', 'player.vimeo.com'];
+// Extensions that are definitely not still images.
+const NON_IMAGE_EXT = /\.(mp4|webm|mov|m4v|avi|mkv|mp3|m4a|wav|pdf|html?)(?:[?#]|$)/i;
+const IMAGE_EXT = /\.(png|jpe?g|gif|webp|avif|bmp|svg)(?:[?#]|$)/i;
+
+/**
+ * True only for URLs plausibly renderable in an <img>. Rejects known
+ * player/embed hosts and non-image extensions; accepts a known image
+ * extension or an extensionless URL (many image CDNs serve those). The point
+ * is to keep video embeds and media files out of the image slot.
+ */
+function isLikelyImageUrl(url: string): boolean {
+  const lower = url.toLowerCase();
+  if (NON_IMAGE_HOSTS.some((h) => lower.includes(h))) return false;
+  if (NON_IMAGE_EXT.test(lower)) return false;
+  if (IMAGE_EXT.test(lower)) return true;
+  // No recognizable file extension at all -> allow (CDN-style image URL).
+  return !/\.[a-z0-9]{2,5}(?:[?#]|$)/i.test(lower);
+}
+
+/** media:* declares its kind via `medium` ("image"|"video"|...) or a MIME `type`. */
+function isImageMediaNode(media: XmlNode): boolean {
+  const medium = nodeText(media['@_medium']);
+  if (medium) return medium === 'image';
+  const type = nodeText(media['@_type']);
+  if (type) return type.startsWith('image/');
+  return true; // no hints -> fall back to URL-shape check by the caller
+}
+
 /** Best-effort image extraction: media:*, enclosure, then inline <img> in body. */
 function extractImage(node: XmlNode, body: string | undefined): string | undefined {
   const mediaThumb = node['media:thumbnail'] ?? node.thumbnail;
   if (mediaThumb && typeof mediaThumb === 'object' && !Array.isArray(mediaThumb)) {
     const url = nodeText(mediaThumb['@_url']) ?? nodeText(mediaThumb.url);
-    if (url) return url;
+    if (url && isLikelyImageUrl(url)) return url;
   }
 
-  const mediaContent = asArray(node['media:content'])[0];
-  if (mediaContent) {
-    const url = nodeText(mediaContent['@_url']) ?? nodeText(mediaContent.url);
-    if (url) return url;
+  // Pick the first media:content that is actually an image, not the first one
+  // outright — video entries (e.g. YouTube) often precede a real thumbnail.
+  for (const media of asArray(node['media:content'])) {
+    if (!isImageMediaNode(media)) continue;
+    const url = nodeText(media['@_url']) ?? nodeText(media.url);
+    if (url && isLikelyImageUrl(url)) return url;
   }
 
   const enclosure = asArray(node.enclosure)[0];
   if (enclosure) {
     const type = nodeText(enclosure['@_type']) ?? '';
     const url = nodeText(enclosure['@_url']) ?? nodeText(enclosure.url);
-    if (url && (type === '' || type.startsWith('image/'))) return url;
+    if (url && (type === '' || type.startsWith('image/')) && isLikelyImageUrl(url)) return url;
   }
 
   if (body) {
     const imgMatch = body.match(/<img[^>]+src=["']([^"']+)["']/i);
-    if (imgMatch) return imgMatch[1];
+    if (imgMatch && isLikelyImageUrl(imgMatch[1])) return imgMatch[1];
   }
 
   return undefined;
@@ -721,4 +755,6 @@ export const __testing = {
   parseJsonFeed,
   deduplicateItems,
   clearCache,
+  extractImage,
+  isLikelyImageUrl,
 };


### PR DESCRIPTION
## Summary

Part of the news-feed image investigation. Fixes the case where the news card briefly flashes a broken image.

`extractImage` in `rssAggregator.ts` returned the first `media:content` URL unconditionally. Some feeds (NASA/space, ScienceDaily) publish video entries as `media:content medium="video"` pointing at YouTube `/embed/` URLs, or enclosures pointing at `.mp4` files. Those landed in `imageUrl` and were rendered in `<img>`, which the browser blocks (`ERR_BLOCKED_BY_ORB` for the YouTube HTML response), producing a broken-image flash before the `onError` fallback swaps in the category icon.

## Change

- Add `isLikelyImageUrl()`: rejects known player/embed hosts (youtube embed, youtu.be, vimeo player) and non-image extensions (`.mp4/.webm/.mov/.html/...`); accepts known image extensions or extensionless CDN URLs.
- Add `isImageMediaNode()`: honors the Media RSS `medium` (`image` vs `video`) and MIME `type` hints.
- Apply the guard to every extraction branch (`media:thumbnail`, `media:content`, `enclosure`, inline `<img>`), and scan `media:content` for the first entry that is actually an image instead of blindly taking the first.

## Evidence

Measured from the running app before the fix: of 60 feed items, 6 had an image; 2 were YouTube embeds (`content-type: text/html`) and 1 was an `.mp4`. The browser probe showed those 2 YouTube requests failing with `net::ERR_BLOCKED_BY_ORB`. After the fix, the live feed returns only the 3 genuine images; the video/embed items correctly fall back to the text/category layout.

## Test plan

- `__tests__/rss-image-extraction.test.ts`: `isLikelyImageUrl` accept/reject cases and `extractImage` across media:content (video skipped, later image used), MIME-typed rejects, hint-less YouTube reject, thumbnail, enclosure, inline-body, and imageless items.
- Existing `rss-aggregator.test.ts` still green; full unit suite 70 suites / 454 tests; `tsc --noEmit` clean.

## Note

This is the data-side fix. A separate PR covers the news card visual/theme issues (missing `weather` style case, Daybreak heading contrast, imageless-card placeholder).

🤖 Generated with [Claude Code](https://claude.com/claude-code)