### PR TITLE
Fix blog: hero-image fallback for imageless posts and readable titles on light themes

### DIFF
--- a/__tests__/blog-hero.test.ts
+++ b/__tests__/blog-hero.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Tests for blogHeroImage — the hero/banner fallback for posts whose
+ * frontmatter heroImage is empty (regression: the 2026-06-12 biometeorology
+ * post shipped with heroImage "" and the blog rendered without any picture).
+ */
+
+import { blogHeroImage } from '@/lib/blog/hero'
+
+describe('blogHeroImage', () => {
+  it('passes a non-empty frontmatter heroImage through untouched', () => {
+    expect(
+      blogHeroImage({
+        title: 'Any Title',
+        heroImage: 'https://ocean.weather.gov/P_sfc_full_ocean.gif',
+        tags: ['weekly-recap'],
+      })
+    ).toBe('https://ocean.weather.gov/P_sfc_full_ocean.gif')
+  })
+
+  it('falls back to a generated OG banner with the encoded title when heroImage is empty', () => {
+    const url = blogHeroImage({
+      title: "Biometeorology: On April 27, 2012, a thunderstorm rolled through Melbourne's western suburbs",
+      heroImage: '',
+      tags: ['biometeorology', 'weather', 'science'],
+    })
+    expect(url.startsWith('/api/og/blog?title=')).toBe(true)
+    expect(url).toContain(encodeURIComponent('Biometeorology: On April 27'))
+    // 'weather'/'science' map to climate-earth → education accent
+    expect(url).toContain('&type=education')
+  })
+
+  it('maps severe-weather tags to the severe OG accent', () => {
+    const url = blogHeroImage({ title: 'Outbreak', heroImage: '', tags: ['tornadoes'] })
+    expect(url).toContain('&type=severe')
+  })
+
+  it('maps space-weather tags to the space OG accent', () => {
+    const url = blogHeroImage({ title: 'Flare', heroImage: '', tags: ['solar flare'] })
+    expect(url).toContain('&type=space')
+  })
+
+  it('maps weekly-dispatch tags to the dispatch OG accent', () => {
+    const url = blogHeroImage({ title: 'This Week in Weather', heroImage: '', tags: ['weekly-recap', 'roadmap'] })
+    expect(url).toContain('&type=dispatch')
+  })
+
+  it('defaults to education for unmapped tags', () => {
+    const url = blogHeroImage({ title: 'Mystery Topic', heroImage: '', tags: ['something-new'] })
+    expect(url).toContain('&type=education')
+  })
+
+  it('severe wins over space when both categories are tagged (canonical order)', () => {
+    const url = blogHeroImage({ title: 'Sun and Storms', heroImage: '', tags: ['solar flare', 'tornadoes'] })
+    expect(url).toContain('&type=severe')
+  })
+})

--- a/app/blog/[slug]/blog-article.tsx
+++ b/app/blog/[slug]/blog-article.tsx
@@ -13,6 +13,7 @@ import PageWrapper from '@/components/page-wrapper'
 import { ShareButtons } from '@/components/share-buttons'
 import type { BlogPost } from '@/lib/blog'
 import { allowedBlogUrl } from '@/lib/blog/allowed-hosts'
