### PR TITLE
Stargazer PR1: surface hidden conditions, wire Kp index and aerosols

### DIFF
--- a/__tests__/stargazer/ground.test.ts
+++ b/__tests__/stargazer/ground.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Tests for Stargazer ground-condition helpers
+ */
+
+import { dewpointSpread, getDewRisk } from '@/lib/stargazer/ground';
+
+describe('dewpointSpread', () => {
+  it('returns the difference between temperature and dewpoint', () => {
+    expect(dewpointSpread(15, 10)).toBe(5);
+  });
+
+  it('can be zero when temperature equals dewpoint (saturated air)', () => {
+    expect(dewpointSpread(8, 8)).toBe(0);
+  });
+
+  it('can be negative for supersaturated/edge inputs', () => {
+    expect(dewpointSpread(4, 6)).toBe(-2);
+  });
+});
+
+describe('getDewRisk', () => {
+  it('flags high risk when the spread is under 2 degrees', () => {
+    expect(getDewRisk(10, 9)).toBe('high');
+    expect(getDewRisk(10, 10)).toBe('high');
+  });
+
+  it('flags moderate risk for a 2 to 5 degree spread', () => {
+    expect(getDewRisk(12, 10)).toBe('moderate');
+    expect(getDewRisk(14, 10)).toBe('moderate');
+  });
+
+  it('flags low risk for a spread of 5 degrees or more', () => {
+    expect(getDewRisk(20, 10)).toBe('low');
+    expect(getDewRisk(15, 10)).toBe('low');
+  });
+});

--- a/__tests__/stargazer/space-environment.test.ts
+++ b/__tests__/stargazer/space-environment.test.ts
@@ -94,6 +94,23 @@ describe('extractForecastMaxKp', () => {
     expect(extractForecastMaxKp(rows)).toBe(5.0);
   });
 
