### PR TITLE
feat(radar): North America radar modernization

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The site targets learners and hobbyists who want accurate data without a generic
 - **Tropical tracker**: NHC 2-day and 7-day outlooks, Atlantic satellite imagery, and sea surface temperature analysis
 - **Aviation weather**: SIGMETs, AIRMETs, turbulence maps, and real-time flight conditions in a terminal-style interface
 - **Learn Hub**: Cloud types, weather systems, extreme phenomena, fun facts, and a weather glossary
-- **Interactive radar**: Map-based NOAA MRMS radar with precipitation overlays
+- **Interactive radar**: North America radar with NOAA/Iowa NEXRAD, MSC GeoMet, RainViewer fallback, and severe weather overlays
 - **Global extremes**: Hot and cold location tracking with live data
 - **Custom themes**: Twelve themes with persistence for signed-in users
 - **Weather Arcade**: Educational games with score tracking

--- a/__tests__/radar-metadata-route.test.ts
+++ b/__tests__/radar-metadata-route.test.ts
@@ -1,0 +1,56 @@
+jest.mock('next/server', () => ({
+  NextRequest: class MockNextRequest {
+    url: string
+    nextUrl: { searchParams: URLSearchParams }
+
+    constructor(url: string) {
+      this.url = url
+      this.nextUrl = { searchParams: new URL(url).searchParams }
+    }
+  },
+  NextResponse: {
+    json: jest.fn((body: unknown, init?: { status?: number; headers?: Record<string, string> }) => ({
+      status: init?.status || 200,
+      headers: init?.headers || {},
+      json: async () => body,
+    })),
+  },
+}))
+
+import { GET } from '@/app/api/radar/metadata/route'
+import { NextRequest } from 'next/server'
+
+describe('GET /api/radar/metadata', () => {
+  it('returns 400 when coordinates are missing', async () => {
+    const res = await GET(new NextRequest('http://localhost/api/radar/metadata'))
+
+    expect(res.status).toBe(400)
+    await expect(res.json()).resolves.toEqual({ error: 'Missing required parameters: lat, lon' })
+  })
+
+  it('returns 400 when coordinates are invalid', async () => {
+    const res = await GET(new NextRequest('http://localhost/api/radar/metadata?lat=91&lon=-75'))
+
+    expect(res.status).toBe(400)
+    await expect(res.json()).resolves.toEqual({ error: 'Coordinates out of valid range' })
+  })
+
+  it('returns US radar metadata with fallback provider', async () => {
+    const res = await GET(new NextRequest('http://localhost/api/radar/metadata?lat=40.7128&lon=-74.006'))
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.selectedProvider.id).toBe('noaa-mrms')
+    expect(body.fallbackProvider.id).toBe('iowa-nexrad')
+    expect(body.frames.length).toBeGreaterThan(0)
+    expect(res.headers['Cache-Control']).toContain('s-maxage=120')
+  })
+
+  it('returns Canada radar metadata', async () => {
+    const res = await GET(new NextRequest('http://localhost/api/radar/metadata?lat=53.5461&lon=-113.4938'))
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.selectedProvider.id).toBe('canada-geomet')
+  })
+})

--- a/__tests__/radar-providers.test.ts
+++ b/__tests__/radar-providers.test.ts
@@ -1,0 +1,44 @@
+import {
+  buildRadarMetadata,
+  getRadarCoverageRegion,
+  selectRadarProvider,
+} from '@/lib/radar'
+
+describe('radar providers', () => {
+  const now = Date.UTC(2026, 5, 18, 21, 40, 0)
+
+  it('selects NOAA MRMS with Iowa fallback for US locations', () => {
+    const selection = selectRadarProvider(40.7128, -74.006)
+
+    expect(selection.selectedProvider.id).toBe('noaa-mrms')
+    expect(selection.fallbackProvider?.id).toBe('iowa-nexrad')
+  })
+
+  it('selects MSC GeoMet with RainViewer fallback for Canada locations', () => {
+    const selection = selectRadarProvider(53.5461, -113.4938)
+
+    expect(selection.selectedProvider.id).toBe('canada-geomet')
+    expect(selection.fallbackProvider?.id).toBe('rainviewer')
+  })
+
+  it('selects RainViewer fallback for Mexico and broader North America', () => {
+    expect(getRadarCoverageRegion(19.4326, -99.1332)).toBe('north-america-fallback')
+    expect(selectRadarProvider(19.4326, -99.1332).selectedProvider.id).toBe('rainviewer')
+  })
+
+  it('uses RainViewer as a degraded global fallback outside North America', () => {
+    expect(getRadarCoverageRegion(51.5072, -0.1276)).toBe('global')
+    expect(selectRadarProvider(51.5072, -0.1276).selectedProvider.id).toBe('rainviewer')
+  })
+
+  it('builds metadata with provider-specific frame windows', () => {
+    const us = buildRadarMetadata(40.7128, -74.006, now)
+    const canada = buildRadarMetadata(53.5461, -113.4938, now)
+
+    expect(us.selectedProvider.id).toBe('noaa-mrms')
+    expect(us.frames).toHaveLength(49)
+    expect(canada.selectedProvider.id).toBe('canada-geomet')
+    expect(canada.frames).toHaveLength(31)
+    expect(canada.legend[0].value).toContain('dBZ')
+  })
+})

--- a/__tests__/radar-timestamps.test.ts
+++ b/__tests__/radar-timestamps.test.ts
@@ -1,0 +1,42 @@
+import {
+  buildRadarFrames,
+  normalizeRadarPastMinutes,
+  normalizeRadarStepMinutes,
+} from '@/lib/radar/radar-timestamps'
+
+describe('radar timestamps', () => {
+  const now = Date.UTC(2026, 5, 18, 21, 43, 22)
+
+  it('builds finite ordered frames quantized to the provider step', () => {
+    const frames = buildRadarFrames({ now, stepMinutes: 5, pastMinutes: 15 })
+
+    expect(frames).toHaveLength(4)
+    expect(frames[0].isoTime).toBe('2026-06-18T21:25:00.000Z')
+    expect(frames[3].isoTime).toBe('2026-06-18T21:40:00.000Z')
+    expect(frames[3].isLive).toBe(true)
+    expect(frames.every((frame) => Number.isFinite(frame.timestamp))).toBe(true)
+  })
+
+  it('sanitizes invalid step and history inputs', () => {
+    expect(normalizeRadarStepMinutes(0)).toBe(5)
+    expect(normalizeRadarStepMinutes(Number.NaN)).toBe(5)
+    expect(normalizeRadarPastMinutes(-1)).toBe(240)
+    expect(normalizeRadarPastMinutes(Number.POSITIVE_INFINITY)).toBe(240)
+
+    const frames = buildRadarFrames({
+      now,
+      stepMinutes: Number.NaN,
+      pastMinutes: Number.NaN,
+    })
+
+    expect(frames).toHaveLength(49)
+    expect(frames.every((frame) => Number.isFinite(frame.timestamp))).toBe(true)
+  })
+
+  it('honors explicit pastSteps when provided', () => {
+    const frames = buildRadarFrames({ now, stepMinutes: 10, pastSteps: 2 })
+
+    expect(frames).toHaveLength(3)
+    expect(frames.map((frame) => frame.offsetMinutes)).toEqual([-20, -10, 0])
+  })
+})

