### PR TITLE
Fix NWS news cards downloading CAP XML instead of opening alert pages

### DIFF
--- a/__tests__/rss-aggregator.test.ts
+++ b/__tests__/rss-aggregator.test.ts
@@ -153,6 +153,24 @@ describe('parseAtomFeed', () => {
     const [it] = parseAtomFeed(xml, source({ category: 'severe', format: 'atom' }));
     expect(it.url).toBe('https://www.example.com/human');
   });
+
+  it('maps NWS CAP alert links to readable forecast product pages', () => {
+    const xml = `<feed xmlns="http://www.w3.org/2005/Atom" xmlns:cap="urn:oasis:names:tc:emergency:cap:1.2"><entry>
+      <title>Flash Flood Warning issued by NWS Austin/San Antonio TX</title>
+      <link rel="alternate" href="https://api.weather.gov/alerts/urn:oid:test-alert.cap" />
+      <summary>Flash flooding is ongoing.</summary>
+      <updated>2026-06-15T13:42:00Z</updated>
+      <cap:parameter>
+        <valueName>AWIPSidentifier</valueName>
+        <value>FFWEWX</value>
+      </cap:parameter>
+    </entry></feed>`;
+
+    const [it] = parseAtomFeed(xml, source({ id: 'nws-alerts', category: 'severe', format: 'atom' }));
+    expect(it.url).toBe(
+      'https://forecast.weather.gov/product.php?site=NWS&issuedby=EWX&product=FFW&format=CI&version=1&glossary=0'
+    );
+  });
 });
 
 describe('parseJsonFeed (USGS elevated volcanoes)', () => {

--- a/lib/services/rss/rssAggregator.ts
+++ b/lib/services/rss/rssAggregator.ts
@@ -247,6 +247,38 @@ function atomLinkHref(node: XmlNode): string | undefined {
   return nodeText(chosen['@_href']) ?? nodeText(chosen.href);
 }
 
+/** Read a named CAP parameter from an NWS alert Atom entry. */
+function capParameterValue(node: XmlNode, name: string): string | undefined {
+  const parameter = asArray(node['cap:parameter']).find((parameter) => {
+    return nodeText(parameter.valueName) === name;
+  });
+  return parameter ? nodeText(parameter.value) : undefined;
+}
+
+/**
+ * The NWS active-alerts Atom feed marks CAP XML documents as rel="alternate".
+ * Those are machine-readable alert payloads and can download in browsers. When
+ * possible, route readers to the public forecast.weather.gov text product page.
+ */
+function nwsAlertReadableUrl(entry: XmlNode, fallbackUrl: string | undefined): string | undefined {
+  if (!fallbackUrl?.endsWith('.cap')) return fallbackUrl;
+
+  const awipsIdentifier = capParameterValue(entry, 'AWIPSidentifier');
+  const match = awipsIdentifier?.trim().match(/^([A-Z0-9]{3})([A-Z0-9]{3,4})$/i);
+  if (!match) return 'https://www.weather.gov/alerts';
+
+  const [, product, issuedBy] = match;
+  const params = new URLSearchParams({
+    site: 'NWS',
+    issuedby: issuedBy.toUpperCase(),
+    product: product.toUpperCase(),
+    format: 'CI',
+    version: '1',
+    glossary: '0',
+  });
+  return `https://forecast.weather.gov/product.php?${params.toString()}`;
+}
+
 // Hosts that serve players/embeds, not images. A feed's media:content can
 // point at a YouTube embed (medium="video"); shoved into <img> the browser
 // blocks it (ERR_BLOCKED_BY_ORB) and the card flashes a broken image.
@@ -419,7 +451,8 @@ function parseAtomFeed(xml: string, source: FeedSource): RSSItem[] {
     const entry = entries[i];
     try {
       const title = firstText(entry, ['title']);
-      const link = atomLinkHref(entry) ?? firstText(entry, ['id']);
+      const rawLink = atomLinkHref(entry) ?? firstText(entry, ['id']);
+      const link = source.id === 'nws-alerts' ? nwsAlertReadableUrl(entry, rawLink) : rawLink;
       const summary = firstText(entry, ['summary', 'content']);
 
       // Author lives in a nested <author><name>…</name></author>.


### PR DESCRIPTION
## Summary
- Map NWS severe alert cards from machine-readable `.cap` URLs to readable `forecast.weather.gov` text product pages.
- Derive the destination from each alert's `AWIPSidentifier` metadata, with a weather.gov alerts fallback when parsing fails.
- Add RSS aggregator regression coverage so future feed/parser changes do not reintroduce CAP download links.

## Test plan
- [x] `npm test -- rss-aggregator.test.ts`
- [x] `npm run typecheck`
- [x] `npx playwright test tests/e2e/news.spec.ts --project=chromium`
- [ ] After deploy, click a severe alert on https://www.16bitweather.co/news and confirm it opens a forecast.weather.gov product page instead of downloading XML


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved NWS alert links to display more readable forecast URLs instead of raw feed entries.

* **Tests**
  * Added unit test coverage for CAP alert Atom feed parsing and URL conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->