+import { blogHeroImage } from '@/lib/blog/hero'
 import { KeyTerms } from '@/components/blog/key-terms'
 
 interface BlogArticleProps {
@@ -36,20 +37,20 @@ export function BlogArticle({ post, relatedPosts }: BlogArticleProps) {
         {/* Hero image — LCP candidate, priority-loaded.
             unoptimized: heroImage is served by our own /api/og endpoint (already
             a generated image); re-optimizing at build time would require a
-            running server and adds no benefit. */}
-        {post.heroImage && (
-          <div className="relative w-full h-64 sm:h-80 mb-6 rounded-lg overflow-hidden">
-            <Image
-              src={post.heroImage}
-              alt={post.title}
-              fill
-              priority
-              unoptimized
-              sizes="(max-width: 768px) 100vw, 768px"
-              className="object-cover"
-            />
-          </div>
-        )}
+            running server and adds no benefit.
+            blogHeroImage falls back to a generated OG banner when frontmatter
+            heroImage is empty, so this block always renders. */}
+        <div className="relative w-full h-64 sm:h-80 mb-6 rounded-lg overflow-hidden">
+          <Image
+            src={blogHeroImage(post)}
+            alt={post.title}
+            fill
+            priority
+            unoptimized
+            sizes="(max-width: 768px) 100vw, 768px"
+            className="object-cover"
+          />
+        </div>
 
         {/* Back link */}
         <Link
@@ -68,10 +69,12 @@ export function BlogArticle({ post, relatedPosts }: BlogArticleProps) {
           <span>BY {post.author.toUpperCase()}</span>
         </div>
 
-        {/* Title */}
+        {/* Title — text-primary, not themeClasses.accentText: accentText maps
+            to text-primary-foreground, which is the on-primary-button color
+            and blends into the page background (white-on-white in Daybreak). */}
         <h1 className={cn(
           'text-3xl sm:text-4xl font-extrabold font-mono uppercase tracking-tight mb-4',
-          themeClasses.accentText
+          'text-primary'
         )}>
           {post.title}
         </h1>

--- a/app/blog/blog-index.tsx
+++ b/app/blog/blog-index.tsx
@@ -11,6 +11,7 @@ import PageWrapper from '@/components/page-wrapper'
 import { ShareButtons } from '@/components/share-buttons'
 import type { BlogPost } from '@/lib/blog'
 import { getPostCategoryIds, type BlogCategory } from '@/lib/blog/categories'
+import { blogHeroImage } from '@/lib/blog/hero'
 
 const POSTS_PER_PAGE = 10
 
@@ -41,10 +42,13 @@ export function BlogIndex({ posts, categories, initialCategory }: BlogIndexProps
           <p className="text-xs font-mono tracking-widest text-muted-foreground">
             // TRANSMISSION LOG
           </p>
+          {/* text-primary, not themeClasses.accentText: accentText maps to
+              text-primary-foreground (the on-primary-button color), which
+              blends into the page background — white-on-white in Daybreak. */}
           <h1
             className={cn(
               'text-4xl sm:text-5xl md:text-6xl font-extrabold font-mono',
-              themeClasses.accentText,
+              'text-primary',
               themeClasses.glow
             )}
           >
@@ -113,10 +117,14 @@ export function BlogIndex({ posts, categories, initialCategory }: BlogIndexProps
                 'bg-[hsl(var(--card))]'
               )}
             >
-              {feat.heroImage ? (
+              {/* blogHeroImage falls back to a generated OG banner when the
+                  frontmatter heroImage is empty, so the featured card always
+                  has art (the old imageless branch rendered its title in
+                  accentText, which was invisible on light themes). */}
+              {(
                 <div className="relative w-full h-56 sm:h-72 md:h-80">
                   <Image
-                    src={feat.heroImage}
+                    src={blogHeroImage(feat)}
                     alt={feat.title}
                     fill
                     priority
@@ -139,25 +147,6 @@ export function BlogIndex({ posts, categories, initialCategory }: BlogIndexProps
                       <span>|</span>
                       <span>BY {feat.author.toUpperCase()}</span>
                     </div>
-                  </div>
-                </div>
-              ) : (
-                <div className="p-6">
-                  <span className="inline-block px-2 py-0.5 text-xs font-mono uppercase tracking-widest text-[hsl(var(--primary))] border border-[hsl(var(--primary))] rounded mb-3">
-                    FEATURED INTEL
-                  </span>
-                  <h2 className={cn(
-                    'text-2xl sm:text-3xl font-extrabold font-mono uppercase tracking-tight mb-2',
-                    themeClasses.accentText
-                  )}>
-                    {feat.title}
-                  </h2>
-                  <div className="flex items-center gap-2 text-xs font-mono text-muted-foreground tracking-wider mb-3">
-                    <span>{new Date(feat.date).toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' }).toUpperCase()}</span>
-                    <span>|</span>
-                    <span>{feat.readTime} MIN READ</span>
-                    <span>|</span>
-                    <span>BY {feat.author.toUpperCase()}</span>
                   </div>
                 </div>
               )}

--- a/lib/blog/hero.ts
+++ b/lib/blog/hero.ts
@@ -1,0 +1,37 @@
+/**
+ * Hero-image resolution for blog posts.
+ *
+ * Posts are expected to carry a `heroImage` URL in frontmatter, but the
+ * newsletter generator falls back to an empty string when its image catalog
+ * has nothing for a topic (e.g. the 2026-06-12 biometeorology post). An
+ * empty hero used to mean "render no picture at all" — on the index that
+ * left the featured card imageless and dropped its title onto an unstyled
+ * branch. Instead, fall back to the site's own OG-image generator so every
+ * post always has a branded banner.
+ *
+ * Pure module — no `fs`/Node imports — safe for server and client components
+ * (same constraint as ./categories).
+ */
+
+import { getPostCategoryIds } from './categories'
+
+/** Accent types understood by /api/og/blog (see app/api/og/blog/route.tsx). */
+type OgType = 'severe' | 'space' | 'education' | 'record' | 'dispatch'
+
+function ogTypeForTags(tags: string[]): OgType {
+  const categories = getPostCategoryIds(tags)
+  if (categories.includes('severe-weather')) return 'severe'
+  if (categories.includes('space-weather')) return 'space'
+  if (categories.includes('weekly-dispatch')) return 'dispatch'
+  return 'education'
+}
+
+/**
+ * The image to render for a post's hero/banner slots: the frontmatter
+ * `heroImage` when present, otherwise a generated OG banner. Always returns
+ * a non-empty URL.
+ */
+export function blogHeroImage(post: { title: string; heroImage: string; tags: string[] }): string {
+  if (post.heroImage) return post.heroImage
+  return `/api/og/blog?title=${encodeURIComponent(post.title)}&type=${ogTypeForTags(post.tags)}`
+}

--- a/scripts/newsletter/publish.ts
+++ b/scripts/newsletter/publish.ts
@@ -6,6 +6,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import { blogHeroImage } from '@/lib/blog/hero';
 import type { ImageEntry } from './images';
 import type { TopicSlug } from './topics';
 
@@ -58,15 +59,18 @@ export async function publishPost(input: PublishInput, opts: { dryRun?: boolean 
   const datePrefix = isoDate.slice(0, 10);
 
   const { title, summary, slug } = buildHeader(input, datePrefix);
+  const tags = buildTags(input);
   // Hero is the page banner — should never be archival imagery presented
-  // without context. Prefer live > reference > archival, falling back to
-  // first image if every option is somehow archival.
+  // without context. Prefer live > reference > archival, then first image.
+  // When the catalog produced no images at all (a topic with no entries —
+  // the 2026-06-12 biometeorology post shipped with heroImage "" and the
+  // blog rendered without any picture), fall back to a generated OG banner
+  // so a post never publishes imageless.
   const heroImage =
     input.images.find((i) => i.kind === 'live')?.url ??
     input.images.find((i) => (i.kind ?? 'reference') === 'reference')?.url ??
     input.images[0]?.url ??
-    '';
-  const tags = buildTags(input);
+    blogHeroImage({ title, heroImage: '', tags });
 
   const frontmatterFields: Record<string, unknown> = {
     slug,


### PR DESCRIPTION
## Problem

After merging #437 (the biometeorology post), the blog rendered with no pictures and near-invisible titles:

1. The post's frontmatter has `heroImage: ""` — the newsletter generator's image catalog had no entries for the topic, and `publishPost` falls back to an empty string. The featured index card and the article page only rendered a hero when `heroImage` was truthy, so the most prominent blog surfaces showed no picture at all.
2. Blog titles (the WEATHER BLOG heading, the featured card's imageless branch, and the article h1) used `themeClasses.accentText`, which maps to `text-primary-foreground` — the color for text **on** primary-colored buttons. On Daybreak (the guest default theme) that is white-on-white; in dark themes it is dark-on-dark. Only elements using that token were affected, which is why body text looked fine.

## Fix

- `lib/blog/hero.ts` (new): `blogHeroImage()` returns the frontmatter `heroImage`, or falls back to a generated `/api/og/blog` banner with the accent type derived from the post's category tags (severe/space/dispatch/education). Pure module, mirrors `lib/blog/categories.ts`.
- Article hero and the featured index card now always render a banner via the helper; the featured card's imageless branch (with its unreadable title) is deleted.
- `scripts/newsletter/publish.ts` uses the same helper for its empty-catalog fallback, so a post can never publish imageless again.
- Blog titles switched from `themeClasses.accentText` to `text-primary`, which tracks each theme's accent and is readable against the page background everywhere.

## Verification

- 7 new unit tests for `blogHeroImage` (passthrough, encoding, all four accent mappings, canonical-order tie-break); full suite 589/589
- `tsc --noEmit` and ESLint clean
- Verified in the browser: blog index and article render the generated banner and readable titles on `daybreak`; title color resolves to bright green on `matrix` and light cyan on `dark`

## Notes

- `generateMetadata` already always used the OG endpoint for social images, so share cards were never affected.
- The deeper generator question — why the image catalog had zero entries for the biometeorology topic — is left for the newsletter pipeline; with the fallback in place an empty catalog is now cosmetic-only.
- `lib/theme-utils.ts`'s global `accentText: 'text-primary-foreground'` mapping is unchanged: other call sites pair it with `accentBg` (`bg-primary`) where it is correct. Auditing those is out of scope here.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Blog posts without custom hero images now automatically generate branded fallback images featuring the post title and category-specific styling.
  * Generated images ensure consistent visual presentation across all blog content.

* **Tests**
  * Added comprehensive test suite for hero image generation logic, covering fallback scenarios and category-based image type mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->