--- a/__tests__/radar-url-state.test.ts
+++ b/__tests__/radar-url-state.test.ts
@@ -1,0 +1,72 @@
+import {
+  DEFAULT_RADAR_LAYERS,
+  DEFAULT_RADAR_ZOOM,
+  mergeRadarUrlParams,
+  parseRadarUrlState,
+  serializeRadarUrlParams,
+} from '@/lib/radar/radar-url-state'
+
+describe('radar-url-state', () => {
+  it('returns defaults when radar params are absent', () => {
+    expect(parseRadarUrlState(new URLSearchParams('location=Chicago'))).toEqual({
+      layers: DEFAULT_RADAR_LAYERS,
+      frameIndex: null,
+      zoom: null,
+    })
+  })
+
+  it('parses custom layers, frame, and zoom', () => {
+    const parsed = parseRadarUrlState(new URLSearchParams('layers=precip,spc&frame=12&zoom=8'))
+    expect(parsed.layers).toEqual({
+      precipitation: true,
+      alerts: false,
+      spc: true,
+      stormReports: false,
+    })
+    expect(parsed.frameIndex).toBe(12)
+    expect(parsed.zoom).toBe(8)
+  })
+
+  it('omits default radar params when serializing', () => {
+    const params = serializeRadarUrlParams({
+      layers: DEFAULT_RADAR_LAYERS,
+      frameIndex: 48,
+      zoom: DEFAULT_RADAR_ZOOM,
+      frameCount: 49,
+    })
+
+    expect(params.get('layers')).toBeNull()
+    expect(params.get('zoom')).toBeNull()
+    expect(params.get('frame')).toBeNull()
+  })
+
+  it('serializes non-default layers, zoom, and historical frame', () => {
+    const params = serializeRadarUrlParams({
+      layers: {
+        precipitation: true,
+        alerts: false,
+        spc: true,
+        stormReports: false,
+      },
+      frameIndex: 10,
+      zoom: 7,
+      frameCount: 49,
+    })
+
+    expect(params.get('layers')).toBe('precip,spc')
+    expect(params.get('zoom')).toBe('7')
+    expect(params.get('frame')).toBe('10')
+  })
+
+  it('merges radar params without dropping location params', () => {
+    const existing = new URLSearchParams('location=Chicago&lat=41.88&lon=-87.63')
+    const radarParams = new URLSearchParams('layers=precip,spc&frame=3&zoom=9')
+    const merged = mergeRadarUrlParams(existing, radarParams)
+
+    expect(merged.get('location')).toBe('Chicago')
+    expect(merged.get('lat')).toBe('41.88')
+    expect(merged.get('layers')).toBe('precip,spc')
+    expect(merged.get('frame')).toBe('3')
+    expect(merged.get('zoom')).toBe('9')
+  })
+})

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -47,7 +47,7 @@ function Accordion({ title, icon: Icon, children, defaultOpen = false }: {
 }
 
 const modules = [
-  { href: "/radar", label: "Radar", desc: "Real-time NOAA MRMS radar with animated playback", icon: Map },
+  { href: "/radar", label: "Radar", desc: "North America radar with NWS alerts, SPC outlooks, and provider fallback", icon: Map },
   { href: "/warnings", label: "Warnings Command Center", desc: "Live NWS alerts with WIS score, SPC outlook, alert polygons, and storm reports", icon: AlertTriangle },
   { href: "/severe", label: "Severe Weather", desc: "Active tornado, thunderstorm, and flood warnings", icon: CloudLightning },
   { href: "/travel", label: "Travel Hub", desc: "Will your trip suck? Airport delay risk, road conditions, and a personal trip score for fly or drive", icon: Route },
@@ -155,7 +155,7 @@ export default function AboutPage() {
                   { icon: Database, label: "DATA LAYER", value: "Supabase PostgreSQL + Row-Level Security" },
                   { icon: CloudLightning, label: "WEATHER DATA", value: "OpenWeatherMap + NOAA + NWS + USGS + NASA" },
                   { icon: Sparkles, label: "AI ENGINE", value: "Vercel AI SDK + Claude (Anthropic)" },
-                  { icon: Globe, label: "RADAR", value: "NOAA MRMS + Iowa NEXRAD via OpenLayers" },
+                  { icon: Globe, label: "RADAR", value: "NOAA/Iowa NEXRAD + MSC GeoMet + RainViewer fallback" },
                   { icon: Gauge, label: "MONITORING", value: "Sentry + Lighthouse CI (score >= 85)" },
                   { icon: Gamepad2, label: "AESTHETIC", value: "Tailwind CSS v4 + 5 retro themes" },
                   { icon: Shield, label: "DEPLOYMENT", value: "Vercel Edge + GitHub Actions CI/CD" },

--- a/app/api/radar/metadata/route.ts
+++ b/app/api/radar/metadata/route.ts
@@ -1,0 +1,44 @@
+import type { NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
+import { buildRadarMetadata } from '@/lib/radar'
+
+function parseCoordinate(value: string | null): number | null {
+  if (value == null || value.trim() === '') return null
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const lat = parseCoordinate(request.nextUrl.searchParams.get('lat'))
+    const lon = parseCoordinate(request.nextUrl.searchParams.get('lon'))
+
+    if (lat == null || lon == null) {
+      return NextResponse.json(
+        { error: 'Missing required parameters: lat, lon' },
+        { status: 400 }
+      )
+    }
+
+    if (lat < -90 || lat > 90 || lon < -180 || lon > 180) {
+      return NextResponse.json(
+        { error: 'Coordinates out of valid range' },
+        { status: 400 }
+      )
+    }
+
+    const metadata = buildRadarMetadata(lat, lon)
+
+    return NextResponse.json(metadata, {
+      headers: {
+        'Cache-Control': 'public, s-maxage=120, stale-while-revalidate=60',
+      },
+    })
+  } catch (error) {
+    console.error('[radar-metadata]', error)
+    return NextResponse.json(
+      { error: 'Failed to build radar metadata' },
+      { status: 500 }
+    )
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -74,7 +74,7 @@ const jsonLd = {
   featureList: [
     'Real-time weather data',
     '7-day weather forecast',
-    'NOAA MRMS weather radar',
+    'North America weather radar',
     'Air quality index',
     'Pollen count',
     'UV index',

--- a/app/radar/layout.tsx
+++ b/app/radar/layout.tsx
@@ -1,6 +1,6 @@
 /**
  * 16-Bit Weather Platform - Radar Page Layout
- * SEO metadata for NOAA MRMS weather radar
+ * SEO metadata for North America weather radar
  */
 
 import type { Metadata } from 'next'
@@ -12,7 +12,7 @@ const radarJsonLd = {
   "@context": "https://schema.org",
   "@type": "WebApplication",
   "name": "Live Weather Radar",
-  "description": "Real-time NOAA MRMS weather radar with precipitation overlays.",
+  "description": "North America weather radar with animated precipitation and severe weather overlays.",
   "url": "https://www.16bitweather.co/radar",
   "applicationCategory": "WeatherApplication",
   "operatingSystem": "Any",
@@ -24,17 +24,17 @@ const radarJsonLd = {
 }
 
 export const metadata: Metadata = {
-  title: 'Live Weather Radar Map - NOAA MRMS Radar | 16 Bit Weather',
-  description: 'Real-time NOAA MRMS weather radar with high-resolution precipitation tracking. View live rain, snow, and storm data across the United States in retro terminal style.',
-  keywords: 'weather radar, NOAA radar, MRMS radar, live radar, precipitation map, rain radar, storm tracker, doppler radar, US weather radar, real-time radar',
+  title: 'Live Weather Radar Map - North America Radar | 16 Bit Weather',
+  description: 'Animated North America weather radar with NOAA, Iowa NEXRAD, MSC GeoMet, RainViewer fallback, NWS alerts, SPC outlooks, and storm report overlays.',
+  keywords: 'weather radar, NOAA radar, MRMS radar, NEXRAD radar, Canada radar, RainViewer radar, live radar, precipitation map, rain radar, storm tracker, doppler radar, severe weather radar',
   openGraph: {
     title: 'Live Weather Radar - 16 Bit Weather',
-    description: 'Real-time NOAA MRMS weather radar with high-resolution precipitation tracking across the US.',
+    description: 'Animated North America weather radar with severe weather overlays and provider fallback.',
     url: 'https://www.16bitweather.co/radar',
     siteName: '16 Bit Weather',
     images: [
       {
-        url: '/api/og?title=Live+Weather+Radar&subtitle=NOAA+MRMS+Precipitation+Map',
+        url: '/api/og?title=Live+Weather+Radar&subtitle=North+America+Radar+And+Alerts',
         width: 1200,
         height: 630,
         alt: 'Live Weather Radar - 16 Bit Weather',
@@ -46,8 +46,8 @@ export const metadata: Metadata = {
   twitter: {
     card: 'summary_large_image',
     title: 'Live Weather Radar - 16 Bit Weather',
-    description: 'Real-time NOAA MRMS weather radar with precipitation tracking',
-    images: ['/api/og?title=Live+Weather+Radar&subtitle=NOAA+MRMS+Precipitation+Map'],
+    description: 'Animated North America radar with severe weather overlays',
+    images: ['/api/og?title=Live+Weather+Radar&subtitle=North+America+Radar+And+Alerts'],
   },
   alternates: {
     canonical: 'https://www.16bitweather.co/radar',

--- a/app/radar/page.tsx
+++ b/app/radar/page.tsx
@@ -74,13 +74,15 @@ export default function MapPage() {
 
   const shareUrl = useMemo(() => {
     if (!weatherData) return 'https://www.16bitweather.co/radar'
-    const params = new URLSearchParams({ location: weatherData.location })
+
+    const params = new URLSearchParams(searchParams.toString())
+    params.set('location', weatherData.location)
     if (weatherData.coordinates) {
       params.set('lat', String(weatherData.coordinates.lat))
       params.set('lon', String(weatherData.coordinates.lon))
     }
     return `https://www.16bitweather.co/radar?${params.toString()}`
-  }, [weatherData])
+  }, [weatherData, searchParams])
 
   const handleRadarSearch = (location: string) => {
     const trimmed = location.trim()

--- a/app/radar/page.tsx
+++ b/app/radar/page.tsx
@@ -10,18 +10,18 @@
  * See LICENSE file for full terms
  */
 
-import { useEffect, useState } from 'react'
-import { useSearchParams } from 'next/navigation'
+import { useEffect, useMemo, useState } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
 import dynamicImport from 'next/dynamic'
 import Link from 'next/link'
-import { Home, Map as MapIcon, Share2 } from 'lucide-react'
+import { Home, Map as MapIcon } from 'lucide-react'
 import { useLocationContext } from '@/components/location-context'
-import { userCacheService } from '@/lib/user-cache-service'
 import type { WeatherData } from '@/lib/types'
 import { useTheme } from '@/components/theme-provider'
 import { fetchWeatherData } from '@/lib/weather'
 import Navigation from '@/components/navigation'
-import { ShareButtons } from '@/components/share-buttons';
+import { ShareButtons } from '@/components/share-buttons'
+import WeatherSearch from '@/components/weather-search'
 
 const WeatherMap = dynamicImport(() => import('@/components/weather-map'), {
   ssr: false,
@@ -36,13 +36,14 @@ const WeatherMap = dynamicImport(() => import('@/components/weather-map'), {
 })
 
 export default function MapPage() {
+  const router = useRouter()
   const searchParams = useSearchParams()
   const urlLocation = searchParams.get('location')
   const { currentLocation } = useLocationContext()
   const { theme } = useTheme()
   const [weatherData, setWeatherData] = useState<WeatherData | null>(null)
   const [isLoading, setIsLoading] = useState(true)
-  const [shareSuccess, setShareSuccess] = useState(false)
+  const [searchError, setSearchError] = useState<string | undefined>()
 
   // Priority: URL location > context location
   const targetLocation = urlLocation || currentLocation
@@ -55,7 +56,7 @@ export default function MapPage() {
       if (targetLocation) {
         try {
           const freshData = await fetchWeatherData(targetLocation, 'imperial')
-          if (freshData?.coordinates?.lat && freshData?.coordinates?.lon) {
+          if (freshData?.coordinates?.lat != null && freshData?.coordinates?.lon != null) {
             setWeatherData(freshData)
             setIsLoading(false)
             return
@@ -71,32 +72,24 @@ export default function MapPage() {
     loadWeatherData()
   }, [targetLocation, urlLocation])
 
-  // Share location handler
-  const handleShare = async () => {
-    if (!weatherData) return
-
-    // Coordinates may be intentionally omitted from cached weather data (privacy / CodeQL).
-    // Only include them in the share URL if present.
-    const shareUrl = weatherData.coordinates
-      ? `${window.location.origin}/map?lat=${weatherData.coordinates.lat}&lon=${weatherData.coordinates.lon}`
-      : `${window.location.origin}/map`
-
-    try {
-      if (navigator.share) {
-        await navigator.share({
-          title: `Weather Radar - ${weatherData.location}`,
-          text: `Check out the weather radar for ${weatherData.location}`,
-          url: shareUrl
-        })
-      } else {
-        // Fallback: copy to clipboard
-        await navigator.clipboard.writeText(shareUrl)
-        setShareSuccess(true)
-        setTimeout(() => setShareSuccess(false), 2000)
-      }
-    } catch (error) {
-      console.error('Share failed:', error)
+  const shareUrl = useMemo(() => {
+    if (!weatherData) return 'https://www.16bitweather.co/radar'
+    const params = new URLSearchParams({ location: weatherData.location })
+    if (weatherData.coordinates) {
+      params.set('lat', String(weatherData.coordinates.lat))
+      params.set('lon', String(weatherData.coordinates.lon))
     }
+    return `https://www.16bitweather.co/radar?${params.toString()}`
+  }, [weatherData])
+
+  const handleRadarSearch = (location: string) => {
+    const trimmed = location.trim()
+    if (!trimmed) {
+      setSearchError('Enter a location to load radar.')
+      return
+    }
+    setSearchError(undefined)
+    router.push(`/radar?location=${encodeURIComponent(trimmed)}`)
   }
 
   if (isLoading) {
@@ -124,10 +117,8 @@ export default function MapPage() {
   }
 
   // Check if we have valid coordinates for the radar
-  const hasValidCoordinates = weatherData?.coordinates?.lat &&
-    weatherData?.coordinates?.lon &&
-    weatherData.coordinates.lat !== 0 &&
-    weatherData.coordinates.lon !== 0
+  const hasValidCoordinates = weatherData?.coordinates?.lat != null &&
+    weatherData?.coordinates?.lon != null
 
   if (!weatherData) {
     return (
@@ -147,15 +138,14 @@ export default function MapPage() {
           <div className="text-white text-center max-w-md px-4">
             <div className="text-xl mb-4 font-mono">NO LOCATION DATA</div>
             <div className="text-sm text-gray-400 mb-6">
-              Search for a location on the home page first to view its weather map.
+              Search for a location to view North America radar and severe weather overlays.
             </div>
-            <Link
-              href="/"
-              className="inline-flex items-center gap-2 text-sm font-mono px-4 py-2 border-2 border-cyan-500 text-cyan-400 hover:bg-cyan-500 hover:text-black transition-colors rounded"
-            >
-              <Home className="w-4 h-4" />
-              Return to Home & Search
-            </Link>
+            <WeatherSearch
+              onSearch={handleRadarSearch}
+              isLoading={isLoading}
+              error={searchError}
+              hideLocationButton
+            />
           </div>
         </div>
       </div>
@@ -209,8 +199,8 @@ export default function MapPage() {
       <Navigation />
 
       {/* Breadcrumb Header */}
-      <div className="p-3 bg-gray-900 border-b border-gray-700 flex items-center justify-between">
-        <div className="flex items-center gap-3">
+      <div className="p-3 bg-gray-900 border-b border-gray-700 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+        <div className="flex flex-wrap items-center gap-3">
           <Link href="/" className="inline-flex items-center gap-2 text-xs font-mono px-3 py-1.5 border-2 border-gray-600 hover:bg-gray-700 transition-colors rounded" aria-label="Return to Home">
             <Home className="w-3 h-3" />
             HOME
@@ -226,19 +216,30 @@ export default function MapPage() {
           )}
         </div>
 
+        <div className="w-full max-w-xl lg:flex-1">
+          <WeatherSearch
+            onSearch={handleRadarSearch}
+            isLoading={isLoading}
+            error={searchError}
+            hideLocationButton
+          />
+        </div>
+
         {/* Share Buttons */}
         <ShareButtons
           config={{
-            title: 'Live Weather Radar',
-            text: 'Live NOAA MRMS weather radar at 16bitweather.co',
-            url: 'https://www.16bitweather.co/radar',
+            title: weatherData.location ? `Live Weather Radar - ${weatherData.location}` : 'Live Weather Radar',
+            text: weatherData.location
+              ? `Live radar and severe weather overlays for ${weatherData.location}`
+              : 'Live North America radar and severe weather overlays at 16bitweather.co',
+            url: shareUrl,
           }}
+          className="justify-end"
         />
       </div>
 
-      {/* Map Container - explicit height for full-screen map page */}
-      {/* Note: Using explicit h-[calc(...)] class instead of flex-1 + inline style to ensure height propagates correctly */}
-      <div className="h-[calc(100vh-120px)] min-h-[400px] overflow-visible">
+      {/* Map Container */}
+      <div className="flex-1 min-h-[500px] overflow-visible">
         <WeatherMap
           latitude={weatherData.coordinates!.lat}
           longitude={weatherData.coordinates!.lon}

--- a/components/weather-map-openlayers.tsx
+++ b/components/weather-map-openlayers.tsx
@@ -4,9 +4,19 @@
 // Phase 2: CartoDB Dark Matter base map, precipitation legend, pulse marker animation
 
 import { useEffect, useRef, useState, useMemo, useCallback } from 'react'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import { Play, Pause, SkipBack, SkipForward, Layers, ChevronDown, Loader2 } from 'lucide-react'
 import type { ThemeType } from '@/lib/theme-config'
-import type { RadarFrame, RadarMetadata, RadarProvider } from '@/lib/radar'
+import {
+  buildRadarFrames,
+  DEFAULT_RADAR_ZOOM,
+  mergeRadarUrlParams,
+  parseRadarUrlState,
+  serializeRadarUrlParams,
+  type RadarFrame,
+  type RadarMetadata,
+  type RadarProvider,
+} from '@/lib/radar'
 
 // OpenLayers imports
 import 'ol/ol.css'
@@ -28,6 +38,8 @@ import type { FeatureLike } from 'ol/Feature'
 const TILE_TRANSITION_MS = 500 // Smooth crossfade between frames
 const BASE_ANIMATION_INTERVAL_MS = 500 // Fluid playback speed
 const PRELOAD_FRAMES_AHEAD = 3 // Number of frames to preload during playback
+const TILE_ERROR_FALLBACK_THRESHOLD = 5
+const URL_SYNC_DEBOUNCE_MS = 300
 
 // CartoDB Dark Matter base map for better radar contrast
 // Note: Removed {r} (Leaflet retina placeholder) - OpenLayers XYZ doesn't support it
@@ -111,6 +123,11 @@ const WeatherMapOpenLayers = ({
   theme = 'nord',
   displayMode = 'full-page'
 }: WeatherMapProps) => {
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const parsedUrlStateRef = useRef(parseRadarUrlState(searchParams))
+
   const mapRef = useRef<HTMLDivElement>(null)
   const mapInstanceRef = useRef<Map | null>(null)
   const radarLayerRef = useRef<TileLayer<TileWMS | XYZ> | null>(null)
@@ -120,6 +137,10 @@ const WeatherMapOpenLayers = ({
   const stormReportsLayerRef = useRef<VectorLayer<VectorSource> | null>(null)
   const [radarMetadata, setRadarMetadata] = useState<RadarMetadata | null>(null)
   const [metadataError, setMetadataError] = useState<string | null>(null)
+  const [activeProvider, setActiveProvider] = useState<RadarProvider | null>(null)
+  const [activeFrames, setActiveFrames] = useState<RadarFrame[]>([])
+  const [usingFallbackProvider, setUsingFallbackProvider] = useState(false)
+  const [radarStateReady, setRadarStateReady] = useState(false)
   const [alertsGeoJson, setAlertsGeoJson] = useState<FeatureCollection | null>(null)
   const [spcGeoJson, setSpcGeoJson] = useState<FeatureCollection | null>(null)
   const [stormReports, setStormReports] = useState<StormReport[]>([])
@@ -130,16 +151,16 @@ const WeatherMapOpenLayers = ({
     body: string
   } | null>(null)
 
-  const [activeLayers, setActiveLayers] = useState<Record<string, boolean>>({
-    precipitation: true,
-    alerts: true,
-    spc: false,
-    stormReports: false,
+  const [activeLayers, setActiveLayers] = useState<Record<string, boolean>>(() => ({
+    precipitation: parsedUrlStateRef.current.layers.precipitation,
+    alerts: parsedUrlStateRef.current.layers.alerts,
+    spc: parsedUrlStateRef.current.layers.spc,
+    stormReports: parsedUrlStateRef.current.layers.stormReports,
     clouds: false,
     wind: false,
     pressure: false,
     temperature: false,
-  })
+  }))
 
   const [opacity, setOpacity] = useState(0.85)
   const [layerMenuOpen, setLayerMenuOpen] = useState(false)
@@ -154,6 +175,13 @@ const WeatherMapOpenLayers = ({
   const preloadCacheRef = useRef<Set<string>>(new Set()) // Track preloaded frames
   const isPlayingRef = useRef(isPlaying)
   const opacityRef = useRef(opacity)
+  const frameIndexRef = useRef(frameIndex)
+  const tileErrorCountRef = useRef(0)
+  const usingFallbackRef = useRef(false)
+  const fallbackProviderRef = useRef<RadarProvider | undefined>(undefined)
+  const activeProviderRef = useRef<RadarProvider | null>(null)
+  const urlSyncTimerRef = useRef<number | null>(null)
+  const urlStateInitializedRef = useRef(false)
 
   // Track client-side mount to prevent hydration mismatch with Date.now()
   const [isMounted, setIsMounted] = useState(false)
@@ -185,12 +213,39 @@ const WeatherMapOpenLayers = ({
         const metadata = (await response.json()) as RadarMetadata
         if (controller.signal.aborted) return
         setRadarMetadata(metadata)
-        setFrameIndex(Math.max(0, metadata.frames.length - 1))
+        fallbackProviderRef.current = metadata.fallbackProvider
+
+        if (!usingFallbackRef.current) {
+          setActiveProvider(metadata.selectedProvider)
+          activeProviderRef.current = metadata.selectedProvider
+          setActiveFrames(metadata.frames)
+          setUsingFallbackProvider(false)
+
+          const urlFrame = parsedUrlStateRef.current.frameIndex
+          const liveIndex = Math.max(0, metadata.frames.length - 1)
+          if (!urlStateInitializedRef.current) {
+            const nextIndex = urlFrame != null
+              ? Math.min(urlFrame, liveIndex)
+              : liveIndex
+            frameIndexRef.current = nextIndex
+            setFrameIndex(nextIndex)
+            urlStateInitializedRef.current = true
+          }
+        } else if (activeProviderRef.current) {
+          const refreshedFrames = buildRadarFrames({
+            stepMinutes: activeProviderRef.current.frameStepMinutes,
+            pastMinutes: activeProviderRef.current.pastMinutes,
+          })
+          setActiveFrames(refreshedFrames)
+          setFrameIndex(Math.max(0, refreshedFrames.length - 1))
+        }
+        setRadarStateReady(true)
       } catch (error) {
         if ((error as Error).name === 'AbortError') return
         console.error('[radar-map] metadata load failed', error)
         setRadarMetadata(null)
         setMetadataError('Radar metadata unavailable. Try again shortly.')
+        setRadarStateReady(false)
       }
     }
 
@@ -202,6 +257,54 @@ const WeatherMapOpenLayers = ({
       controller.abort()
     }
   }, [isMounted, latitude, longitude])
+
+  const locationQueryKey = useMemo(
+    () => `${latitude ?? ''}:${longitude ?? ''}:${searchParams.get('location') ?? ''}`,
+    [latitude, longitude, searchParams],
+  )
+
+  useEffect(() => {
+    usingFallbackRef.current = false
+    setUsingFallbackProvider(false)
+    tileErrorCountRef.current = 0
+    urlStateInitializedRef.current = false
+    setRadarStateReady(false)
+    parsedUrlStateRef.current = parseRadarUrlState(new URLSearchParams(window.location.search))
+    setActiveLayers((prev) => ({
+      ...prev,
+      precipitation: parsedUrlStateRef.current.layers.precipitation,
+      alerts: parsedUrlStateRef.current.layers.alerts,
+      spc: parsedUrlStateRef.current.layers.spc,
+      stormReports: parsedUrlStateRef.current.layers.stormReports,
+    }))
+  }, [locationQueryKey])
+
+  const activateFallbackProvider = useCallback(() => {
+    const fallback = fallbackProviderRef.current
+    const current = activeProviderRef.current
+    if (!fallback || current?.id === fallback.id) return
+
+    tileErrorCountRef.current = 0
+    usingFallbackRef.current = true
+    activeProviderRef.current = fallback
+
+    const frames = buildRadarFrames({
+      stepMinutes: fallback.frameStepMinutes,
+      pastMinutes: fallback.pastMinutes,
+    })
+
+    setUsingFallbackProvider(true)
+    setActiveProvider(fallback)
+    setActiveFrames(frames)
+    const nextIndex = Math.max(0, frames.length - 1)
+    frameIndexRef.current = nextIndex
+    setFrameIndex(nextIndex)
+    setMetadataError(null)
+    console.warn('[radar-map] switched to fallback provider', {
+      from: current?.id,
+      to: fallback.id,
+    })
+  }, [])
 
   useEffect(() => {
     if (!isMounted || latitude == null || longitude == null) return
@@ -259,8 +362,8 @@ const WeatherMapOpenLayers = ({
     return () => controller.abort()
   }, [isMounted, latitude, longitude])
 
-  const radarProvider = radarMetadata?.selectedProvider ?? null
-  const radarFrames = useMemo(() => radarMetadata?.frames ?? [], [radarMetadata])
+  const radarProvider = activeProvider
+  const radarFrames = useMemo(() => activeFrames, [activeFrames])
   const timestamps = useMemo(() => {
     return radarFrames.map((frame) => frame.timestamp)
   }, [radarFrames])
@@ -288,13 +391,15 @@ const WeatherMapOpenLayers = ({
       opacity: 0.9,
     })
 
+    const initialZoom = parsedUrlStateRef.current.zoom ?? DEFAULT_RADAR_ZOOM
+
     // Create map
     const map = new Map({
       target: mapRef.current,
       layers: [baseLayer],
       view: new View({
         center: fromLonLat([centerLon, centerLat]),
-        zoom: 10,
+        zoom: initialZoom,
       }),
     })
 
@@ -378,7 +483,7 @@ const WeatherMapOpenLayers = ({
     if (!mapInstanceRef.current || latitude == null || longitude == null) return
 
     mapInstanceRef.current.getView().setCenter(fromLonLat([longitude, latitude]))
-    mapInstanceRef.current.getView().setZoom(10)
+    mapInstanceRef.current.getView().setZoom(parsedUrlStateRef.current.zoom ?? DEFAULT_RADAR_ZOOM)
   }, [latitude, longitude])
 
   // Add location marker
@@ -623,7 +728,14 @@ const WeatherMapOpenLayers = ({
       if (loadingTileCount === 0) {
         setIsLoading(false)
       }
-      console.warn('[radar-map] Tile load error', { provider: radarProvider.id })
+      tileErrorCountRef.current += 1
+      console.warn('[radar-map] Tile load error', {
+        provider: radarProvider.id,
+        count: tileErrorCountRef.current,
+      })
+      if (tileErrorCountRef.current >= TILE_ERROR_FALLBACK_THRESHOLD) {
+        activateFallbackProvider()
+      }
     })
 
     const radarLayer = new TileLayer({
@@ -638,17 +750,19 @@ const WeatherMapOpenLayers = ({
     radarLayerRef.current = radarLayer
     radarSourceRef.current = radarSource
 
-    // Set initial time to most recent
+    // Apply the current timeline frame when the radar layer is created.
     if (radarFrames.length > 0) {
-      const initialIndex = timestamps.length - 1
-      const initialFrame = radarFrames[initialIndex]
+      const currentIndex = Math.min(
+        Math.max(frameIndexRef.current, 0),
+        radarFrames.length - 1,
+      )
+      const currentFrame = radarFrames[currentIndex]
       if (radarProvider.protocol === 'wms' && radarProvider.wms && 'updateParams' in radarSource) {
-        radarSource.updateParams({ [radarProvider.wms.timeParam]: initialFrame.isoTime })
+        radarSource.updateParams({ [radarProvider.wms.timeParam]: currentFrame.isoTime })
       } else if (radarProvider.protocol === 'xyz' && 'setUrl' in radarSource) {
-        const nextUrl = buildRadarXyzUrl(radarProvider, initialFrame)
+        const nextUrl = buildRadarXyzUrl(radarProvider, currentFrame)
         if (nextUrl) radarSource.setUrl(nextUrl)
       }
-      setFrameIndex(initialIndex)
     }
 
     return () => {
@@ -658,7 +772,7 @@ const WeatherMapOpenLayers = ({
         radarSourceRef.current = null
       }
     }
-  }, [radarProvider, activeLayers.precipitation, radarFrames, timestamps.length])
+  }, [radarProvider, activeLayers.precipitation, radarFrames, timestamps.length, activateFallbackProvider])
 
   // Update opacity when it changes
   useEffect(() => {
@@ -671,6 +785,10 @@ const WeatherMapOpenLayers = ({
   useEffect(() => {
     isPlayingRef.current = isPlaying
   }, [isPlaying])
+
+  useEffect(() => {
+    frameIndexRef.current = frameIndex
+  }, [frameIndex])
 
   // Update provider frame when timeline changes.
   useEffect(() => {
@@ -754,6 +872,70 @@ const WeatherMapOpenLayers = ({
     img.crossOrigin = 'anonymous'
     img.src = preloadUrl
   }, [radarFrames, radarProvider])
+
+  // Keep shareable URL state in sync with map controls.
+  const syncRadarUrlState = useCallback(() => {
+    if (!radarStateReady || activeFrames.length === 0) return
+
+    if (urlSyncTimerRef.current) {
+      window.clearTimeout(urlSyncTimerRef.current)
+    }
+
+    urlSyncTimerRef.current = window.setTimeout(() => {
+      const liveIndex = Math.max(0, activeFrames.length - 1)
+      const frameForUrl = isPlayingRef.current ? liveIndex : frameIndex
+      const currentZoom = mapInstanceRef.current?.getView().getZoom() ?? null
+      const radarParams = serializeRadarUrlParams({
+        layers: {
+          precipitation: activeLayers.precipitation,
+          alerts: activeLayers.alerts,
+          spc: activeLayers.spc,
+          stormReports: activeLayers.stormReports,
+        },
+        frameIndex: frameForUrl,
+        zoom: currentZoom,
+        frameCount: activeFrames.length,
+      })
+      const merged = mergeRadarUrlParams(new URLSearchParams(window.location.search), radarParams)
+      const nextQuery = merged.toString()
+      const currentQuery = window.location.search.replace(/^\?/, '')
+      if (nextQuery !== currentQuery) {
+        router.replace(nextQuery ? `${pathname}?${nextQuery}` : pathname, { scroll: false })
+      }
+    }, URL_SYNC_DEBOUNCE_MS)
+  }, [
+    activeFrames.length,
+    activeLayers.alerts,
+    activeLayers.precipitation,
+    activeLayers.spc,
+    activeLayers.stormReports,
+    frameIndex,
+    pathname,
+    radarStateReady,
+    router,
+  ])
+
+  useEffect(() => {
+    syncRadarUrlState()
+  }, [syncRadarUrlState])
+
+  useEffect(() => {
+    const map = mapInstanceRef.current
+    if (!map) return
+
+    const view = map.getView()
+    const handleZoomChange = () => syncRadarUrlState()
+    view.on('change:resolution', handleZoomChange)
+    return () => view.un('change:resolution', handleZoomChange)
+  }, [syncRadarUrlState, radarProvider])
+
+  useEffect(() => {
+    return () => {
+      if (urlSyncTimerRef.current) {
+        window.clearTimeout(urlSyncTimerRef.current)
+      }
+    }
+  }, [])
 
   // Animation playback with preloading
   useEffect(() => {
@@ -932,6 +1114,7 @@ const WeatherMapOpenLayers = ({
       <div className={`absolute top-4 left-4 px-3 py-1.5 rounded-md font-mono text-xs font-bold z-[2000] ${themeStyles.badge}`}>
         {radarProvider ? (
           <span>
+            {usingFallbackProvider ? 'FALLBACK ' : ''}
             {isPlaying ? 'PLAYING' : isLiveFrame ? 'LIVE' : 'HISTORY'} {radarProvider.shortName} RADAR • {Math.round(radarProvider.pastMinutes / 60)}H HISTORY
             {metadataUpdatedAt ? ` • UPDATED ${metadataUpdatedAt}` : ''}
           </span>

--- a/components/weather-map-openlayers.tsx
+++ b/components/weather-map-openlayers.tsx
@@ -5,8 +5,8 @@
 
 import { useEffect, useRef, useState, useMemo, useCallback } from 'react'
 import { Play, Pause, SkipBack, SkipForward, Layers, ChevronDown, Loader2 } from 'lucide-react'
-import { isInMRMSCoverage } from '@/lib/utils/location-utils'
 import type { ThemeType } from '@/lib/theme-config'
+import type { RadarFrame, RadarMetadata, RadarProvider } from '@/lib/radar'
 
 // OpenLayers imports
 import 'ol/ol.css'
@@ -20,13 +20,9 @@ import Feature from 'ol/Feature'
 import Point from 'ol/geom/Point'
 import VectorLayer from 'ol/layer/Vector'
 import VectorSource from 'ol/source/Vector'
-import { Style, Icon } from 'ol/style'
-
-// CORRECT WMS-T endpoint that supports TIME parameter
-// Reference: https://mesonet.agron.iastate.edu/ogc/
-// The n0q.cgi endpoint does NOT support TIME - must use n0q-t.cgi
-const NEXRAD_WMS_URL = 'https://mesonet.agron.iastate.edu/cgi-bin/wms/nexrad/n0q-t.cgi'
-const NEXRAD_LAYER = 'nexrad-n0q-wmst'
+import GeoJSON from 'ol/format/GeoJSON'
+import { Style, Icon, Fill, Stroke, Circle as CircleStyle } from 'ol/style'
+import type { FeatureLike } from 'ol/Feature'
 
 // Animation tuning constants
 const TILE_TRANSITION_MS = 500 // Smooth crossfade between frames
@@ -37,21 +33,75 @@ const PRELOAD_FRAMES_AHEAD = 3 // Number of frames to preload during playback
 // Note: Removed {r} (Leaflet retina placeholder) - OpenLayers XYZ doesn't support it
 const CARTO_DARK_MATTER_URL = 'https://{a-d}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png'
 
-// NEXRAD radar reflectivity legend (dBZ values) - industry standard scale
-const RADAR_LEGEND = [
-  { color: '#00ffc8', label: 'Light', dbz: '5-20' },
-  { color: '#00c800', label: 'Moderate', dbz: '20-35' },
-  { color: '#ffff00', label: 'Heavy', dbz: '35-50' },
-  { color: '#ff8c00', label: 'Very Heavy', dbz: '50-65' },
-  { color: '#ff0000', label: 'Extreme', dbz: '65+' },
-]
-
 interface WeatherMapProps {
   latitude?: number
   longitude?: number
   locationName?: string
   theme?: ThemeType
   displayMode?: 'full-page' | 'widget'
+}
+
+type FeatureCollection = {
+  type: 'FeatureCollection'
+  features: Array<{
+    type?: string
+    geometry?: unknown
+    properties?: Record<string, unknown>
+  }>
+}
+
+interface StormReport {
+  category: 'tornado' | 'hail' | 'wind'
+  time: string
+  size: string
+  location: string
+  state: string
+  lat: number | null
+  lon: number | null
+  comments: string
+  date: string
+}
+
+function buildRadarXyzUrl(provider: RadarProvider, frame: RadarFrame): string | null {
+  if (!provider.xyz) return null
+  return provider.xyz.urlTemplate.replace('{epochSeconds}', String(frame.epochSeconds))
+}
+
+function alertStyle(feature: FeatureLike): Style {
+  const severity = String(feature.get('severity') ?? 'Minor')
+  const color = severity === 'Extreme'
+    ? '#dc2626'
+    : severity === 'Severe'
+      ? '#ea580c'
+      : severity === 'Moderate'
+        ? '#ca8a04'
+        : '#2563eb'
+
+  return new Style({
+    fill: new Fill({ color: `${color}33` }),
+    stroke: new Stroke({ color, width: 2 }),
+  })
+}
+
+function spcStyle(feature: FeatureLike): Style {
+  const fill = String(feature.get('fill') ?? '#facc15')
+  const stroke = String(feature.get('stroke') ?? '#fef08a')
+  return new Style({
+    fill: new Fill({ color: `${fill}66` }),
+    stroke: new Stroke({ color: stroke, width: 2 }),
+  })
+}
+
+function stormReportStyle(feature: FeatureLike): Style {
+  const category = String(feature.get('category') ?? '')
+  const color = category === 'tornado' ? '#ef4444' : category === 'hail' ? '#a855f7' : '#38bdf8'
+  return new Style({
+    image: new CircleStyle({
+      radius: 6,
+      fill: new Fill({ color: `${color}dd` }),
+      stroke: new Stroke({ color: '#020617', width: 1 }),
+    }),
+  })
 }
 
 const WeatherMapOpenLayers = ({
@@ -63,11 +113,28 @@ const WeatherMapOpenLayers = ({
 }: WeatherMapProps) => {
   const mapRef = useRef<HTMLDivElement>(null)
   const mapInstanceRef = useRef<Map | null>(null)
-  const radarLayerRef = useRef<TileLayer<TileWMS> | null>(null)
-  const radarSourceRef = useRef<TileWMS | null>(null)
+  const radarLayerRef = useRef<TileLayer<TileWMS | XYZ> | null>(null)
+  const radarSourceRef = useRef<TileWMS | XYZ | null>(null)
+  const alertsLayerRef = useRef<VectorLayer<VectorSource> | null>(null)
+  const spcLayerRef = useRef<VectorLayer<VectorSource> | null>(null)
+  const stormReportsLayerRef = useRef<VectorLayer<VectorSource> | null>(null)
+  const [radarMetadata, setRadarMetadata] = useState<RadarMetadata | null>(null)
+  const [metadataError, setMetadataError] = useState<string | null>(null)
+  const [alertsGeoJson, setAlertsGeoJson] = useState<FeatureCollection | null>(null)
+  const [spcGeoJson, setSpcGeoJson] = useState<FeatureCollection | null>(null)
+  const [stormReports, setStormReports] = useState<StormReport[]>([])
+  const [selectedOverlay, setSelectedOverlay] = useState<{
+    x: number
+    y: number
+    title: string
+    body: string
+  } | null>(null)
 
   const [activeLayers, setActiveLayers] = useState<Record<string, boolean>>({
     precipitation: true,
+    alerts: true,
+    spc: false,
+    stormReports: false,
     clouds: false,
     wind: false,
     pressure: false,
@@ -85,10 +152,8 @@ const WeatherMapOpenLayers = ({
   const [radarVisible, setRadarVisible] = useState(false) // For fade-in animation
   const timerRef = useRef<number | null>(null)
   const preloadCacheRef = useRef<Set<string>>(new Set()) // Track preloaded frames
-
-  // NEXRAD configuration
-  const NEXRAD_STEP_MINUTES = 5
-  const NEXRAD_PAST_STEPS = 48 // 4 hours past (5 min * 48 = 240 min = 4 hours)
+  const isPlayingRef = useRef(isPlaying)
+  const opacityRef = useRef(opacity)
 
   // Track client-side mount to prevent hydration mismatch with Date.now()
   const [isMounted, setIsMounted] = useState(false)
@@ -96,34 +161,120 @@ const WeatherMapOpenLayers = ({
     setIsMounted(true)
   }, [])
 
-  // Check if location is in US
-  const isUSLocation = useMemo(() => {
-    if (!latitude || !longitude) return false
-    return isInMRMSCoverage(latitude, longitude)
-  }, [latitude, longitude])
-
-  // Generate NEXRAD timestamps - only after client mount to prevent hydration mismatch
-  const timestamps = useMemo(() => {
-    if (!isUSLocation || !isMounted) return []
-
-    const now = Date.now()
-    const quantize = (ms: number) => Math.floor(ms / (NEXRAD_STEP_MINUTES * 60 * 1000)) * (NEXRAD_STEP_MINUTES * 60 * 1000)
-    const base = quantize(now)
-    const times: number[] = []
-
-    for (let i = NEXRAD_PAST_STEPS; i >= 0; i -= 1) {
-      times.push(base - i * NEXRAD_STEP_MINUTES * 60 * 1000)
+  useEffect(() => {
+    if (!isMounted || latitude == null || longitude == null) {
+      setRadarMetadata(null)
+      return
     }
 
-    return times
-  }, [isUSLocation, isMounted])
+    const controller = new AbortController()
+
+    async function loadRadarMetadata() {
+      setMetadataError(null)
+      try {
+        const params = new URLSearchParams({
+          lat: String(latitude),
+          lon: String(longitude),
+        })
+        const response = await fetch(`/api/radar/metadata?${params.toString()}`, {
+          signal: controller.signal,
+        })
+        if (!response.ok) {
+          throw new Error(`Radar metadata failed: ${response.status}`)
+        }
+        const metadata = (await response.json()) as RadarMetadata
+        if (controller.signal.aborted) return
+        setRadarMetadata(metadata)
+        setFrameIndex(Math.max(0, metadata.frames.length - 1))
+      } catch (error) {
+        if ((error as Error).name === 'AbortError') return
+        console.error('[radar-map] metadata load failed', error)
+        setRadarMetadata(null)
+        setMetadataError('Radar metadata unavailable. Try again shortly.')
+      }
+    }
+
+    loadRadarMetadata()
+    const refreshTimer = window.setInterval(loadRadarMetadata, 5 * 60 * 1000)
+
+    return () => {
+      window.clearInterval(refreshTimer)
+      controller.abort()
+    }
+  }, [isMounted, latitude, longitude])
+
+  useEffect(() => {
+    if (!isMounted || latitude == null || longitude == null) return
+
+    const controller = new AbortController()
+
+    async function loadSevereOverlays() {
+      try {
+        const point = `${latitude},${longitude}`
+        const [alertsRes, spcRes, reportsRes] = await Promise.all([
+          fetch(`/api/weather/alerts?geojson=1&point=${encodeURIComponent(point)}`, {
+            signal: controller.signal,
+          }),
+          fetch('/api/weather/spc-outlook?day=1&type=cat', {
+            signal: controller.signal,
+          }),
+          fetch('/api/weather/storm-reports?days=2', {
+            signal: controller.signal,
+          }),
+        ])
+
+        if (controller.signal.aborted) return
+
+        if (alertsRes.ok) {
+          const alerts = (await alertsRes.json()) as FeatureCollection
+          setAlertsGeoJson(alerts.type === 'FeatureCollection' ? alerts : null)
+        } else {
+          setAlertsGeoJson(null)
+        }
+
+        if (spcRes.ok) {
+          const spc = (await spcRes.json()) as FeatureCollection
+          setSpcGeoJson(spc.type === 'FeatureCollection' ? spc : null)
+        } else {
+          setSpcGeoJson(null)
+        }
+
+        if (reportsRes.ok) {
+          const reportsJson = (await reportsRes.json()) as { reports?: StormReport[] }
+          setStormReports(reportsJson.reports ?? [])
+        } else {
+          setStormReports([])
+        }
+      } catch (error) {
+        if ((error as Error).name === 'AbortError') return
+        console.warn('[radar-map] severe overlays unavailable', error)
+        setAlertsGeoJson(null)
+        setSpcGeoJson(null)
+        setStormReports([])
+      }
+    }
+
+    loadSevereOverlays()
+
+    return () => controller.abort()
+  }, [isMounted, latitude, longitude])
+
+  const radarProvider = radarMetadata?.selectedProvider ?? null
+  const radarFrames = useMemo(() => radarMetadata?.frames ?? [], [radarMetadata])
+  const timestamps = useMemo(() => {
+    return radarFrames.map((frame) => frame.timestamp)
+  }, [radarFrames])
+  const hasRadarProvider = !!radarProvider && timestamps.length > 0
+  const metadataUpdatedAt = radarMetadata?.generatedAt
+    ? new Date(radarMetadata.generatedAt).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })
+    : null
 
   // Initialize map
   useEffect(() => {
     if (!mapRef.current || mapInstanceRef.current) return
 
-    const centerLon = longitude || -98.5795
-    const centerLat = latitude || 39.8283
+    const centerLon = -98.5795
+    const centerLat = 39.8283
 
 
     // Create base layer (CartoDB Dark Matter - better radar visibility)
@@ -148,6 +299,39 @@ const WeatherMapOpenLayers = ({
     })
 
     mapInstanceRef.current = map
+
+    map.on('click', (evt) => {
+      const hit = map.forEachFeatureAtPixel(evt.pixel, (feature) => feature)
+      if (!hit) {
+        setSelectedOverlay(null)
+        return
+      }
+
+      const props = hit.getProperties() as Record<string, unknown>
+      const title = String(props.event ?? props.LABEL2 ?? props.LABEL ?? props.category ?? props.label ?? 'Map feature')
+      const body = [
+        props.headline,
+        props.areaDesc,
+        props.instruction,
+        props.comments,
+        props.location && props.state ? `${props.location}, ${props.state}` : null,
+      ]
+        .filter(Boolean)
+        .map(String)
+        .join('\n\n')
+
+      setSelectedOverlay({
+        x: evt.pixel[0],
+        y: evt.pixel[1],
+        title,
+        body: body || 'No additional details available.',
+      })
+    })
+
+    map.on('pointermove', (evt) => {
+      const hit = map.forEachFeatureAtPixel(evt.pixel, () => true)
+      map.getTargetElement().style.cursor = hit ? 'pointer' : ''
+    })
 
     // Fix for production: force map to recalculate size multiple times
     // Sometimes the container size isn't ready immediately
@@ -191,7 +375,7 @@ const WeatherMapOpenLayers = ({
 
   // Update map center when location changes
   useEffect(() => {
-    if (!mapInstanceRef.current || !latitude || !longitude) return
+    if (!mapInstanceRef.current || latitude == null || longitude == null) return
 
     mapInstanceRef.current.getView().setCenter(fromLonLat([longitude, latitude]))
     mapInstanceRef.current.getView().setZoom(10)
@@ -199,7 +383,7 @@ const WeatherMapOpenLayers = ({
 
   // Add location marker
   useEffect(() => {
-    if (!mapInstanceRef.current || !latitude || !longitude) return
+    if (!mapInstanceRef.current || latitude == null || longitude == null) return
 
     const map = mapInstanceRef.current
 
@@ -253,9 +437,117 @@ const WeatherMapOpenLayers = ({
     map.addLayer(markerLayer)
   }, [latitude, longitude])
 
-  // Initialize SINGLE radar layer with WMS-T support
   useEffect(() => {
-    if (!mapInstanceRef.current || !isUSLocation || !activeLayers.precipitation) {
+    const map = mapInstanceRef.current
+    if (!map) return
+
+    if (alertsLayerRef.current) {
+      map.removeLayer(alertsLayerRef.current)
+      alertsLayerRef.current = null
+    }
+
+    if (!activeLayers.alerts || !alertsGeoJson?.features?.length) return
+
+    const filtered = {
+      ...alertsGeoJson,
+      features: alertsGeoJson.features.filter((feature) => feature.geometry != null),
+    }
+
+    if (!filtered.features.length) return
+
+    const source = new VectorSource({
+      features: new GeoJSON().readFeatures(filtered, {
+        featureProjection: 'EPSG:3857',
+        dataProjection: 'EPSG:4326',
+      }),
+    })
+
+    const layer = new VectorLayer({
+      source,
+      style: alertStyle,
+      zIndex: 700,
+    })
+
+    alertsLayerRef.current = layer
+    map.addLayer(layer)
+  }, [activeLayers.alerts, alertsGeoJson])
+
+  useEffect(() => {
+    const map = mapInstanceRef.current
+    if (!map) return
+
+    if (spcLayerRef.current) {
+      map.removeLayer(spcLayerRef.current)
+      spcLayerRef.current = null
+    }
+
+    if (!activeLayers.spc || !spcGeoJson?.features?.length) return
+
+    const filtered = {
+      ...spcGeoJson,
+      features: spcGeoJson.features.filter((feature) => feature.geometry != null),
+    }
+
+    if (!filtered.features.length) return
+
+    const source = new VectorSource({
+      features: new GeoJSON().readFeatures(filtered, {
+        featureProjection: 'EPSG:3857',
+        dataProjection: 'EPSG:4326',
+      }),
+    })
+
+    const layer = new VectorLayer({
+      source,
+      style: spcStyle,
+      zIndex: 650,
+    })
+
+    spcLayerRef.current = layer
+    map.addLayer(layer)
+  }, [activeLayers.spc, spcGeoJson])
+
+  useEffect(() => {
+    const map = mapInstanceRef.current
+    if (!map) return
+
+    if (stormReportsLayerRef.current) {
+      map.removeLayer(stormReportsLayerRef.current)
+      stormReportsLayerRef.current = null
+    }
+
+    if (!activeLayers.stormReports || !stormReports.length) return
+
+    const source = new VectorSource()
+    for (const report of stormReports) {
+      if (report.lat == null || report.lon == null) continue
+      source.addFeature(new Feature({
+        geometry: new Point(fromLonLat([report.lon, report.lat])),
+        category: report.category,
+        label: `${report.category.toUpperCase()} · ${report.size}`,
+        location: report.location,
+        state: report.state,
+        comments: report.comments,
+        date: report.date,
+        time: report.time,
+      }))
+    }
+
+    if (source.isEmpty()) return
+
+    const layer = new VectorLayer({
+      source,
+      style: stormReportStyle,
+      zIndex: 750,
+    })
+
+    stormReportsLayerRef.current = layer
+    map.addLayer(layer)
+  }, [activeLayers.stormReports, stormReports])
+
+  // Initialize provider-selected radar layer.
+  useEffect(() => {
+    if (!mapInstanceRef.current || !radarProvider || !activeLayers.precipitation || timestamps.length === 0) {
       // Remove radar layer if it exists
       if (radarLayerRef.current && mapInstanceRef.current) {
         mapInstanceRef.current.removeLayer(radarLayerRef.current)
@@ -275,21 +567,32 @@ const WeatherMapOpenLayers = ({
     // Reset fade-in state for new layer (fixes Cursor BugBot issue)
     setRadarVisible(false)
 
-    // Create WMS source with TIME support
-    // Key insight: n0q-t.cgi supports the TIME parameter, n0q.cgi does NOT
-    const radarSource = new TileWMS({
-      url: NEXRAD_WMS_URL,
-      params: {
-        'LAYERS': NEXRAD_LAYER,
-        'FORMAT': 'image/png',
-        'TRANSPARENT': 'true',
-        'VERSION': '1.1.1',
-        // TIME will be set via updateParams()
-      },
-      serverType: 'mapserver',
-      transition: TILE_TRANSITION_MS, // Smooth cross-fade between frames
-      crossOrigin: 'anonymous',
-    })
+    const latestFrame = radarFrames[radarFrames.length - 1]
+    let radarSource: TileWMS | XYZ | null = null
+
+    if (radarProvider.protocol === 'wms' && radarProvider.wms) {
+      radarSource = new TileWMS({
+        url: radarProvider.wms.url,
+        params: radarProvider.wms.params,
+        serverType: radarProvider.wms.serverType,
+        transition: TILE_TRANSITION_MS, // Smooth cross-fade between frames
+        crossOrigin: 'anonymous',
+      })
+    } else if (radarProvider.protocol === 'xyz' && latestFrame) {
+      const initialUrl = buildRadarXyzUrl(radarProvider, latestFrame)
+      if (initialUrl) {
+        radarSource = new XYZ({
+          url: initialUrl,
+          crossOrigin: 'anonymous',
+          transition: TILE_TRANSITION_MS,
+        })
+      }
+    }
+
+    if (!radarSource) {
+      setMetadataError('Radar provider is missing a usable tile source.')
+      return
+    }
 
     // Track loading state - use a counter to handle concurrent tile loads
     let loadingTileCount = 0
@@ -298,7 +601,7 @@ const WeatherMapOpenLayers = ({
     radarSource.on('tileloadstart', () => {
       loadingTileCount++
       // Only show loading indicator when not playing (to avoid button flicker)
-      if (!isPlaying && loadingTileCount === 1) {
+      if (!isPlayingRef.current && loadingTileCount === 1) {
         setIsLoading(true)
       }
     })
@@ -320,26 +623,31 @@ const WeatherMapOpenLayers = ({
       if (loadingTileCount === 0) {
         setIsLoading(false)
       }
-      console.warn('⚠️ [v6] Tile load error')
+      console.warn('[radar-map] Tile load error', { provider: radarProvider.id })
     })
 
     const radarLayer = new TileLayer({
       source: radarSource,
-      opacity: opacity,
+      opacity: opacityRef.current,
       zIndex: 500,
     })
 
-    radarLayer.set('name', 'nexrad-radar')
+    radarLayer.set('name', `${radarProvider.id}-radar`)
     map.addLayer(radarLayer)
 
     radarLayerRef.current = radarLayer
     radarSourceRef.current = radarSource
 
     // Set initial time to most recent
-    if (timestamps.length > 0) {
+    if (radarFrames.length > 0) {
       const initialIndex = timestamps.length - 1
-      const initialTime = new Date(timestamps[initialIndex]).toISOString()
-      radarSource.updateParams({ 'TIME': initialTime })
+      const initialFrame = radarFrames[initialIndex]
+      if (radarProvider.protocol === 'wms' && radarProvider.wms && 'updateParams' in radarSource) {
+        radarSource.updateParams({ [radarProvider.wms.timeParam]: initialFrame.isoTime })
+      } else if (radarProvider.protocol === 'xyz' && 'setUrl' in radarSource) {
+        const nextUrl = buildRadarXyzUrl(radarProvider, initialFrame)
+        if (nextUrl) radarSource.setUrl(nextUrl)
+      }
       setFrameIndex(initialIndex)
     }
 
@@ -350,28 +658,39 @@ const WeatherMapOpenLayers = ({
         radarSourceRef.current = null
       }
     }
-  }, [isUSLocation, activeLayers.precipitation, timestamps.length > 0])
+  }, [radarProvider, activeLayers.precipitation, radarFrames, timestamps.length])
 
   // Update opacity when it changes
   useEffect(() => {
+    opacityRef.current = opacity
     if (radarLayerRef.current) {
       radarLayerRef.current.setOpacity(opacity)
     }
   }, [opacity])
 
-  // Update TIME parameter when frame changes - THIS IS THE KEY FIX
   useEffect(() => {
-    if (!radarSourceRef.current || timestamps.length === 0) return
+    isPlayingRef.current = isPlaying
+  }, [isPlaying])
 
-    const currentTimestamp = timestamps[frameIndex]
-    if (!currentTimestamp) return
+  // Update provider frame when timeline changes.
+  useEffect(() => {
+    if (!radarSourceRef.current || !radarProvider || radarFrames.length === 0) return
 
-    const timeISO = new Date(currentTimestamp).toISOString()
+    const currentFrame = radarFrames[frameIndex]
+    if (!currentFrame) return
 
-    // This is the correct way to animate WMS-T layers in OpenLayers
-    // updateParams() triggers a re-fetch with the new TIME value
-    radarSourceRef.current.updateParams({ 'TIME': timeISO })
-  }, [frameIndex, timestamps])
+    const source = radarSourceRef.current
+
+    if (radarProvider.protocol === 'wms' && radarProvider.wms && 'updateParams' in source) {
+      source.updateParams({ [radarProvider.wms.timeParam]: currentFrame.isoTime })
+      return
+    }
+
+    if (radarProvider.protocol === 'xyz' && 'setUrl' in source) {
+      const nextUrl = buildRadarXyzUrl(radarProvider, currentFrame)
+      if (nextUrl) source.setUrl(nextUrl)
+    }
+  }, [frameIndex, radarFrames, radarProvider])
 
   // Clear preload cache when location changes (fixes CodeRabbit memory leak issue)
   useEffect(() => {
@@ -380,15 +699,15 @@ const WeatherMapOpenLayers = ({
 
   // Preload upcoming frames for smoother playback
   const preloadFrame = useCallback((index: number) => {
-    if (!timestamps[index] || !radarSourceRef.current || !mapInstanceRef.current) return
+    const frame = radarFrames[index]
+    if (!frame || !radarProvider || !radarSourceRef.current || !mapInstanceRef.current) return
     
     // Limit cache size to prevent memory bloat (fixes CodeRabbit issue)
     if (preloadCacheRef.current.size > 100) {
       preloadCacheRef.current.clear()
     }
     
-    const timeISO = new Date(timestamps[index]).toISOString()
-    const cacheKey = `${timeISO}`
+    const cacheKey = `${radarProvider.id}:${frame.isoTime}`
     
     if (preloadCacheRef.current.has(cacheKey)) return
     preloadCacheRef.current.add(cacheKey)
@@ -407,12 +726,34 @@ const WeatherMapOpenLayers = ({
       }
     }
     
+    let preloadUrl: string | null = null
+    if (radarProvider.protocol === 'wms' && radarProvider.wms) {
+      const params = new URLSearchParams({
+        SERVICE: 'WMS',
+        REQUEST: 'GetMap',
+        WIDTH: '256',
+        HEIGHT: '256',
+        BBOX: bbox,
+        ...radarProvider.wms.params,
+        [radarProvider.wms.timeParam]: frame.isoTime,
+      })
+      const version = radarProvider.wms.params.VERSION
+      params.set(version === '1.1.1' ? 'SRS' : 'CRS', 'EPSG:3857')
+      preloadUrl = `${radarProvider.wms.url}?${params.toString()}`
+    } else if (radarProvider.protocol === 'xyz') {
+      preloadUrl = buildRadarXyzUrl(radarProvider, frame)
+        ?.replace('{z}', '5')
+        .replace('{x}', '9')
+        .replace('{y}', '12') ?? null
+    }
+
+    if (!preloadUrl) return
+
     // Create a hidden image to preload the tile
-    const preloadUrl = `${NEXRAD_WMS_URL}?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetMap&LAYERS=${NEXRAD_LAYER}&TIME=${encodeURIComponent(timeISO)}&FORMAT=image/png&TRANSPARENT=true&WIDTH=256&HEIGHT=256&SRS=EPSG:3857&BBOX=${bbox}`
     const img = new Image()
     img.crossOrigin = 'anonymous'
     img.src = preloadUrl
-  }, [timestamps, latitude, longitude])
+  }, [radarFrames, radarProvider])
 
   // Animation playback with preloading
   useEffect(() => {
@@ -447,7 +788,7 @@ const WeatherMapOpenLayers = ({
   // Keyboard controls
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if (!isUSLocation || !activeLayers.precipitation) return
+      if (!hasRadarProvider || !activeLayers.precipitation) return
 
       // Don't intercept keys when user is typing in an input field
       const activeElement = document.activeElement as HTMLElement
@@ -471,7 +812,7 @@ const WeatherMapOpenLayers = ({
 
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
-  }, [isUSLocation, activeLayers.precipitation, timestamps.length])
+  }, [hasRadarProvider, activeLayers.precipitation, timestamps.length])
 
   const currentTime = timestamps[frameIndex]
   const humanTime = currentTime ? new Date(currentTime).toUTCString().replace(' GMT', '') : ''
@@ -525,17 +866,17 @@ const WeatherMapOpenLayers = ({
   // Jump to end (live)
   const handleSkipToEnd = useCallback(() => {
     setIsPlaying(false)
-    setFrameIndex(timestamps.length - 1)
+    setFrameIndex(Math.max(0, timestamps.length - 1))
   }, [timestamps.length])
 
   return (
     <div
       data-radar-container
-      className={`flex gap-2 w-full rounded-lg ${themeStyles.container}`}
+      className={`flex w-full flex-col gap-2 rounded-lg sm:flex-row ${themeStyles.container}`}
       style={{ height: '100%', minHeight: '350px' }}
     >
       {/* Main Map Area */}
-      <div className="relative flex-1 overflow-visible">
+      <div className="relative min-h-[350px] flex-1 overflow-visible">
       {/* Map Container - explicit dimensions for production */}
       <div
         ref={mapRef}
@@ -560,22 +901,50 @@ const WeatherMapOpenLayers = ({
       )}
       
       {/* Radar fade-in overlay - stays in DOM and animates opacity (fixes Bugbot transition issue) */}
-      {isUSLocation && activeLayers.precipitation && (
+      {hasRadarProvider && activeLayers.precipitation && (
         <div 
           className={`absolute inset-0 bg-gray-900 z-[1998] transition-opacity duration-500 pointer-events-none ${radarVisible ? 'opacity-0' : 'opacity-100'}`}
         />
       )}
 
+      {selectedOverlay && (
+        <div
+          className="absolute z-[2100] max-w-sm rounded-md border border-cyan-500/40 bg-gray-950/95 p-3 text-xs font-mono text-white shadow-xl backdrop-blur-sm"
+          style={{
+            left: selectedOverlay.x + 12,
+            top: selectedOverlay.y + 12,
+          }}
+        >
+          <button
+            type="button"
+            onClick={() => setSelectedOverlay(null)}
+            className="absolute right-2 top-1 text-gray-400 hover:text-white"
+            aria-label="Close radar feature details"
+          >
+            x
+          </button>
+          <p className="mb-1 pr-5 text-sm font-bold text-cyan-300">{selectedOverlay.title}</p>
+          <p className="whitespace-pre-wrap leading-relaxed text-gray-300">{selectedOverlay.body}</p>
+        </div>
+      )}
+
       {/* Status Badge */}
       <div className={`absolute top-4 left-4 px-3 py-1.5 rounded-md font-mono text-xs font-bold z-[2000] ${themeStyles.badge}`}>
-        {isUSLocation ? (
+        {radarProvider ? (
           <span>
-            {isPlaying ? '▶️' : isLiveFrame ? '🔴 LIVE' : '🎬'} NEXRAD RADAR • 4 HOUR HISTORY
+            {isPlaying ? 'PLAYING' : isLiveFrame ? 'LIVE' : 'HISTORY'} {radarProvider.shortName} RADAR • {Math.round(radarProvider.pastMinutes / 60)}H HISTORY
+            {metadataUpdatedAt ? ` • UPDATED ${metadataUpdatedAt}` : ''}
           </span>
         ) : (
-          <span>🌎 US LOCATIONS ONLY</span>
+          <span>{metadataError ?? 'RADAR METADATA LOADING'}</span>
         )}
       </div>
+
+      {radarProvider && (
+        <div className="absolute bottom-3 right-3 z-[1900] max-w-[70vw] rounded bg-gray-950/80 px-2 py-1 text-right font-mono text-[9px] uppercase tracking-wide text-gray-300 backdrop-blur-sm max-sm:bottom-16">
+          Source: {radarProvider.attribution}
+        </div>
+      )}
 
       {/* Layer Controls */}
       <div className="absolute top-4 right-4 z-[2000]">
@@ -598,7 +967,31 @@ const WeatherMapOpenLayers = ({
               className={`w-full px-3 py-2 text-left font-mono text-xs hover:bg-gray-700 transition-colors ${activeLayers.precipitation ? 'bg-cyan-600/30 text-cyan-300' : 'text-gray-300'
                 }`}
             >
-              {activeLayers.precipitation ? '✓' : '○'} Precipitation {isUSLocation ? '(NEXRAD)' : ''}
+              {activeLayers.precipitation ? '✓' : '○'} Precipitation {radarProvider ? `(${radarProvider.shortName})` : ''}
+            </button>
+
+            <button
+              onClick={() => setActiveLayers(prev => ({ ...prev, alerts: !prev.alerts }))}
+              className={`w-full px-3 py-2 text-left font-mono text-xs hover:bg-gray-700 transition-colors ${activeLayers.alerts ? 'bg-red-600/30 text-red-300' : 'text-gray-300'
+                }`}
+            >
+              {activeLayers.alerts ? '✓' : '○'} NWS Alerts ({alertsGeoJson?.features?.length ?? 0})
+            </button>
+
+            <button
+              onClick={() => setActiveLayers(prev => ({ ...prev, spc: !prev.spc }))}
+              className={`w-full px-3 py-2 text-left font-mono text-xs hover:bg-gray-700 transition-colors ${activeLayers.spc ? 'bg-yellow-600/30 text-yellow-300' : 'text-gray-300'
+                }`}
+            >
+              {activeLayers.spc ? '✓' : '○'} SPC Outlook ({spcGeoJson?.features?.length ?? 0})
+            </button>
+
+            <button
+              onClick={() => setActiveLayers(prev => ({ ...prev, stormReports: !prev.stormReports }))}
+              className={`w-full px-3 py-2 text-left font-mono text-xs hover:bg-gray-700 transition-colors ${activeLayers.stormReports ? 'bg-purple-600/30 text-purple-300' : 'text-gray-300'
+                }`}
+            >
+              {activeLayers.stormReports ? '✓' : '○'} Storm Reports ({stormReports.length})
             </button>
 
             {/* Opacity slider */}
@@ -621,15 +1014,15 @@ const WeatherMapOpenLayers = ({
       </div>
 
       {/* Animation Controls - Position varies by display mode: top for full-page, bottom for widget */}
-      {isUSLocation && activeLayers.precipitation && timestamps.length > 0 && (
+      {hasRadarProvider && activeLayers.precipitation && timestamps.length > 0 && (
         <div
           className={`absolute left-1/2 -translate-x-1/2 flex flex-col items-center pointer-events-auto ${
-            displayMode === 'widget' ? 'bottom-2 gap-1' : 'top-16 gap-2'
+            displayMode === 'widget' ? 'bottom-2 gap-1' : 'bottom-4 gap-2'
           }`}
           style={{ zIndex: 2000 }}
         >
           {/* Compact Controls Bar - smaller in widget mode */}
-          <div className={`flex items-center bg-gray-900/95 rounded-md border-2 border-cyan-500 shadow-2xl backdrop-blur-sm ${
+          <div className={`flex max-w-[92vw] flex-wrap items-center justify-center bg-gray-900/95 rounded-md border-2 border-cyan-500 shadow-2xl backdrop-blur-sm ${
             displayMode === 'widget' ? 'gap-1 px-2 py-1' : 'gap-2 px-3 py-2'
           }`}>
             <button
@@ -773,18 +1166,18 @@ const WeatherMapOpenLayers = ({
         </div>
       )}
 
-      {/* No Radar Message for International */}
-      {!isUSLocation && activeLayers.precipitation && (
+      {/* Metadata error message */}
+      {!hasRadarProvider && activeLayers.precipitation && metadataError && (
         <div className="absolute inset-0 flex items-center justify-center z-[2000] pointer-events-none">
           <div className="bg-gray-800/95 rounded-lg p-6 max-w-md text-center shadow-xl">
             <div className="text-2xl font-mono font-bold text-white mb-2">
-              HIGH-RESOLUTION RADAR UNAVAILABLE
+              RADAR UNAVAILABLE
             </div>
             <div className="text-sm text-gray-300 mb-4">
-              Animated radar is only available for US locations.
+              {metadataError}
             </div>
             <div className="text-xs text-gray-400">
-              Current conditions and forecasts are still available above.
+              Current conditions and forecasts are still available.
             </div>
           </div>
         </div>
@@ -792,20 +1185,20 @@ const WeatherMapOpenLayers = ({
       </div>
 
       {/* Radar Reflectivity Legend - Right Side, Outside Map */}
-      {isUSLocation && activeLayers.precipitation && radarVisible && (
-        <div className="flex-shrink-0 self-center">
+      {hasRadarProvider && activeLayers.precipitation && radarVisible && (
+        <div className="flex-shrink-0 self-center max-sm:absolute max-sm:bottom-3 max-sm:left-3 max-sm:z-[2000]">
           <div className="bg-gray-900/95 rounded-md p-1.5 backdrop-blur-sm shadow-xl">
             <div className="font-mono text-[8px] text-gray-400 mb-1 uppercase tracking-wide text-center">
               dBZ
             </div>
             <div className="flex flex-col gap-0.5">
-              {RADAR_LEGEND.map((item) => (
-                <div key={item.dbz} className="flex items-center gap-1">
+              {radarMetadata?.legend.map((item) => (
+                <div key={item.value} className="flex items-center gap-1">
                   <div
                     className="w-3 h-2.5 rounded-sm border border-gray-700"
                     style={{ backgroundColor: item.color }}
                   />
-                  <span className="font-mono text-[8px] text-gray-300 whitespace-nowrap">{item.dbz}</span>
+                  <span className="font-mono text-[8px] text-gray-300 whitespace-nowrap">{item.value}</span>
                 </div>
               ))}
             </div>

--- a/lib/radar/index.ts
+++ b/lib/radar/index.ts
@@ -1,0 +1,4 @@
+export * from '@/lib/radar/radar-timestamps'
+export * from '@/lib/radar/providers/coverage'
+export * from '@/lib/radar/providers/registry'
+export type * from '@/lib/radar/providers/types'

--- a/lib/radar/index.ts
+++ b/lib/radar/index.ts
@@ -1,4 +1,5 @@
 export * from '@/lib/radar/radar-timestamps'
+export * from '@/lib/radar/radar-url-state'
 export * from '@/lib/radar/providers/coverage'
 export * from '@/lib/radar/providers/registry'
 export type * from '@/lib/radar/providers/types'

--- a/lib/radar/providers/coverage.ts
+++ b/lib/radar/providers/coverage.ts
@@ -1,0 +1,19 @@
+import { isUSLocation } from '@/lib/utils/location-utils'
+
+export function isCanadaRadarCoverage(latitude: number, longitude: number): boolean {
+  return latitude >= 41 && latitude <= 84 && longitude >= -142 && longitude <= -52
+}
+
+export function isNorthAmericaFallbackCoverage(latitude: number, longitude: number): boolean {
+  return latitude >= 7 && latitude <= 84 && longitude >= -170 && longitude <= -45
+}
+
+export function getRadarCoverageRegion(
+  latitude: number,
+  longitude: number
+): 'us' | 'canada' | 'north-america-fallback' | 'global' {
+  if (isUSLocation(latitude, longitude)) return 'us'
+  if (isCanadaRadarCoverage(latitude, longitude)) return 'canada'
+  if (isNorthAmericaFallbackCoverage(latitude, longitude)) return 'north-america-fallback'
+  return 'global'
+}

--- a/lib/radar/providers/registry.ts
+++ b/lib/radar/providers/registry.ts
@@ -1,0 +1,180 @@
+import { buildRadarFrames } from '@/lib/radar/radar-timestamps'
+import { getRadarCoverageRegion } from '@/lib/radar/providers/coverage'
+import type {
+  RadarLegendBand,
+  RadarMetadata,
+  RadarProvider,
+  RadarProviderId,
+  RadarProviderSelection,
+} from '@/lib/radar/providers/types'
+
+export const REFLECTIVITY_LEGEND: RadarLegendBand[] = [
+  { color: '#00ffc8', label: 'Light', value: '5-20 dBZ' },
+  { color: '#00c800', label: 'Moderate', value: '20-35 dBZ' },
+  { color: '#ffff00', label: 'Heavy', value: '35-50 dBZ' },
+  { color: '#ff8c00', label: 'Very Heavy', value: '50-65 dBZ' },
+  { color: '#ff0000', label: 'Extreme', value: '65+ dBZ' },
+]
+
+export const RADAR_PROVIDERS: Record<RadarProviderId, RadarProvider> = {
+  'noaa-mrms': {
+    id: 'noaa-mrms',
+    displayName: 'NOAA MRMS Radar',
+    shortName: 'MRMS',
+    coverage: 'us',
+    protocol: 'wms',
+    attribution: 'NOAA/NWS MRMS',
+    refreshIntervalSeconds: 300,
+    frameStepMinutes: 5,
+    pastMinutes: 240,
+    supportsAnimation: true,
+    qualityTier: 'official',
+    fallbackProviderId: 'iowa-nexrad',
+    wms: {
+      url: '/api/weather/noaa-wms',
+      params: {
+        LAYERS: '1',
+        FORMAT: 'image/png',
+        TRANSPARENT: 'true',
+        VERSION: '1.3.0',
+        STYLES: '',
+      },
+      serverType: 'mapserver',
+      timeParam: 'TIME',
+      direct: false,
+    },
+    notes: [
+      'Official US radar mosaic via the existing NOAA WMS proxy.',
+      'Falls back to Iowa NEXRAD if the proxy or upstream service is unhealthy.',
+    ],
+  },
+  'iowa-nexrad': {
+    id: 'iowa-nexrad',
+    displayName: 'Iowa State NEXRAD Radar',
+    shortName: 'NEXRAD',
+    coverage: 'us',
+    protocol: 'wms',
+    attribution: 'Iowa Environmental Mesonet / NOAA NEXRAD',
+    refreshIntervalSeconds: 300,
+    frameStepMinutes: 5,
+    pastMinutes: 240,
+    supportsAnimation: true,
+    qualityTier: 'community',
+    wms: {
+      url: 'https://mesonet.agron.iastate.edu/cgi-bin/wms/nexrad/n0q-t.cgi',
+      params: {
+        LAYERS: 'nexrad-n0q-wmst',
+        FORMAT: 'image/png',
+        TRANSPARENT: 'true',
+        VERSION: '1.1.1',
+      },
+      serverType: 'mapserver',
+      timeParam: 'TIME',
+      direct: true,
+    },
+    notes: ['Reliable public WMS-T fallback for US reflectivity loops.'],
+  },
+  'canada-geomet': {
+    id: 'canada-geomet',
+    displayName: 'Canada MSC GeoMet Radar',
+    shortName: 'GeoMet',
+    coverage: 'canada',
+    protocol: 'wms',
+    attribution: 'Environment and Climate Change Canada MSC GeoMet',
+    refreshIntervalSeconds: 360,
+    frameStepMinutes: 6,
+    pastMinutes: 180,
+    supportsAnimation: true,
+    qualityTier: 'official',
+    fallbackProviderId: 'rainviewer',
+    wms: {
+      url: 'https://geo.weather.gc.ca/geomet/',
+      params: {
+        LAYERS: 'RADAR_1KM_RRAI',
+        FORMAT: 'image/png',
+        TRANSPARENT: 'true',
+        VERSION: '1.3.0',
+        TILED: 'true',
+      },
+      serverType: 'geoserver',
+      timeParam: 'TIME',
+      direct: true,
+    },
+    notes: ['Official Canadian radar via time-enabled MSC GeoMet WMS.'],
+  },
+  rainviewer: {
+    id: 'rainviewer',
+    displayName: 'RainViewer Radar',
+    shortName: 'RainViewer',
+    coverage: 'north-america-fallback',
+    protocol: 'xyz',
+    attribution: 'RainViewer',
+    refreshIntervalSeconds: 300,
+    frameStepMinutes: 10,
+    pastMinutes: 120,
+    supportsAnimation: true,
+    qualityTier: 'fallback',
+    xyz: {
+      urlTemplate: 'https://tilecache.rainviewer.com/v2/radar/{epochSeconds}/256/{z}/{x}/{y}/2/1_1.png',
+      direct: true,
+    },
+    notes: [
+      'Fallback radar tile source for Mexico and general North America coverage.',
+      'Use requires attribution and commercial-term review before high-volume production use.',
+    ],
+  },
+}
+
+export function getRadarProvider(id: RadarProviderId): RadarProvider {
+  return RADAR_PROVIDERS[id]
+}
+
+export function selectRadarProvider(latitude: number, longitude: number): RadarProviderSelection {
+  const region = getRadarCoverageRegion(latitude, longitude)
+
+  if (region === 'us') {
+    return {
+      selectedProvider: RADAR_PROVIDERS['noaa-mrms'],
+      fallbackProvider: RADAR_PROVIDERS['iowa-nexrad'],
+      reason: 'US location selected official NOAA MRMS radar with Iowa NEXRAD fallback.',
+    }
+  }
+
+  if (region === 'canada') {
+    return {
+      selectedProvider: RADAR_PROVIDERS['canada-geomet'],
+      fallbackProvider: RADAR_PROVIDERS.rainviewer,
+      reason: 'Canada location selected official MSC GeoMet radar with RainViewer fallback.',
+    }
+  }
+
+  return {
+    selectedProvider: RADAR_PROVIDERS.rainviewer,
+    reason: 'Location outside official US/Canada radar coverage selected RainViewer fallback.',
+  }
+}
+
+export function buildRadarMetadata(
+  latitude: number,
+  longitude: number,
+  now = Date.now()
+): RadarMetadata {
+  const selection = selectRadarProvider(latitude, longitude)
+  const provider = selection.selectedProvider
+  const frames = buildRadarFrames({
+    now,
+    stepMinutes: provider.frameStepMinutes,
+    pastMinutes: provider.pastMinutes,
+  })
+
+  return {
+    location: { lat: latitude, lon: longitude },
+    generatedAt: new Date(now).toISOString(),
+    selectedProvider: provider,
+    fallbackProvider: selection.fallbackProvider,
+    frames,
+    refreshIntervalSeconds: provider.refreshIntervalSeconds,
+    legend: REFLECTIVITY_LEGEND,
+    selectionReason: selection.reason,
+  }
+}

--- a/lib/radar/providers/types.ts
+++ b/lib/radar/providers/types.ts
@@ -1,0 +1,64 @@
+import type { RadarFrame } from '@/lib/radar/radar-timestamps'
+
+export type RadarProviderId = 'noaa-mrms' | 'iowa-nexrad' | 'canada-geomet' | 'rainviewer'
+
+export type RadarProviderCoverage = 'us' | 'canada' | 'north-america-fallback'
+
+export type RadarProviderProtocol = 'wms' | 'xyz'
+
+export interface RadarWmsConfig {
+  url: string
+  params: Record<string, string>
+  serverType?: 'mapserver' | 'geoserver'
+  timeParam: string
+  direct: boolean
+}
+
+export interface RadarXyzConfig {
+  urlTemplate: string
+  direct: boolean
+}
+
+export interface RadarLegendBand {
+  color: string
+  label: string
+  value: string
+}
+
+export interface RadarProvider {
+  id: RadarProviderId
+  displayName: string
+  shortName: string
+  coverage: RadarProviderCoverage
+  protocol: RadarProviderProtocol
+  attribution: string
+  refreshIntervalSeconds: number
+  frameStepMinutes: number
+  pastMinutes: number
+  supportsAnimation: boolean
+  qualityTier: 'official' | 'community' | 'fallback'
+  wms?: RadarWmsConfig
+  xyz?: RadarXyzConfig
+  fallbackProviderId?: RadarProviderId
+  notes: string[]
+}
+
+export interface RadarProviderSelection {
+  selectedProvider: RadarProvider
+  fallbackProvider?: RadarProvider
+  reason: string
+}
+
+export interface RadarMetadata {
+  location: {
+    lat: number
+    lon: number
+  }
+  generatedAt: string
+  selectedProvider: RadarProvider
+  fallbackProvider?: RadarProvider
+  frames: RadarFrame[]
+  refreshIntervalSeconds: number
+  legend: RadarLegendBand[]
+  selectionReason: string
+}

--- a/lib/radar/radar-timestamps.ts
+++ b/lib/radar/radar-timestamps.ts
@@ -1,0 +1,61 @@
+export interface BuildRadarFramesOptions {
+  now?: number
+  stepMinutes?: number
+  pastMinutes?: number
+  pastSteps?: number
+}
+
+export interface RadarFrame {
+  timestamp: number
+  isoTime: string
+  epochSeconds: number
+  offsetMinutes: number
+  isLive: boolean
+}
+
+const DEFAULT_STEP_MINUTES = 5
+const DEFAULT_PAST_MINUTES = 240
+const MAX_PAST_MINUTES = 12 * 60
+
+export function normalizeRadarStepMinutes(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    return DEFAULT_STEP_MINUTES
+  }
+  return Math.max(1, Math.round(value))
+}
+
+export function normalizeRadarPastMinutes(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+    return DEFAULT_PAST_MINUTES
+  }
+  return Math.min(MAX_PAST_MINUTES, Math.round(value))
+}
+
+function quantizeTime(ms: number, stepMinutes: number): number {
+  const stepMs = stepMinutes * 60 * 1000
+  return Math.floor(ms / stepMs) * stepMs
+}
+
+export function buildRadarFrames(options: BuildRadarFramesOptions = {}): RadarFrame[] {
+  const stepMinutes = normalizeRadarStepMinutes(options.stepMinutes)
+  const now = typeof options.now === 'number' && Number.isFinite(options.now)
+    ? options.now
+    : Date.now()
+  const base = quantizeTime(now, stepMinutes)
+  const pastSteps = typeof options.pastSteps === 'number' && Number.isFinite(options.pastSteps)
+    ? Math.max(0, Math.floor(options.pastSteps))
+    : Math.floor(normalizeRadarPastMinutes(options.pastMinutes) / stepMinutes)
+
+  const frames: RadarFrame[] = []
+  for (let i = pastSteps; i >= 0; i -= 1) {
+    const timestamp = base - i * stepMinutes * 60 * 1000
+    frames.push({
+      timestamp,
+      isoTime: new Date(timestamp).toISOString(),
+      epochSeconds: Math.floor(timestamp / 1000),
+      offsetMinutes: i === 0 ? 0 : -i * stepMinutes,
+      isLive: i === 0,
+    })
+  }
+  return frames
+}

--- a/lib/radar/radar-url-state.ts
+++ b/lib/radar/radar-url-state.ts
@@ -1,0 +1,135 @@
+export const DEFAULT_RADAR_ZOOM = 10
+
+export type RadarLayerParam = 'precip' | 'alerts' | 'spc' | 'stormReports'
+
+export interface RadarShareLayerState {
+  precipitation: boolean
+  alerts: boolean
+  spc: boolean
+  stormReports: boolean
+}
+
+export const DEFAULT_RADAR_LAYERS: RadarShareLayerState = {
+  precipitation: true,
+  alerts: true,
+  spc: false,
+  stormReports: false,
+}
+
+export interface ParsedRadarUrlState {
+  layers: RadarShareLayerState
+  frameIndex: number | null
+  zoom: number | null
+}
+
+const LAYER_PARAM_TO_STATE: Record<RadarLayerParam, keyof RadarShareLayerState> = {
+  precip: 'precipitation',
+  alerts: 'alerts',
+  spc: 'spc',
+  stormReports: 'stormReports',
+}
+
+const STATE_TO_LAYER_PARAM: Record<keyof RadarShareLayerState, RadarLayerParam> = {
+  precipitation: 'precip',
+  alerts: 'alerts',
+  spc: 'spc',
+  stormReports: 'stormReports',
+}
+
+function normalizeLayerToken(token: string): RadarLayerParam | null {
+  const normalized = token.trim().toLowerCase()
+  if (normalized === 'precip' || normalized === 'precipitation') return 'precip'
+  if (normalized === 'alerts' || normalized === 'nws') return 'alerts'
+  if (normalized === 'spc' || normalized === 'outlook') return 'spc'
+  if (normalized === 'stormreports' || normalized === 'storm' || normalized === 'reports') {
+    return 'stormReports'
+  }
+  return null
+}
+
+export function parseRadarUrlState(searchParams: URLSearchParams): ParsedRadarUrlState {
+  const layers = { ...DEFAULT_RADAR_LAYERS }
+  const layersParam = searchParams.get('layers')
+
+  if (layersParam === 'none') {
+    layers.precipitation = false
+    layers.alerts = false
+    layers.spc = false
+    layers.stormReports = false
+  } else if (layersParam) {
+    layers.precipitation = false
+    layers.alerts = false
+    layers.spc = false
+    layers.stormReports = false
+
+    for (const token of layersParam.split(',')) {
+      const key = normalizeLayerToken(token)
+      if (key) {
+        layers[LAYER_PARAM_TO_STATE[key]] = true
+      }
+    }
+  }
+
+  const frameRaw = searchParams.get('frame')
+  const frameParsed = frameRaw != null ? Number.parseInt(frameRaw, 10) : Number.NaN
+  const frameIndex = Number.isFinite(frameParsed) && frameParsed >= 0 ? frameParsed : null
+
+  const zoomRaw = searchParams.get('zoom')
+  const zoomParsed = zoomRaw != null ? Number.parseInt(zoomRaw, 10) : Number.NaN
+  const zoom = Number.isFinite(zoomParsed) && zoomParsed >= 1 && zoomParsed <= 18 ? zoomParsed : null
+
+  return { layers, frameIndex, zoom }
+}
+
+export function layersMatchDefault(layers: RadarShareLayerState): boolean {
+  return (
+    layers.precipitation === DEFAULT_RADAR_LAYERS.precipitation
+    && layers.alerts === DEFAULT_RADAR_LAYERS.alerts
+    && layers.spc === DEFAULT_RADAR_LAYERS.spc
+    && layers.stormReports === DEFAULT_RADAR_LAYERS.stormReports
+  )
+}
+
+export function serializeRadarUrlParams(state: {
+  layers: RadarShareLayerState
+  frameIndex: number
+  zoom: number | null
+  frameCount: number
+}): URLSearchParams {
+  const params = new URLSearchParams()
+
+  if (!layersMatchDefault(state.layers)) {
+    const enabled = (Object.keys(STATE_TO_LAYER_PARAM) as Array<keyof RadarShareLayerState>)
+      .filter((layerKey) => state.layers[layerKey])
+      .map((layerKey) => STATE_TO_LAYER_PARAM[layerKey])
+
+    params.set('layers', enabled.length > 0 ? enabled.join(',') : 'none')
+  }
+
+  if (state.zoom != null && Math.round(state.zoom) !== DEFAULT_RADAR_ZOOM) {
+    params.set('zoom', String(Math.round(state.zoom)))
+  }
+
+  const liveIndex = Math.max(0, state.frameCount - 1)
+  if (state.frameCount > 0 && state.frameIndex >= 0 && state.frameIndex < liveIndex) {
+    params.set('frame', String(state.frameIndex))
+  }
+
+  return params
+}
+
+export function mergeRadarUrlParams(
+  existing: URLSearchParams,
+  radarParams: URLSearchParams,
+): URLSearchParams {
+  const merged = new URLSearchParams(existing.toString())
+  merged.delete('layers')
+  merged.delete('zoom')
+  merged.delete('frame')
+
+  for (const [key, value] of radarParams.entries()) {
+    merged.set(key, value)
+  }
+
+  return merged
+}

--- a/planning/radar-paid-provider-spike.md
+++ b/planning/radar-paid-provider-spike.md
@@ -1,0 +1,45 @@
+# Radar Paid Provider Spike
+
+## Context
+
+The North America radar modernization now has a public-data baseline:
+
+- US: NOAA MRMS metadata default with Iowa NEXRAD fallback.
+- Canada: MSC GeoMet WMS.
+- Broader North America/global fallback: RainViewer tile template.
+- Severe weather context: NWS alert polygons, SPC outlooks, and recent storm reports.
+
+Paid radar should only be introduced if it improves reliability, coverage, latency, nowcast quality, or user value enough to justify recurring cost and operational complexity.
+
+## Candidate Providers
+
+| Provider | Why evaluate | Cost posture | Notes |
+| --- | --- | --- | --- |
+| Tomorrow.io Weather Maps | Low published entry price and broad weather map layers | Low paid tier appears plausible | Confirm radar tile call accounting and allowed public web usage before implementation. |
+| meteoblue Weather Maps API | Radar, satellite, and forecast map layers with a modern map product | Unknown/custom business pricing | Evaluate only if public baseline feels materially less polished. |
+| RainViewer commercial/Pro terms | Already fits the fallback tile model and has radar-specific UX | Public API is free/no-SLA for small use; commercial terms require review | Good first commercial conversation because integration shape is already compatible. |
+| Xweather/Aeris | Strong severe weather, lightning, and enterprise radar layers | Likely too expensive for first pass | Do not implement unless a higher budget is explicitly approved. |
+
+## Measurement Gate
+
+Before adopting a paid source, measure the public baseline:
+
+- Average radar page tile requests per view on desktop and mobile.
+- Tile requests during a 4-hour animation loop at 1x playback.
+- Vercel function invocations and egress if any source is proxied.
+- Load time and Lighthouse score for `/radar`.
+- Tile failure rate and provider fallback count from logs/Sentry.
+
+## Decision Criteria
+
+Approve a paid provider only if all of the following are true:
+
+- Monthly cost is acceptable at expected traffic with at least 3x headroom.
+- Keys remain server-side or are restricted to safe browser usage by the provider.
+- Terms allow public consumer web display with required attribution.
+- The provider improves at least one visible user outcome: smoother animation, better Canada/Mexico coverage, future radar/nowcast, satellite/lightning, or stronger uptime.
+- The implementation can enforce usage caps or graceful fallback before launch.
+
+## Current Recommendation
+
+Ship the public-data baseline first. Then run a short trial with Tomorrow.io and RainViewer commercial terms using measured tile counts from the live baseline. Keep Xweather/Aeris out of scope unless the product direction shifts toward premium severe-weather intelligence.

--- a/tests/e2e/radar.spec.ts
+++ b/tests/e2e/radar.spec.ts
@@ -85,5 +85,17 @@ test.describe('Radar Map', () => {
 
     await expect(page.getByText(/GEOMET RADAR/i)).toBeVisible({ timeout: 15000 });
   });
+
+  test('radar honors shareable URL layer and frame params', async ({ page }) => {
+    await page.goto('/radar?location=Chicago&layers=precip,spc&frame=5&zoom=8');
+    await waitForRadarToLoad(page);
+
+    await page.getByRole('button', { name: /LAYERS/i }).click();
+    await expect(page.getByText(/✓ SPC Outlook/i)).toBeVisible();
+    await expect(page.locator('[data-radar-container] input[type="range"]').nth(1)).toHaveValue('5');
+    await expect(page).toHaveURL(/layers=precip(?:%2C|,)?spc/);
+    await expect(page).toHaveURL(/(?:^|[?&])frame=5(?:&|$)/);
+    await expect(page).toHaveURL(/(?:^|[?&])zoom=8(?:&|$)/);
+  });
 });
 

--- a/tests/e2e/radar.spec.ts
+++ b/tests/e2e/radar.spec.ts
@@ -1,123 +1,89 @@
 import { test, expect } from './fixtures';
-import { setupStableApp, navigateToMapPage, waitForRadarToLoad, checkRadarVisibility, setTheme } from '../fixtures/utils';
+import {
+  setupStableApp,
+  navigateToRadarPage,
+  waitForRadarToLoad,
+  checkRadarVisibility,
+  setTheme,
+  stubRadarApis,
+} from '../fixtures/utils';
 
 test.describe('Radar Map', () => {
   test.beforeEach(async ({ page }) => {
     await setupStableApp(page);
+    await stubRadarApis(page);
   });
 
   test('radar map loads successfully', async ({ page }) => {
-    await navigateToMapPage(page);
+    await navigateToRadarPage(page);
     
-    // Wait for radar to load
     await waitForRadarToLoad(page);
     
-    // Verify radar container exists
-    const radarContainer = page.locator('[data-radar-container], [class*="map"], [class*="Map"]').first();
-    await expect(radarContainer).toBeVisible({ timeout: 15000 });
+    const radarContainer = page.locator('[data-radar-container]').first();
+    await expect(radarContainer).toBeVisible();
+    await expect(page.getByText(/MRMS RADAR/i)).toBeVisible({ timeout: 15000 });
   });
 
   test('radar visible in synthwave theme', async ({ page }) => {
     await setTheme(page, 'synthwave84');
-    // Wait for theme to be fully applied
-    await page.waitForTimeout(300);
-    
-    await navigateToMapPage(page);
+    await navigateToRadarPage(page);
     
     await waitForRadarToLoad(page);
-    
-    // Wait a bit more for radar to fully render
-    await page.waitForTimeout(1000);
-    
-    // Check that radar container has proper z-index
+
     const isVisible = await checkRadarVisibility(page);
     expect(isVisible).toBeTruthy();
-    
-    // Verify radar container is above scanlines (z-index >= 10000)
-    const radarContainer = page.locator('[data-radar-container]').first();
-    if (await radarContainer.count() > 0) {
-      const zIndex = await radarContainer.evaluate((el) => {
-        return window.getComputedStyle(el).zIndex;
-      });
-      
-      // Should be 10000 or higher to be above theme overlays
-      expect(parseInt(zIndex) >= 10000 || zIndex === 'auto').toBeTruthy();
-    }
   });
 
   test('radar visible in matrix theme', async ({ page }) => {
     await setTheme(page, 'matrix');
-    // Wait for theme to be fully applied
-    await page.waitForTimeout(300);
-    
-    await navigateToMapPage(page);
+    await navigateToRadarPage(page);
     
     await waitForRadarToLoad(page);
-    
-    // Wait a bit more for radar to fully render
-    await page.waitForTimeout(1000);
-    
-    // Check that radar container has proper z-index
+
     const isVisible = await checkRadarVisibility(page);
     expect(isVisible).toBeTruthy();
-    
-    // Verify radar container is above CRT scanlines
-    const radarContainer = page.locator('[data-radar-container]').first();
-    if (await radarContainer.count() > 0) {
-      const zIndex = await radarContainer.evaluate((el) => {
-        return window.getComputedStyle(el).zIndex;
-      });
-      
-      expect(parseInt(zIndex) >= 10000 || zIndex === 'auto').toBeTruthy();
-    }
   });
 
   test('radar visible in default dark theme', async ({ page }) => {
     await setTheme(page, 'dark');
-    await navigateToMapPage(page);
+    await navigateToRadarPage(page);
     
     await waitForRadarToLoad(page);
     
-    const radarContainer = page.locator('[data-radar-container], [class*="map"], [class*="Map"]').first();
-    await expect(radarContainer).toBeVisible({ timeout: 15000 });
+    await expect(page.locator('[data-radar-container] .ol-viewport')).toBeVisible();
   });
 
-  test('radar map controls are visible', async ({ page }) => {
-    await navigateToMapPage(page);
+  test('radar map controls and overlay toggles are visible', async ({ page }) => {
+    await navigateToRadarPage(page);
     await waitForRadarToLoad(page);
     
-    // Wait for controls to render (they may load after the map)
-    await page.waitForTimeout(2000);
-    
-    // First verify the radar map is visible
-    const isVisible = await checkRadarVisibility(page);
-    expect(isVisible).toBeTruthy();
-    
-    // Check for layer controls, buttons, or status badge
-    // Look for common control patterns in the radar component
-    const controls = page.locator('button, [class*="badge"], [class*="control"], [class*="Control"], [role="button"]');
-    const controlCount = await controls.count();
-    
-    // Should have at least some controls (play/pause, layer menu, etc.)
-    // Controls are optional - main thing is that the map is visible
-    if (controlCount > 0) {
-      expect(controlCount).toBeGreaterThan(0);
-    }
+    await expect(page.getByRole('button', { name: /PLAY/i })).toBeVisible();
+    await page.getByRole('button', { name: /LAYERS/i }).click();
+    await expect(page.getByText(/NWS Alerts/i)).toBeVisible();
+    await expect(page.getByText(/SPC Outlook/i)).toBeVisible();
+    await expect(page.getByText(/Storm Reports/i)).toBeVisible();
   });
 
-  test('radar map displays status badge', async ({ page }) => {
-    await navigateToMapPage(page);
+  test('radar map displays provider status badge and source attribution', async ({ page }) => {
+    await navigateToRadarPage(page);
     await waitForRadarToLoad(page);
     
-    // Look for status badge with radar info
-    const statusBadge = page.locator('[class*="badge"], [class*="status"]').filter({ 
-      hasText: /(RADAR|NEXRAD|LIVE|US LOCATIONS)/i 
+    await expect(page.getByText(/MRMS RADAR/i)).toBeVisible();
+    await expect(page.getByText(/Source: NOAA\/NWS MRMS/i)).toBeVisible();
+  });
+
+  test('Canada location selects GeoMet provider', async ({ page }) => {
+    await setupStableApp(page, {
+      cityName: 'Edmonton',
+      country: 'CA',
+      lat: 53.5461,
+      lon: -113.4938,
     });
-    
-    // Status badge may or may not exist depending on location
-    if (await statusBadge.count() > 0) {
-      await expect(statusBadge.first()).toBeVisible({ timeout: 5000 });
-    }
+    await stubRadarApis(page);
+    await navigateToRadarPage(page, 'Edmonton, CA');
+    await waitForRadarToLoad(page);
+
+    await expect(page.getByText(/GEOMET RADAR/i)).toBeVisible({ timeout: 15000 });
   });
 });
 

--- a/tests/fixtures/utils.ts
+++ b/tests/fixtures/utils.ts
@@ -140,6 +140,55 @@ export async function stubWeatherApis(page: Page, opts: StubOptions = {}): Promi
   const nowIso = new Date().toISOString();
   const forecastDay = nowIso.split('T')[0];
 
+  await page.route('**/api/open-meteo/forecast**', (route) => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({
+      latitude: o.lat,
+      longitude: o.lon,
+      timezone: 'America/New_York',
+      utc_offset_seconds: -14400,
+      current: {
+        temperature_2m: o.tempF,
+        relative_humidity_2m: o.humidity,
+        weather_code: 0,
+        wind_speed_10m: 5,
+        wind_direction_10m: 45,
+        wind_gusts_10m: 12,
+        surface_pressure: o.pressure,
+        uv_index: 5,
+      },
+      daily: {
+        time: [forecastDay],
+        temperature_2m_max: [o.tempF + 3],
+        temperature_2m_min: [o.tempF - 3],
+        weather_code: [0],
+        precipitation_probability_max: [20],
+        sunrise: [`${forecastDay}T06:00`],
+        sunset: [`${forecastDay}T20:00`],
+      },
+      hourly: {
+        time: Array.from({ length: 48 }, (_, i) => {
+          const d = new Date(Date.now() + i * 60 * 60 * 1000);
+          return d.toISOString().slice(0, 16);
+        }),
+        temperature_2m: Array.from({ length: 48 }, () => o.tempF),
+        weather_code: Array.from({ length: 48 }, () => 0),
+        precipitation_probability: Array.from({ length: 48 }, () => 20),
+        wind_speed_10m: Array.from({ length: 48 }, () => 5),
+        wind_direction_10m: Array.from({ length: 48 }, () => 45),
+        relative_humidity_2m: Array.from({ length: 48 }, () => o.humidity),
+        visibility: Array.from({ length: 48 }, () => 16000),
+      },
+    })
+  }));
+
+  await page.route('**/api/open-meteo/air-quality**', (route) => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ current: { us_aqi: 30 } })
+  }));
+
   // Regex (not globs): `**/precipitation**` matches `.../precipitation-history` because ** spans `-history`;
   // Playwright checks routes last-registered-first, so the wrong stub could win without exact paths.
   await page.route(/.*\/api\/weather\/precipitation-history(?:\?.*)?$/, (route) => route.fulfill({
@@ -665,56 +714,114 @@ export async function getCurrentTheme(page: Page): Promise<string> {
 //   RADAR MAP HELPERS
 //   ═══════════════════════════════════════════════════════════
 
+const transparentPng = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==',
+  'base64'
+);
+
+export async function stubRadarApis(page: Page): Promise<void> {
+  await page.route('**/api/weather/noaa-wms**', (route) => route.fulfill({
+    status: 200,
+    contentType: 'image/png',
+    body: transparentPng,
+  }));
+
+  await page.route('**/geo.weather.gc.ca/geomet/**', (route) => route.fulfill({
+    status: 200,
+    contentType: 'image/png',
+    body: transparentPng,
+  }));
+
+  await page.route('**/tilecache.rainviewer.com/**', (route) => route.fulfill({
+    status: 200,
+    contentType: 'image/png',
+    body: transparentPng,
+  }));
+
+  await page.route('**/basemaps.cartocdn.com/**', (route) => route.fulfill({
+    status: 200,
+    contentType: 'image/png',
+    body: transparentPng,
+  }));
+
+  await page.route('**/api/weather/alerts**', (route) => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({
+      type: 'FeatureCollection',
+      features: [{
+        type: 'Feature',
+        geometry: {
+          type: 'Polygon',
+          coordinates: [[[-74.2, 40.6], [-73.8, 40.6], [-73.8, 40.9], [-74.2, 40.9], [-74.2, 40.6]]],
+        },
+        properties: {
+          id: 'alert-1',
+          event: 'Severe Thunderstorm Warning',
+          severity: 'Severe',
+          headline: 'Severe Thunderstorm Warning for test area',
+          areaDesc: 'Test County',
+          instruction: 'Move indoors.',
+        },
+      }],
+    }),
+  }));
+
+  await page.route('**/api/weather/spc-outlook**', (route) => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({
+      type: 'FeatureCollection',
+      features: [{
+        type: 'Feature',
+        geometry: {
+          type: 'Polygon',
+          coordinates: [[[-75, 40], [-73, 40], [-73, 42], [-75, 42], [-75, 40]]],
+        },
+        properties: {
+          LABEL: 'SLGT',
+          LABEL2: 'Slight Risk',
+          fill: '#FFE066',
+          stroke: '#facc15',
+        },
+      }],
+    }),
+  }));
+
+  await page.route('**/api/weather/storm-reports**', (route) => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({
+      reports: [{
+        category: 'hail',
+        time: '2100',
+        size: '1.00',
+        location: 'Test City',
+        county: 'Test',
+        state: 'NY',
+        lat: 40.75,
+        lon: -74,
+        comments: 'Test hail report',
+        date: '2026-06-18',
+      }],
+      total: 1,
+      days: 2,
+    }),
+  }));
+}
+
+export async function navigateToRadarPage(page: Page, location = 'New York, US'): Promise<void> {
+  await page.goto(`/radar?location=${encodeURIComponent(location)}`, { waitUntil: 'domcontentloaded' });
+}
+
 export async function navigateToMapPage(page: Page): Promise<void> {
-  await page.goto('/map', { waitUntil: 'domcontentloaded' });
-  // Wait for page to be fully loaded
-  await page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {
-    // If networkidle times out, continue anyway
-  });
-  // Wait for map container to exist in DOM
-  await page.waitForSelector('[data-radar-container], [class*="map"], [class*="Map"], [class*="radar"], [class*="Radar"]', {
-    timeout: 15000,
-    state: 'attached'
-  }).catch(() => {
-    // If selector not found, that's okay - we'll check in waitForRadarToLoad
-  });
+  await navigateToRadarPage(page);
 }
 
 export async function waitForRadarToLoad(page: Page): Promise<void> {
-  // Wait for radar container or map element to be attached to DOM
-  // Try multiple selectors to be more flexible
-  const selectors = [
-    '[data-radar-container]',
-    '[class*="map"]',
-    '[class*="Map"]',
-    '[class*="radar"]',
-    '[class*="Radar"]',
-  ];
-
-  let found = false;
-  for (const selector of selectors) {
-    try {
-      await page.waitForSelector(selector, { timeout: 5000, state: 'attached' });
-      found = true;
-      break;
-    } catch (e) {
-      // Try next selector
-      continue;
-    }
-  }
-
-  if (!found) {
-    // If no specific selector found, wait for any div with height (map containers usually have height)
-    await page.waitForFunction(() => {
-      const containers = document.querySelectorAll('[data-radar-container], [class*="map"], [class*="Map"]');
-      return containers.length > 0;
-    }, { timeout: 10000 }).catch(() => {
-      // If still not found, that's okay - test will fail with a clear error
-    });
-  }
-
-  // Give the map a moment to render
-  await page.waitForTimeout(1000);
+  const radarContainer = page.locator('[data-radar-container]').first();
+  await expect(radarContainer).toBeVisible({ timeout: 20000 });
+  await expect(radarContainer.locator('.ol-viewport')).toBeVisible({ timeout: 20000 });
 }
 
 export async function checkRadarVisibility(page: Page): Promise<boolean> {


### PR DESCRIPTION
## Summary

- Add a metadata-driven radar provider layer (NOAA MRMS, Iowa NEXRAD, MSC GeoMet, RainViewer fallback) with a `/api/radar/metadata` endpoint and unit tests.
- Refactor the OpenLayers radar map to use provider metadata, add NWS alerts, SPC outlooks, and storm report overlays with click-to-inspect, plus mobile-first controls and provider attribution.
- Improve radar page UX with inline location search, location-aware share URLs, deterministic Playwright stubs, and updated product copy.

## Test plan

- [x] `npm test -- radar` (12 unit tests)
- [x] `npx playwright test tests/e2e/radar.spec.ts --project=chromium` (7 tests)
- [ ] CI build, lint, and full E2E on PR


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded radar coverage to North America with multiple provider options (NOAA MRMS, Iowa NEXRAD, MSC GeoMet) and automatic fallback support.
  * Added weather alerts, severe weather outlooks, and storm reports overlays to the radar map.
  * Radar view settings (layers, zoom, frame) now preserved in shareable URLs.
  * New radar metadata API endpoint for location-based provider selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->