+  it('keeps a genuine all-quiet (0) forecast as 0, not null', () => {
+    const rows = [
+      { kp: 0, observed: 'predicted' },
+      { kp: 0, observed: 'predicted' },
+    ];
+    expect(extractForecastMaxKp(rows)).toBe(0);
+  });
+
+  it('bounds the horizon to the next ~24h (first 8 predicted rows)', () => {
+    const rows = [
+      ...Array.from({ length: 8 }, () => ({ kp: 1, observed: 'predicted' })),
+      // A storm beyond the 24h window must not inflate the reported max.
+      { kp: 7, observed: 'predicted' },
+    ];
+    expect(extractForecastMaxKp(rows)).toBe(1);
+  });
+
   it('returns null when nothing parses', () => {
     expect(extractForecastMaxKp([])).toBeNull();
     expect(extractForecastMaxKp(null)).toBeNull();

--- a/__tests__/stargazer/space-environment.test.ts
+++ b/__tests__/stargazer/space-environment.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Tests for Stargazer Kp index parsing (NOAA SWPC payload shapes)
+ */
+
+import {
+  parseKpRow,
+  parseKpTimeTag,
+  parseKpEntry,
+  extractCurrentKp,
+  extractForecastMaxKp,
+} from '@/lib/stargazer/space-environment';
+
+describe('parseKpRow', () => {
+  it('reads the current object shape ({ Kp })', () => {
+    expect(parseKpRow({ time_tag: '2026-06-07T12:00:00', Kp: 3.67 })).toBe(3.67);
+  });
+
+  it('reads the forecast object shape ({ kp })', () => {
+    expect(parseKpRow({ time_tag: '2026-06-07T12:00:00', kp: 5.33 })).toBe(5.33);
+  });
+
+  it('reads the legacy array shape ([time_tag, Kp, ...])', () => {
+    expect(parseKpRow(['2026-06-07T12:00:00', '4.00', 27, 8])).toBe(4);
+  });
+
+  it('returns null for the header row or junk', () => {
+    expect(parseKpRow(['time_tag', 'Kp', 'a_running', 'station_count'])).toBeNull();
+    expect(parseKpRow({ time_tag: '2026-06-07T12:00:00' })).toBeNull();
+    expect(parseKpRow(null)).toBeNull();
+  });
+});
+
+describe('parseKpTimeTag', () => {
+  it('reads time_tag from the object shape', () => {
+    expect(parseKpTimeTag({ time_tag: '2026-06-07T12:00:00', Kp: 2 })).toBe('2026-06-07T12:00:00');
+  });
+
+  it('reads index 0 from the array shape', () => {
+    expect(parseKpTimeTag(['2026-06-07T12:00:00', '2', 7, 8])).toBe('2026-06-07T12:00:00');
+  });
+
+  it('returns empty string when absent', () => {
+    expect(parseKpTimeTag({ Kp: 2 })).toBe('');
+    expect(parseKpTimeTag(null)).toBe('');
+  });
+});
+
+describe('parseKpEntry', () => {
+  it('builds a { timeTag, kp } entry from the object shape', () => {
+    expect(parseKpEntry({ time_tag: '2026-06-07T12:00:00', Kp: 3.67 })).toEqual({
+      timeTag: '2026-06-07T12:00:00',
+      kp: 3.67,
+    });
+  });
+
+  it('returns null for the legacy header row', () => {
+    expect(parseKpEntry(['time_tag', 'Kp', 'a_running', 'station_count'])).toBeNull();
+  });
+});
+
+describe('extractCurrentKp', () => {
+  it('returns the most recent numeric Kp', () => {
+    const rows = [
+      { time_tag: '2026-06-07T06:00:00', Kp: 2.0 },
+      { time_tag: '2026-06-07T09:00:00', Kp: 2.67 },
+      { time_tag: '2026-06-07T12:00:00', Kp: 1.67 },
+    ];
+    expect(extractCurrentKp(rows)).toBe(1.67);
+  });
+
+  it('skips trailing non-numeric rows', () => {
+    const rows = [{ Kp: 3.0 }, { time_tag: 'x' }];
+    expect(extractCurrentKp(rows)).toBe(3.0);
+  });
+
+  it('returns null for non-array input', () => {
+    expect(extractCurrentKp(null)).toBeNull();
+  });
+});
+
+describe('extractForecastMaxKp', () => {
+  it('prefers predicted rows and returns their max', () => {
+    const rows = [
+      { time_tag: '2026-06-06T00:00:00', kp: 6.33, observed: 'observed' },
+      { time_tag: '2026-06-07T12:00:00', kp: 2.0, observed: 'predicted' },
+      { time_tag: '2026-06-07T15:00:00', kp: 4.33, observed: 'predicted' },
+    ];
+    // 6.33 is observed (past), so it must be ignored; max of predicted is 4.33.
+    expect(extractForecastMaxKp(rows)).toBe(4.33);
+  });
+
+  it('falls back to all rows when none are flagged predicted', () => {
+    const rows = [{ kp: 2.0 }, { kp: 5.0 }];
+    expect(extractForecastMaxKp(rows)).toBe(5.0);
+  });
+
+  it('returns null when nothing parses', () => {
+    expect(extractForecastMaxKp([])).toBeNull();
+    expect(extractForecastMaxKp(null)).toBeNull();
+  });
+});

--- a/app/api/space-weather/kp-index/route.ts
+++ b/app/api/space-weather/kp-index/route.ts
@@ -9,6 +9,7 @@
 
 import { NextResponse } from 'next/server';
 import { fetchWithTimeout } from '@/lib/fetch-with-timeout';
+import { parseKpEntry, parseKpRow } from '@/lib/stargazer/space-environment';
 
 export interface KpIndexData {
   timestamp: string;
@@ -40,7 +41,9 @@ export async function GET() {
       } as RequestInit)
     ]);
 
-    // Parse Kp index data (array format: [time_tag, Kp, a_running, station_count])
+    // Parse Kp index data. NOAA ships this in two shapes over time: array-of-objects
+    // ({ time_tag, Kp, ... }) and the legacy array-of-arrays with a header row. The
+    // shared parsers handle both and skip any non-numeric header/junk rows.
     let currentKp = 0;
     let currentTimeTag = '';
     const recentKp: Array<{ timeTag: string; kp: number }> = [];
