### PR TITLE
Fix news card theming and give imageless cards a category placeholder

### DIFF
--- a/__tests__/news-card.test.tsx
+++ b/__tests__/news-card.test.tsx
@@ -78,14 +78,24 @@ describe('NewsCard default variant', () => {
     expect(openSpy).toHaveBeenCalledTimes(1);
   });
 
-  it('falls back to the text layout when the image fails to load', () => {
+  it('falls back to the placeholder when the image fails to load', () => {
     render(<NewsCard item={makeItem()} />);
 
     const img = screen.getByAltText(/severe thunderstorm warning/i);
     fireEvent.error(img);
 
-    // After an image error the banner is gone and the inline priority
-    // indicator (only shown without an image) appears.
+    // After an image error the <img> is removed and the card shows the
+    // category placeholder banner instead, but stays a working link.
     expect(screen.queryByAltText(/severe thunderstorm warning/i)).toBeNull();
+    expect(screen.getByRole('link')).toBeTruthy();
+  });
+
+  it('renders a placeholder (no <img>) for an imageless item but stays clickable', () => {
+    render(<NewsCard item={makeItem({ imageUrl: undefined, category: 'earthquakes' })} />);
+
+    expect(screen.queryByRole('img')).toBeNull();
+    const link = screen.getByRole('link');
+    fireEvent.click(link);
+    expect(openSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/news/page.tsx
+++ b/app/news/page.tsx
@@ -176,7 +176,9 @@ export default function NewsPage() {
           <h1
             className={cn(
               'text-3xl sm:text-4xl md:text-5xl font-extrabold mb-2 font-mono',
-              themeClasses.accentText
+              // text-primary (not accentText/text-primary-foreground): the latter
+              // is near-white and disappears on the light Daybreak background.
+              'text-primary'
             )}
           >
             EARTH & SPACE NEWS

--- a/components/news/CategoryBadge.tsx
+++ b/components/news/CategoryBadge.tsx
@@ -84,7 +84,7 @@ const categoryConfig: Record<
   weather: {
     label: 'WEATHER',
     icon: Cloud,
-    colorClass: 'bg-terminal-accent-info text-white border-terminal-border',
+    colorClass: 'bg-sky-600 text-white border-sky-800',
   },
   severe: {
     label: 'SEVERE',
@@ -99,7 +99,7 @@ const categoryConfig: Record<
   climate: {
     label: 'CLIMATE',
     icon: Thermometer,
-    colorClass: 'bg-terminal-accent text-white border-terminal-border',
+    colorClass: 'bg-teal-600 text-white border-teal-800',
   },
   tropical: {
     label: 'TROPICAL',
@@ -118,8 +118,16 @@ const categoryConfig: Record<
   },
 };
 
+/** Icon + color for a category; falls back to the generic config. Exported so
+ *  imageless news cards can reuse the same icon/color for a placeholder banner. */
+export function getCategoryConfig(category: CategoryType) {
+  return categoryConfig[category] || categoryConfig.general;
+}
+
+export type { CategoryType };
+
 export default function CategoryBadge({ category, className }: CategoryBadgeProps) {
-  const config = categoryConfig[category] || categoryConfig.general;
+  const config = getCategoryConfig(category);
   const Icon = config.icon;
 
   return (

--- a/components/news/NewsCard.tsx
+++ b/components/news/NewsCard.tsx
@@ -14,7 +14,7 @@ import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { useTheme } from '@/components/theme-provider';
 import { getComponentStyles, type ThemeType } from '@/lib/theme-utils';
-import CategoryBadge from './CategoryBadge';
+import CategoryBadge, { getCategoryConfig, type CategoryType } from './CategoryBadge';
 import PriorityIndicator from './PriorityIndicator';
 import type { RSSItem } from '@/lib/services/rss/rssAggregator';
 import { safeExternalUrl } from '@/lib/safe-url';
@@ -57,13 +57,16 @@ export default function NewsCard({ item, variant = 'default', className }: NewsC
       : item.description
     : '';
 
-  // Priority-based border styles
+  // Priority-based border styles. Low priority falls back to a visible theme
+  // border (border-border) rather than themeClasses.borderColor, which is
+  // border-transparent for the 'weather' variant and left low-priority cards
+  // edgeless and blended into the page on every theme.
   const priorityBorderClass =
     item.priority === 'high'
       ? 'border-red-500 hover:border-red-400'
       : item.priority === 'medium'
       ? 'border-yellow-500 hover:border-yellow-400'
-      : themeClasses.borderColor;
+      : 'border-border';
 
   // Handle keyboard navigation
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -80,7 +83,7 @@ export default function NewsCard({ item, variant = 'default', className }: NewsC
         className={cn(
           'border-2 transition-all hover:shadow-lg cursor-pointer group card-interactive',
           priorityBorderClass,
-          themeClasses.background,
+          'bg-card',
           className
         )}
         onClick={openSafeUrl}
@@ -106,7 +109,7 @@ export default function NewsCard({ item, variant = 'default', className }: NewsC
               <div
                 className={cn(
                   'w-16 h-16 flex-shrink-0 border-2 rounded flex items-center justify-center',
-                  themeClasses.borderColor
+                  'border-border'
                 )}
               >
                 <CategoryBadge category={item.category} />
@@ -155,13 +158,15 @@ export default function NewsCard({ item, variant = 'default', className }: NewsC
   // image or it failed to load, so an errored image never leaves a blank banner
   // and a missing priority indicator.
   const showImage = Boolean(item.imageUrl) && !imageError;
+  const categoryConfig = getCategoryConfig(item.category as CategoryType);
+  const CategoryIcon = categoryConfig.icon;
 
   return (
     <Card
       className={cn(
         'border-2 transition-all hover:shadow-lg overflow-hidden group flex flex-col h-full cursor-pointer card-interactive',
         priorityBorderClass,
-        themeClasses.background,
+        'bg-card',
         className
       )}
       onClick={openSafeUrl}
@@ -171,7 +176,7 @@ export default function NewsCard({ item, variant = 'default', className }: NewsC
       aria-label={`${item.title} from ${item.source}, ${timeAgo}. Opens in new tab`}
     >
       {/* Image */}
-      {showImage && (
+      {showImage ? (
         <div className="relative w-full h-48 overflow-hidden">
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
@@ -184,13 +189,28 @@ export default function NewsCard({ item, variant = 'default', className }: NewsC
             <PriorityIndicator priority={item.priority} size="md" />
           </div>
         </div>
+      ) : (
+        // Most feed items (USGS/NWS/NHC data feeds) have no image. Rather than
+        // a blank card, show a category-colored banner with the category icon so
+        // imageless cards read as deliberate and stay scannable by category.
+        <div
+          className={cn(
+            'relative w-full h-24 flex items-center justify-center border-b-2',
+            categoryConfig.colorClass
+          )}
+          aria-hidden="true"
+        >
+          <CategoryIcon className="w-10 h-10 opacity-90" />
+          <div className="absolute top-2 right-2 flex gap-2">
+            <PriorityIndicator priority={item.priority} size="md" />
+          </div>
+        </div>
       )}
 
       {/* Header */}
       <CardHeader className="flex-1">
         <div className="flex gap-2 mb-2 flex-wrap">
           <CategoryBadge category={item.category} />
-          {!showImage && <PriorityIndicator priority={item.priority} showLabel size="sm" />}
           {/* Magnitude badge for earthquakes */}
           {item.magnitude && (
             <span className={cn(
@@ -241,7 +261,7 @@ export default function NewsCard({ item, variant = 'default', className }: NewsC
         <Button
           variant="outline"
           size="sm"
-          className={cn('font-mono font-bold text-xs border-2 flex-shrink-0', themeClasses.accentText)}
+          className={cn('font-mono font-bold text-xs border-2 flex-shrink-0', 'text-primary')}
           onClick={(e) => {
             e.stopPropagation();
             openSafeUrl();

--- a/components/news/NewsHero.tsx
+++ b/components/news/NewsHero.tsx
@@ -70,7 +70,9 @@ export default function NewsHero({ item, className }: NewsHeroProps) {
           <div
             className={cn(
               'w-full lg:w-1/2 h-64 lg:h-80 flex items-center justify-center border-b border-subtle lg:border-b-0 lg:border-r',
-              themeClasses.background
+              // bg-muted (a real theme surface), not themeClasses.background which
+              // matches the card and left this placeholder panel invisible.
+              'bg-muted'
             )}
           >
             <div className="text-center p-8">
@@ -141,7 +143,7 @@ export default function NewsHero({ item, className }: NewsHeroProps) {
             </div>
             <Button
               variant="outline"
-              className={cn('font-mono font-bold border-2', themeClasses.accentText)}
+              className={cn('font-mono font-bold border-2', 'text-primary')}
               onClick={(e) => {
                 e.stopPropagation();
                 openSafeUrl();

--- a/components/news/PriorityIndicator.tsx
+++ b/components/news/PriorityIndicator.tsx
@@ -43,8 +43,8 @@ const priorityConfig: Record<
   low: {
     label: 'INFO',
     icon: Info,
-    colorClass: 'text-terminal-accent-info',
-    textClass: 'text-terminal-accent-info font-normal',
+    colorClass: 'text-sky-500',
+    textClass: 'text-sky-600 font-normal',
   },
 };
 


### PR DESCRIPTION
## Summary

Second part of the news-feed investigation (companion to the image-extractor PR). Fixes verified cross-theme rendering bugs in the news section and improves the imageless-card experience.

The news components call `getComponentStyles(theme, 'weather')`, but there is **no `'weather'` case** in `getComponentStyles` — it falls through to defaults (`bg-background`, `border-transparent`, `accentText = text-primary-foreground`). That caused:

- **Low-priority cards** rendered with a transparent border on a page-colored background — edgeless floating text on every theme.
- **Page heading** used `text-primary-foreground` (near-white), invisible on the light **Daybreak** background.
- **READ buttons** used the same near-white token (invisible on light themes); the **NewsHero placeholder panel** was the same color as the card (invisible).
- **PriorityIndicator (low)** and the **WEATHER/CLIMATE CategoryBadge** colors used `terminal-*` CSS vars that only exist under the legacy `[data-palette]` system, not the active `[data-theme]` themes — so they rendered with no color.

## Approach

Scoped explicit, theme-resolved classes (`bg-card`, `border-border`, `text-primary`) to the **news components only**, rather than adding a `'weather'` case to `getComponentStyles`. That function is shared by **~45 components** (space-weather, aviation, learn, many pages), so adding a case would have a large, out-of-scope blast radius.

## UX: imageless cards

~54 of 60 feed items are imageless data feeds (USGS/NWS/NHC). The default card now renders a **category-colored placeholder banner** with the category icon (mirroring the compact variant's icon tile) instead of a blank top, so imageless cards look deliberate and stay scannable. `getCategoryConfig` is exported from `CategoryBadge` to share the icon/color map.

## Verification

- In-browser across themes (dev server): Daybreak heading now visible, cards have visible borders/surfaces, hero placeholder visible, **0 console errors** on Daybreak and the dark theme.
- `__tests__/news-card.test.tsx` extended: imageless card renders a placeholder (no `<img>`) and stays clickable; image-error falls back to the placeholder.
- Full unit suite 69 suites / 446 tests; `tsc --noEmit` clean; ESLint clean.

## Scope notes

- No change to `getComponentStyles` (deliberately, per blast radius above).
- Hardcoded hazard colors (red/yellow priority borders, magnitude badges) are kept — red/orange read fine on all themes; the yellow tier is marginal on Daybreak but left as-is to keep this focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)