@@ -48,19 +51,13 @@ export async function GET() {
     if (kpResponse.status === 'fulfilled' && kpResponse.value.ok) {
       const kpData = await kpResponse.value.json();
 
-      // First row is header, rest is data
-      if (Array.isArray(kpData) && kpData.length > 1) {
-        // Get last 8 entries (24 hours of 3-hour intervals)
-        const dataRows = kpData.slice(1);
-        const last8 = dataRows.slice(-8);
-
-        for (const row of last8) {
-          if (Array.isArray(row) && row.length >= 2) {
-            const timeTag = row[0] as string;
-            const kp = parseFloat(row[1] as string) || 0;
-            recentKp.push({ timeTag, kp });
-          }
-        }
+      if (Array.isArray(kpData) && kpData.length > 0) {
+        // Last 8 numeric entries (24 hours of 3-hour intervals)
+        const entries = kpData
+          .map(parseKpEntry)
+          .filter((e): e is { timeTag: string; kp: number } => e != null);
+        const last8 = entries.slice(-8);
+        recentKp.push(...last8);
 
         // Current is the last entry
         if (recentKp.length > 0) {
@@ -76,16 +73,21 @@ export async function GET() {
     if (forecastResponse.status === 'fulfilled' && forecastResponse.value.ok) {
       try {
         const forecastData = await forecastResponse.value.json();
-        // Forecast is array with time ranges and expected Kp
-        if (Array.isArray(forecastData) && forecastData.length > 1) {
-          const upcoming = forecastData.slice(1, 9); // Next 24 hours
+        // Forecast mixes recent observed rows with predicted ones. Prefer the
+        // predicted rows (the actual forecast); fall back to the tail otherwise.
+        if (Array.isArray(forecastData) && forecastData.length > 0) {
+          const predicted = forecastData.filter(
+            (r) => r && typeof r === 'object' && (r as Record<string, unknown>).observed === 'predicted',
+          );
+          const source = predicted.length > 0 ? predicted : forecastData;
+          const upcoming = source.slice(0, 8); // Next ~24 hours
           let maxKp = 0;
           let sumKp = 0;
           let count = 0;
 
           for (const row of upcoming) {
-            if (Array.isArray(row) && row.length >= 2) {
-              const kp = parseFloat(row[1] as string) || 0;
+            const kp = parseKpRow(row);
+            if (kp != null) {
               maxKp = Math.max(maxKp, kp);
               sumKp += kp;
               count++;

--- a/app/api/stargazer/route.ts
+++ b/app/api/stargazer/route.ts
@@ -23,12 +23,16 @@ import {
 } from '@/lib/stargazer/seven-timer';
 import { fetchISSTLE, calculateISSPasses } from '@/lib/stargazer/satellites';
 import { fetchUpcomingLaunches } from '@/lib/stargazer/launches';
+import { getDewRisk } from '@/lib/stargazer/ground';
+import { fetchKpIndex } from '@/lib/stargazer/space-environment';
+import { fetchOpenMeteoAirQuality } from '@/lib/open-meteo';
 
 import deepSkyCatalog from '@/data/deep-sky-catalog.json';
 import meteorShowerData from '@/data/meteor-showers.json';
 
 import type {
   StargazerData,
+  StargazerEnvironment,
   StargazerSubScores,
   HourlyCondition,
   DeepSkyHighlight,
@@ -56,6 +60,7 @@ interface OpenMeteoHourly {
   dewpoint_2m: number[];
   temperature_2m: number[];
   wind_speed_10m: number[];
+  wind_direction_10m: number[];
   visibility: number[];
   surface_pressure: number[];
 }
@@ -77,14 +82,6 @@ function cToF(c: number): number {
 /** Convert km/h to mph */
 function kmhToMph(kmh: number): number {
   return kmh * 0.621371;
-}
-
-/** Compute dew risk from temperature and dewpoint (both in Celsius) */
-function getDewRisk(tempC: number, dewpointC: number): 'low' | 'moderate' | 'high' {
-  const delta = tempC - dewpointC;
-  if (delta < 2) return 'high';
-  if (delta < 5) return 'moderate';
-  return 'low';
 }
 
 // ============================================================================
@@ -115,16 +112,18 @@ export async function GET(request: NextRequest) {
 
   try {
     // ---- Parallel fetches ----
-    const openMeteoUrl = `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&hourly=cloud_cover,cloud_cover_low,cloud_cover_mid,cloud_cover_high,relative_humidity_2m,dewpoint_2m,temperature_2m,wind_speed_10m,visibility,surface_pressure&forecast_days=2&timezone=auto`;
+    const openMeteoUrl = `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&hourly=cloud_cover,cloud_cover_low,cloud_cover_mid,cloud_cover_high,relative_humidity_2m,dewpoint_2m,temperature_2m,wind_speed_10m,wind_direction_10m,visibility,surface_pressure&forecast_days=2&timezone=auto`;
 
     const reverseGeoUrl = `https://nominatim.openstreetmap.org/reverse?lat=${lat}&lon=${lon}&format=json&zoom=10&extratags=1`;
 
-    const [openMeteoRes, sevenTimerData, issTle, launches, reverseGeoRes] = await Promise.all([
+    const [openMeteoRes, sevenTimerData, issTle, launches, reverseGeoRes, airQuality, kp] = await Promise.all([
       fetchWithTimeout(openMeteoUrl, { next: { revalidate: 900 } }),
       fetchSevenTimerData(lat, lon),
       fetchISSTLE(),
       fetchUpcomingLaunches(10),
       fetchWithTimeout(reverseGeoUrl, { next: { revalidate: 86400 }, headers: { 'User-Agent': '16BitWeather/1.0 (https://16bitweather.co)' } }).catch(() => null),
+      fetchOpenMeteoAirQuality(lat, lon).catch(() => null),
+      fetchKpIndex(),
     ]);
 
     // ---- Parse Open-Meteo ----
@@ -232,10 +231,13 @@ export async function GET(request: NextRequest) {
         seeing,
         transparency,
         windSpeed: hourly.wind_speed_10m[i],
+        windDirection: hourly.wind_direction_10m[i],
         humidity: hourly.relative_humidity_2m[i],
         temperature: tempC,
         dewpoint: dewpointC,
         dewRisk: getDewRisk(tempC, dewpointC),
+        visibility: hourly.visibility[i],
+        surfacePressure: hourly.surface_pressure[i],
       });
     }
 
@@ -444,6 +446,15 @@ export async function GET(request: NextRequest) {
     }
     const bortleEstimate = estimateBortleClass(population);
 
+    // ---- Sky environment (space weather + aerosols) ----
+    const environment: StargazerEnvironment = {
+      kpIndex: kp.current,
+      kpForecastMax: kp.forecastMax,
+      dust: airQuality?.current?.dust ?? null,
+      pm2_5: airQuality?.current?.pm2_5 ?? null,
+      usAqi: airQuality?.current?.us_aqi ?? null,
+    };
+
     // ---- Build response ----
     const data: StargazerData = {
       score,
@@ -452,6 +463,7 @@ export async function GET(request: NextRequest) {
       limitingFactor,
       darkWindow,
       hourlyConditions,
+      environment,
       moon: moonInfo,
       planets,
       deepSkyHighlights,

--- a/app/stargazer/page.tsx
+++ b/app/stargazer/page.tsx
@@ -348,7 +348,11 @@ function ConditionsPanel({ data }: { data: StargazerData }) {
               )}
             </span>
             <span className="text-[10px] font-mono text-muted-foreground block">
-              {environment?.kpIndex != null && environment.kpIndex >= 5 ? 'aurora possible' : 'geomagnetically quiet'}
+              {environment?.kpIndex == null
+                ? 'data unavailable'
+                : environment.kpIndex >= 5
+                  ? 'aurora possible'
+                  : 'geomagnetically quiet'}
             </span>
           </div>
           <div>

--- a/app/stargazer/page.tsx
+++ b/app/stargazer/page.tsx
@@ -17,6 +17,8 @@ import { ShareButtons } from '@/components/share-buttons';
 import type { StargazerData } from '@/lib/stargazer/types';
 import { getSubScoreLabel } from '@/lib/stargazer/score';
 import { formatTonightDate } from '@/lib/stargazer/bortle';
+import { dewpointSpread } from '@/lib/stargazer/ground';
+import { getCompassDirection } from '@/lib/weather/weather-utils';
 import StargazerNav, { type StargazerTabId } from '@/components/stargazer/StargazerNav';
 import FullHourlyTimeline from '@/components/stargazer/HourlyTimeline';
 import MoonIntel from '@/components/stargazer/MoonIntel';
@@ -214,7 +216,7 @@ function PersistentHeader({ data }: { data: StargazerData }) {
 // ============================================================================
 
 function ConditionsPanel({ data }: { data: StargazerData }) {
-  const { hourlyConditions, bestWindow, darkWindow, moon } = data;
+  const { hourlyConditions, bestWindow, darkWindow, moon, environment } = data;
 
   // Rehydrate dates from JSON serialization
   const conditions = hourlyConditions?.map((h) => ({
@@ -284,16 +286,42 @@ function ConditionsPanel({ data }: { data: StargazerData }) {
                   <span className="text-xl font-bold font-mono">{Math.round(groundConditions.humidity)}%</span>
                 </div>
                 <div>
-                  <span className="text-xs font-mono uppercase text-muted-foreground block">Wind Speed</span>
-                  <span className="text-xl font-bold font-mono">{Math.round(groundConditions.windSpeed)} km/h</span>
+                  <span className="text-xs font-mono uppercase text-muted-foreground block">Wind</span>
+                  <span className="text-xl font-bold font-mono">
+                    {Math.round(groundConditions.windSpeed)} km/h
+                    {groundConditions.windDirection != null && (
+                      <span className="text-sm text-muted-foreground ml-1">{getCompassDirection(groundConditions.windDirection)}</span>
+                    )}
+                  </span>
                 </div>
                 <div>
                   <span className="text-xs font-mono uppercase text-muted-foreground block">Cloud Cover</span>
                   <span className="text-xl font-bold font-mono">{Math.round(groundConditions.cloudCover)}%</span>
                 </div>
                 <div>
+                  <span className="text-xs font-mono uppercase text-muted-foreground block">Dew Point</span>
+                  <span className="text-xl font-bold font-mono">
+                    {Math.round(groundConditions.dewpoint)}&deg;C
+                    <span className="text-sm text-muted-foreground ml-1">
+                      ({dewpointSpread(groundConditions.temperature, groundConditions.dewpoint).toFixed(1)}&deg; spread)
+                    </span>
+                  </span>
+                </div>
+                <div>
                   <span className="text-xs font-mono uppercase text-muted-foreground block">Dew Risk</span>
                   <span className="text-xl font-bold font-mono capitalize">{String(groundConditions.dewRisk)}</span>
+                </div>
+                <div>
+                  <span className="text-xs font-mono uppercase text-muted-foreground block">Visibility</span>
+                  <span className="text-xl font-bold font-mono">
+                    {groundConditions.visibility != null ? `${(groundConditions.visibility / 1000).toFixed(1)} km` : '--'}
+                  </span>
+                </div>
+                <div>
+                  <span className="text-xs font-mono uppercase text-muted-foreground block">Pressure</span>
+                  <span className="text-xl font-bold font-mono">
+                    {groundConditions.surfacePressure != null ? `${Math.round(groundConditions.surfacePressure)} hPa` : '--'}
+                  </span>
                 </div>
                 <div>
                   <span className="text-xs font-mono uppercase text-muted-foreground block">Seeing</span>
@@ -301,6 +329,43 @@ function ConditionsPanel({ data }: { data: StargazerData }) {
                 </div>
               </>
             )}
+          </div>
+        </div>
+      </div>
+
+      {/* Sky environment: space weather + aerosols */}
+      <div className="container-primary p-4 font-mono">
+        <h2 className="border-b border-subtle py-3 mb-3 text-xs font-mono uppercase text-muted-foreground">
+          Sky Environment
+        </h2>
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
+          <div>
+            <span className="text-xs font-mono uppercase text-muted-foreground block">Kp Index</span>
+            <span className="text-xl font-bold font-mono">
+              {environment?.kpIndex != null ? environment.kpIndex.toFixed(1) : '--'}
+              {environment?.kpForecastMax != null && (
+                <span className="text-sm text-muted-foreground ml-1">(max {environment.kpForecastMax.toFixed(1)})</span>
+              )}
+            </span>
+            <span className="text-[10px] font-mono text-muted-foreground block">
+              {environment?.kpIndex != null && environment.kpIndex >= 5 ? 'aurora possible' : 'geomagnetically quiet'}
+            </span>
+          </div>
+          <div>
+            <span className="text-xs font-mono uppercase text-muted-foreground block">Aerosol / Dust</span>
+            <span className="text-xl font-bold font-mono">
+              {environment?.dust != null ? `${Math.round(environment.dust)}` : '--'}
+              <span className="text-sm text-muted-foreground ml-1">&micro;g/m&sup3;</span>
+            </span>
+          </div>
+          <div>
+            <span className="text-xs font-mono uppercase text-muted-foreground block">Air Quality</span>
+            <span className="text-xl font-bold font-mono">
+              {environment?.usAqi != null ? Math.round(environment.usAqi) : '--'}
+              {environment?.pm2_5 != null && (
+                <span className="text-sm text-muted-foreground ml-1">PM2.5 {Math.round(environment.pm2_5)}</span>
+              )}
+            </span>
           </div>
         </div>
       </div>

--- a/components/stargazer/HourlyTimeline.tsx
+++ b/components/stargazer/HourlyTimeline.tsx
@@ -3,6 +3,7 @@
 import { cn } from '@/lib/utils';
 import { useTheme } from '@/components/theme-provider';
 import { getComponentStyles, type ThemeType } from '@/lib/theme-utils';
+import { getCompassDirection } from '@/lib/weather/weather-utils';
 import type { HourlyCondition, DarkWindow } from '@/lib/stargazer/types';
 
 interface HourlyTimelineProps {
@@ -18,9 +19,12 @@ type MetricKey =
   | 'seeing'
   | 'transparency'
   | 'windSpeed'
+  | 'windDirection'
   | 'humidity'
   | 'temperature'
-  | 'dewRisk';
+  | 'dewpoint'
+  | 'dewRisk'
+  | 'visibility';
 
 const metricLabels: Record<MetricKey, string> = {
   cloudCover: 'Cloud Cover',
@@ -30,9 +34,12 @@ const metricLabels: Record<MetricKey, string> = {
   seeing: 'Seeing',
   transparency: 'Transparency',
   windSpeed: 'Wind',
+  windDirection: 'Wind Dir',
   humidity: 'Humidity',
   temperature: 'Temp',
+  dewpoint: 'Dew Point',
   dewRisk: 'Dew Risk',
+  visibility: 'Vis (km)',
 };
 
 function getCellColor(metric: MetricKey, value: number | string): string {
@@ -67,8 +74,22 @@ function getCellColor(metric: MetricKey, value: number | string): string {
     return 'bg-red-600';
   }
 
-  if (metric === 'temperature') {
+  if (metric === 'temperature' || metric === 'dewpoint') {
     return 'bg-blue-600';
+  }
+
+  if (metric === 'windDirection') {
+    // Direction is informational, not good/bad -- keep it neutral.
+    return 'bg-slate-600';
+  }
+
+  if (metric === 'visibility') {
+    // Open-Meteo visibility is in meters; higher is better for imaging.
+    const v = value as number;
+    if (v >= 20000) return 'bg-green-600';
+    if (v >= 10000) return 'bg-yellow-600';
+    if (v >= 5000) return 'bg-orange-600';
+    return 'bg-red-600';
   }
 
   // Cloud cover metrics (lower is better)
@@ -81,8 +102,10 @@ function getCellColor(metric: MetricKey, value: number | string): string {
 
 function formatCellValue(metric: MetricKey, value: number | string): string {
   if (metric === 'dewRisk') return String(value).charAt(0).toUpperCase();
-  if (metric === 'temperature') return `${Math.round(value as number)}°`;
+  if (metric === 'temperature' || metric === 'dewpoint') return `${Math.round(value as number)}°`;
   if (metric === 'windSpeed') return `${Math.round(value as number)}`;
+  if (metric === 'windDirection') return getCompassDirection(value as number);
+  if (metric === 'visibility') return `${Math.round((value as number) / 1000)}`;
   if (metric === 'humidity' || metric.startsWith('cloudCover'))
     return `${Math.round(value as number)}%`;
   return String(Math.round(value as number));
@@ -104,9 +127,12 @@ const metrics: MetricKey[] = [
   'seeing',
   'transparency',
   'windSpeed',
+  'windDirection',
   'humidity',
   'temperature',
+  'dewpoint',
   'dewRisk',
+  'visibility',
 ];
 
 function getScoreRowColor(score: number): string {

--- a/components/stargazer/StargazerAttribution.tsx
+++ b/components/stargazer/StargazerAttribution.tsx
@@ -9,7 +9,9 @@ export default function StargazerAttribution() {
   const styles = getComponentStyles((theme || 'nord') as ThemeType, 'card');
 
   const attributions = [
+    'Weather data by Open-Meteo.com (CC BY 4.0)',
     'Astronomical seeing and transparency data from 7Timer.info',
+    'Space weather (Kp index) from NOAA SWPC',
     'Celestial calculations powered by Astronomy Engine',
     'Launch data from The Space Devs',
     'Satellite tracking data from CelesTrak',

--- a/lib/stargazer/ground.ts
+++ b/lib/stargazer/ground.ts
@@ -1,0 +1,21 @@
+/**
+ * Stargazer - Ground condition helpers
+ *
+ * Pure functions for ground weather readouts. Kept separate from the API route
+ * so they can be unit tested without a fetch.
+ */
+
+export type DewRisk = 'low' | 'moderate' | 'high';
+
+/** Temperature minus dewpoint (both Celsius). Larger spread means lower dew risk. */
+export function dewpointSpread(tempC: number, dewpointC: number): number {
+  return tempC - dewpointC;
+}
+
+/** Classify dew risk from the temperature/dewpoint spread (both Celsius). */
+export function getDewRisk(tempC: number, dewpointC: number): DewRisk {
+  const delta = dewpointSpread(tempC, dewpointC);
+  if (delta < 2) return 'high';
+  if (delta < 5) return 'moderate';
+  return 'low';
+}

--- a/lib/stargazer/space-environment.ts
+++ b/lib/stargazer/space-environment.ts
@@ -69,19 +69,23 @@ export function extractCurrentKp(rows: unknown): number | null {
   return null;
 }
 
-/** Max Kp from a SWPC forecast payload, preferring rows flagged predicted. */
+/**
+ * Max Kp from a SWPC forecast payload, preferring rows flagged predicted and
+ * bounded to the next ~24h (8 rows of 3-hour intervals). Returns null only when
+ * no row yields a numeric Kp; a genuine all-quiet (0) forecast returns 0.
+ */
 export function extractForecastMaxKp(rows: unknown): number | null {
   if (!Array.isArray(rows)) return null;
   const predicted = rows.filter(
     (r) => r && typeof r === 'object' && (r as Record<string, unknown>).observed === 'predicted',
   );
-  const pool = predicted.length > 0 ? predicted : rows;
-  let max = 0;
+  const pool = (predicted.length > 0 ? predicted : rows).slice(0, 8);
+  let max: number | null = null;
   for (const row of pool) {
     const v = parseKpRow(row);
-    if (v != null) max = Math.max(max, v);
+    if (v != null) max = max == null ? v : Math.max(max, v);
   }
-  return max > 0 ? max : null;
+  return max;
 }
 
 /**

--- a/lib/stargazer/space-environment.ts
+++ b/lib/stargazer/space-environment.ts
@@ -1,0 +1,119 @@
+/**
+ * Stargazer - Space environment (geomagnetic) data
+ *
+ * Fetches the planetary Kp index from NOAA SWPC. Kept out of the API route so the
+ * pure parsing logic can be unit tested without a network call.
+ */
+
+import { fetchWithTimeout } from '@/lib/fetch-with-timeout';
+
+const KP_CURRENT_URL =
+  'https://services.swpc.noaa.gov/products/noaa-planetary-k-index.json';
+const KP_FORECAST_URL =
+  'https://services.swpc.noaa.gov/products/noaa-planetary-k-index-forecast.json';
+
+export interface KpReading {
+  /** Most recent observed Kp (0-9), null if unavailable */
+  current: number | null;
+  /** Max expected Kp over the forecast horizon, null if unavailable */
+  forecastMax: number | null;
+}
+
+/**
+ * Pull a numeric Kp value from one row of a NOAA SWPC product. The endpoints have
+ * shipped in two shapes over time: array-of-objects ({ Kp } or { kp }) and the
+ * legacy array-of-arrays ([time_tag, Kp, ...]). Returns null if neither matches.
+ */
+export function parseKpRow(row: unknown): number | null {
+  if (Array.isArray(row)) {
+    const v = parseFloat(String(row[1]));
+    return Number.isNaN(v) ? null : v;
+  }
+  if (row && typeof row === 'object') {
+    const obj = row as Record<string, unknown>;
+    const raw = obj.Kp ?? obj.kp ?? obj.kp_index;
+    if (raw != null) {
+      const v = parseFloat(String(raw));
+      return Number.isNaN(v) ? null : v;
+    }
+  }
+  return null;
+}
+
+/** Pull the time_tag from a SWPC row (array index 0 or object key), or '' if absent. */
+export function parseKpTimeTag(row: unknown): string {
+  if (Array.isArray(row)) {
+    return typeof row[0] === 'string' ? row[0] : '';
+  }
+  if (row && typeof row === 'object') {
+    const tt = (row as Record<string, unknown>).time_tag;
+    return typeof tt === 'string' ? tt : '';
+  }
+  return '';
+}
+
+/** Parse one SWPC row into a { timeTag, kp } entry, or null if it has no numeric Kp. */
+export function parseKpEntry(row: unknown): { timeTag: string; kp: number } | null {
+  const kp = parseKpRow(row);
+  if (kp == null) return null;
+  return { timeTag: parseKpTimeTag(row), kp };
+}
+
+/** Most recent numeric Kp from a SWPC current-index payload, or null. */
+export function extractCurrentKp(rows: unknown): number | null {
+  if (!Array.isArray(rows)) return null;
+  for (let i = rows.length - 1; i >= 0; i--) {
+    const v = parseKpRow(rows[i]);
+    if (v != null) return v;
+  }
+  return null;
+}
+
+/** Max Kp from a SWPC forecast payload, preferring rows flagged predicted. */
+export function extractForecastMaxKp(rows: unknown): number | null {
+  if (!Array.isArray(rows)) return null;
+  const predicted = rows.filter(
+    (r) => r && typeof r === 'object' && (r as Record<string, unknown>).observed === 'predicted',
+  );
+  const pool = predicted.length > 0 ? predicted : rows;
+  let max = 0;
+  for (const row of pool) {
+    const v = parseKpRow(row);
+    if (v != null) max = Math.max(max, v);
+  }
+  return max > 0 ? max : null;
+}
+
+/**
+ * Fetch the current planetary Kp index and the max expected Kp over the next ~24h
+ * from NOAA SWPC. Best-effort: returns nulls on any failure so the page still renders.
+ */
+export async function fetchKpIndex(): Promise<KpReading> {
+  try {
+    const [currentRes, forecastRes] = await Promise.all([
+      fetchWithTimeout(KP_CURRENT_URL, {
+        headers: { Accept: 'application/json' },
+        next: { revalidate: 900 },
+      }).catch(() => null),
+      fetchWithTimeout(KP_FORECAST_URL, {
+        headers: { Accept: 'application/json' },
+        next: { revalidate: 900 },
+      }).catch(() => null),
+    ]);
+
+    let current: number | null = null;
+    if (currentRes && currentRes.ok) {
+      current = extractCurrentKp(await currentRes.json());
+    }
+
+    let forecastMax: number | null = null;
+    if (forecastRes && forecastRes.ok) {
+      forecastMax = extractForecastMaxKp(await forecastRes.json());
+    }
+
+    return { current, forecastMax };
+  } catch (error) {
+    console.error('[Stargazer] Kp index fetch failed:', error);
+    return { current: null, forecastMax: null };
+  }
+}

--- a/lib/stargazer/types.ts
+++ b/lib/stargazer/types.ts
@@ -48,10 +48,16 @@ export interface HourlyCondition {
   seeing: number;
   transparency: number;
   windSpeed: number;
+  /** Ground wind direction in degrees (0-360, meteorological) */
+  windDirection: number;
   humidity: number;
   temperature: number;
   dewpoint: number;
   dewRisk: 'low' | 'moderate' | 'high';
+  /** Horizontal visibility in meters (Open-Meteo) */
+  visibility: number;
+  /** Surface pressure in hPa */
+  surfacePressure: number;
   /** Per-hour composite score (0-100), computed during dark window */
   hourlyScore?: number;
   /** Per-hour sub-scores breakdown */
@@ -260,6 +266,23 @@ export interface LimitingFactor {
 }
 
 // ============================================================================
+// Sky Environment (space weather + aerosols)
+// ============================================================================
+
+export interface StargazerEnvironment {
+  /** Current planetary Kp index (0-9), null if unavailable */
+  kpIndex: number | null;
+  /** Max expected Kp over the next ~24h, null if unavailable */
+  kpForecastMax: number | null;
+  /** Dust concentration in ug/m3, null if unavailable */
+  dust: number | null;
+  /** Fine particulate (PM2.5) in ug/m3, null if unavailable */
+  pm2_5: number | null;
+  /** US Air Quality Index, null if unavailable */
+  usAqi: number | null;
+}
+
+// ============================================================================
 // Consolidated API Response
 // ============================================================================
 
@@ -270,6 +293,7 @@ export interface StargazerData {
   limitingFactor: LimitingFactor | null;
   darkWindow: DarkWindow;
   hourlyConditions: HourlyCondition[];
+  environment: StargazerEnvironment;
   moon: MoonInfo;
   planets: PlanetVisibility[];
   deepSkyHighlights: DeepSkyHighlight[];


### PR DESCRIPTION
First slice of the Stargazer Pro astrophotography upgrade (the "surface what we already have" PR from the saved plan). No new fetch dependencies beyond a single Open-Meteo field; everything else was already fetched and discarded, or comes from existing wrappers/endpoints.

## Changes

**New per-hour data (already fetched, previously discarded)**
- Added `wind_direction_10m` to the existing Open-Meteo request.
- Store `windDirection`, `visibility`, and `surfacePressure` on each hourly condition.

**New data sources (existing wrappers/endpoints)**
- Aerosol/dust + PM2.5 + US AQI via `fetchOpenMeteoAirQuality`.
- Planetary Kp index (current + forecast max) from NOAA SWPC.
- All new fetches are best-effort (fail to null) so the page still renders if any source is down.

**UI**
- Conditions tab Ground Conditions now shows wind direction, numeric dew point + temp/dewpoint spread, visibility, and pressure.
- New Sky Environment card: Kp index, aerosol/dust, air quality.
- Hourly timeline gains Wind Dir, Dew Point, and Visibility rows.
- All styled with the existing terminal tokens.

**Attribution**
- Added the mandatory Open-Meteo CC BY 4.0 line ("Weather data by Open-Meteo.com") plus NOAA SWPC.

**Bug fix (kp-index route)**
- NOAA's planetary K-index products now return an array of objects (`Kp`/`kp` keys), not the legacy array-of-arrays with a header row, so `app/api/space-weather/kp-index` was returning 0. Shared shape-agnostic parsers in `lib/stargazer/space-environment.ts` handle both forms; the route now returns live values.

**Testable extractions**
- `lib/stargazer/ground.ts` (`dewpointSpread`, `getDewRisk`) and `lib/stargazer/space-environment.ts` (Kp fetch + parsers), with Jest coverage.

## Verification
- `npm test -- __tests__/stargazer`: 69 passed.
- `npm run lint`: 0 errors.
- `npm run knip`: clean.
- Live checks: `/api/stargazer` returns populated environment + per-hour fields; `/api/space-weather/kp-index` returns a real current value and forecast (was 0 before).

## Not in this PR
- PR2 (ephemeris: twilight, live sun altitude, moon-altitude curve, usable-window length; 250 hPa jet-stream readout).
- Phase 2 (MSC astro-RDPS seeing/transparency), Phase 3 (VIIRS Bortle, scored go/no-go).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Sky Environment section displaying geomagnetic activity (Kp Index with forecast) and air quality metrics (aerosol, dust, AQI).
  * Enhanced ground weather conditions with wind compass direction, dew point spread, visibility, and surface pressure.
  * Extended hourly timeline with wind direction, dew point, and visibility metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->