### PR TITLE
feat(radar): follow-up hardening, telemetry, GOES satellite, and map modules

### DIFF
--- a/__tests__/radar-providers.test.ts
+++ b/__tests__/radar-providers.test.ts
@@ -41,4 +41,12 @@ describe('radar providers', () => {
     expect(canada.frames).toHaveLength(31)
     expect(canada.legend[0].value).toContain('dBZ')
   })
+
+  it('defaults non-finite metadata timestamps to the current time', () => {
+    const metadata = buildRadarMetadata(40.7128, -74.006, Number.NaN)
+
+    expect(metadata.generatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+    expect(metadata.frames.length).toBeGreaterThan(0)
+    expect(Number.isFinite(Date.parse(metadata.generatedAt))).toBe(true)
+  })
 })

--- a/__tests__/radar-timestamps.test.ts
+++ b/__tests__/radar-timestamps.test.ts
@@ -39,4 +39,12 @@ describe('radar timestamps', () => {
     expect(frames).toHaveLength(3)
     expect(frames.map((frame) => frame.offsetMinutes)).toEqual([-20, -10, 0])
   })
+
+  it('clamps excessive pastSteps to the max history window', () => {
+    const frames = buildRadarFrames({ now, stepMinutes: 5, pastSteps: 999_999 })
+
+    expect(frames).toHaveLength(145)
+    expect(frames[0].offsetMinutes).toBe(-720)
+    expect(frames.at(-1)?.isLive).toBe(true)
+  })
 })

--- a/__tests__/radar-url-state.test.ts
+++ b/__tests__/radar-url-state.test.ts
@@ -22,6 +22,7 @@ describe('radar-url-state', () => {
       alerts: false,
       spc: true,
       stormReports: false,
+      satellite: false,
     })
     expect(parsed.frameIndex).toBe(12)
     expect(parsed.zoom).toBe(8)
@@ -47,6 +48,7 @@ describe('radar-url-state', () => {
         alerts: false,
         spc: true,
         stormReports: false,
+        satellite: false,
       },
       frameIndex: 10,
       zoom: 7,

--- a/app/api/radar/metadata/route.ts
+++ b/app/api/radar/metadata/route.ts
@@ -1,6 +1,7 @@
 import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
 import { buildRadarMetadata } from '@/lib/radar'
+import { captureRadarMetadataRouteError, trackRadarMetadataApi } from '@/lib/radar/telemetry'
 
 function parseCoordinate(value: string | null): number | null {
   if (value == null || value.trim() === '') return null
@@ -9,6 +10,7 @@ function parseCoordinate(value: string | null): number | null {
 }
 
 export async function GET(request: NextRequest) {
+  const startTime = Date.now()
   try {
     const lat = parseCoordinate(request.nextUrl.searchParams.get('lat'))
     const lon = parseCoordinate(request.nextUrl.searchParams.get('lon'))
@@ -28,6 +30,7 @@ export async function GET(request: NextRequest) {
     }
 
     const metadata = buildRadarMetadata(lat, lon)
+    trackRadarMetadataApi(Date.now() - startTime, true)
 
     return NextResponse.json(metadata, {
       headers: {
@@ -35,6 +38,8 @@ export async function GET(request: NextRequest) {
       },
     })
   } catch (error) {
+    trackRadarMetadataApi(Date.now() - startTime, false)
+    captureRadarMetadataRouteError(error)
     console.error('[radar-metadata]', error)
     return NextResponse.json(
       { error: 'Failed to build radar metadata' },

--- a/app/api/weather/noaa-goes-wms/route.ts
+++ b/app/api/weather/noaa-goes-wms/route.ts
@@ -1,0 +1,125 @@
+import type { NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
+import { rateLimitRequest } from '@/lib/services/weather-rate-limiter'
+import { tileProxyOriginHeaders } from '@/lib/services/tile-proxy-cors'
+import { GOES_IR_WMS_LAYER } from '@/lib/radar/goes-satellite'
+
+export const runtime = 'nodejs'
+
+const GOES_WMS_BASE_URL =
+  'https://nowcoast.noaa.gov/arcgis/services/nowcoast/sat_meteo_imagery_time/MapServer/WMSServer'
+
+const ALLOWED_PARAMS = [
+  'REQUEST',
+  'SERVICE',
+  'VERSION',
+  'LAYERS',
+  'WIDTH',
+  'HEIGHT',
+  'CRS',
+  'BBOX',
+  'TIME',
+  'STYLES',
+  'FORMAT',
+] as const
+
+const TRANSPARENT_PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==',
+  'base64',
+)
+
+function transparentTileResponse(request: NextRequest, cacheControl = 'public, max-age=60') {
+  return new NextResponse(TRANSPARENT_PNG, {
+    headers: {
+      'Content-Type': 'image/png',
+      'Cache-Control': cacheControl,
+      ...tileProxyOriginHeaders(request),
+    },
+  })
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const rateLimit = await rateLimitRequest(request)
+    if (!rateLimit.allowed) return rateLimit.response
+
+    const { searchParams } = new URL(request.url)
+    const requiredParams = ['REQUEST', 'SERVICE', 'VERSION', 'LAYERS', 'WIDTH', 'HEIGHT', 'CRS', 'BBOX']
+    for (const param of requiredParams) {
+      if (!searchParams.get(param)) {
+        return NextResponse.json(
+          { error: `Missing required parameter: ${param}` },
+          { status: 400, headers: tileProxyOriginHeaders(request) },
+        )
+      }
+    }
+
+    const layer = searchParams.get('LAYERS')
+    if (layer !== GOES_IR_WMS_LAYER) {
+      return NextResponse.json(
+        { error: 'Unsupported GOES layer' },
+        { status: 400, headers: tileProxyOriginHeaders(request) },
+      )
+    }
+
+    const goesUrl = new URL(GOES_WMS_BASE_URL)
+    for (const key of ALLOWED_PARAMS) {
+      const val = searchParams.get(key)
+      if (val) goesUrl.searchParams.set(key, val)
+    }
+
+    const response = await fetch(goesUrl.toString(), {
+      headers: {
+        'User-Agent': '16-Bit-Weather/noaa-goes-wms-proxy',
+      },
+      signal: AbortSignal.timeout(10000),
+    })
+
+    if (!response.ok) {
+      console.error(`[NOAA GOES WMS Proxy] Error ${response.status}: ${response.statusText}`)
+      return transparentTileResponse(request)
+    }
+
+    const contentType = response.headers.get('content-type') || 'image/png'
+    const imageBuffer = await response.arrayBuffer()
+    const timeParam = searchParams.get('TIME')
+    let cacheControl = 'public, max-age=300, s-maxage=600'
+
+    if (timeParam) {
+      try {
+        const tileTime = new Date(timeParam).getTime()
+        const ageMinutes = (Date.now() - tileTime) / (1000 * 60)
+        if (ageMinutes < 15) {
+          cacheControl = 'public, max-age=120, s-maxage=300, stale-while-revalidate=120'
+        } else if (ageMinutes < 120) {
+          cacheControl = 'public, max-age=900, s-maxage=1800, stale-while-revalidate=900'
+        } else {
+          cacheControl = 'public, max-age=3600, s-maxage=7200, stale-while-revalidate=3600'
+        }
+      } catch {
+        // keep default cache
+      }
+    }
+
+    return new NextResponse(imageBuffer, {
+      headers: {
+        'Content-Type': contentType,
+        'Cache-Control': cacheControl,
+        ...tileProxyOriginHeaders(request),
+      },
+    })
+  } catch (error) {
+    console.error('[NOAA GOES WMS Proxy] Fetch error:', error)
+    return transparentTileResponse(request, 'public, max-age=30')
+  }
+}
+
+export async function OPTIONS(request: NextRequest) {
+  return new NextResponse(null, {
+    status: 204,
+    headers: {
+      ...tileProxyOriginHeaders(request),
+      'Access-Control-Max-Age': '86400',
+    },
+  })
+}

--- a/components/radar/radar-constants.ts
+++ b/components/radar/radar-constants.ts
@@ -1,0 +1,9 @@
+export const TILE_TRANSITION_MS = 500
+export const BASE_ANIMATION_INTERVAL_MS = 500
+export const PRELOAD_FRAMES_AHEAD = 3
+export const TILE_ERROR_FALLBACK_THRESHOLD = 5
+export const URL_SYNC_DEBOUNCE_MS = 300
+
+export const CARTO_DARK_MATTER_URL = 'https://{a-d}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png'
+
+export const DEFAULT_MAP_CENTER: [number, number] = [-98.5795, 39.8283]

--- a/components/radar/radar-map-types.ts
+++ b/components/radar/radar-map-types.ts
@@ -1,0 +1,39 @@
+import type { ThemeType } from '@/lib/theme-config'
+
+export interface WeatherMapProps {
+  latitude?: number
+  longitude?: number
+  locationName?: string
+  theme?: ThemeType
+  displayMode?: 'full-page' | 'widget'
+}
+
+export type RadarFeatureCollection = {
+  type: 'FeatureCollection'
+  features: Array<{
+    type?: string
+    geometry?: unknown
+    properties?: Record<string, unknown>
+  }>
+}
+
+export interface RadarStormReport {
+  category: 'tornado' | 'hail' | 'wind'
+  time: string
+  size: string
+  location: string
+  state: string
+  lat: number | null
+  lon: number | null
+  comments: string
+  date: string
+}
+
+export interface RadarSelectedOverlay {
+  x: number
+  y: number
+  title: string
+  body: string
+}
+
+export type RadarPlaybackSpeed = 0.5 | 1 | 2

--- a/components/radar/radar-styles.ts
+++ b/components/radar/radar-styles.ts
@@ -1,0 +1,39 @@
+import type { FeatureLike } from 'ol/Feature'
+import { Style, Fill, Stroke, Circle as CircleStyle } from 'ol/style'
+
+export function alertStyle(feature: FeatureLike): Style {
+  const severity = String(feature.get('severity') ?? 'Minor')
+  const color = severity === 'Extreme'
+    ? '#dc2626'
+    : severity === 'Severe'
+      ? '#ea580c'
+      : severity === 'Moderate'
+        ? '#ca8a04'
+        : '#2563eb'
+
+  return new Style({
+    fill: new Fill({ color: `${color}33` }),
+    stroke: new Stroke({ color, width: 2 }),
+  })
+}
+
+export function spcStyle(feature: FeatureLike): Style {
+  const fill = String(feature.get('fill') ?? '#facc15')
+  const stroke = String(feature.get('stroke') ?? '#fef08a')
+  return new Style({
+    fill: new Fill({ color: `${fill}66` }),
+    stroke: new Stroke({ color: stroke, width: 2 }),
+  })
+}
+
+export function stormReportStyle(feature: FeatureLike): Style {
+  const category = String(feature.get('category') ?? '')
+  const color = category === 'tornado' ? '#ef4444' : category === 'hail' ? '#a855f7' : '#38bdf8'
+  return new Style({
+    image: new CircleStyle({
+      radius: 6,
+      fill: new Fill({ color: `${color}dd` }),
+      stroke: new Stroke({ color: '#020617', width: 1 }),
+    }),
+  })
+}

--- a/components/radar/radar-tile-utils.ts
+++ b/components/radar/radar-tile-utils.ts
@@ -1,0 +1,6 @@
+import type { RadarFrame, RadarProvider } from '@/lib/radar'
+
+export function buildRadarXyzUrl(provider: RadarProvider, frame: RadarFrame): string | null {
+  if (!provider.xyz) return null
+  return provider.xyz.urlTemplate.replace('{epochSeconds}', String(frame.epochSeconds))
+}

--- a/components/weather-map-openlayers.tsx
+++ b/components/weather-map-openlayers.tsx
@@ -8,11 +8,36 @@ import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import { Play, Pause, SkipBack, SkipForward, Layers, ChevronDown, Loader2 } from 'lucide-react'
 import type { ThemeType } from '@/lib/theme-config'
 import {
+  BASE_ANIMATION_INTERVAL_MS,
+  CARTO_DARK_MATTER_URL,
+  DEFAULT_MAP_CENTER,
+  PRELOAD_FRAMES_AHEAD,
+  TILE_ERROR_FALLBACK_THRESHOLD,
+  TILE_TRANSITION_MS,
+  URL_SYNC_DEBOUNCE_MS,
+} from '@/components/radar/radar-constants'
+import type {
+  RadarFeatureCollection,
+  RadarSelectedOverlay,
+  RadarStormReport,
+  WeatherMapProps,
+} from '@/components/radar/radar-map-types'
+import { alertStyle, spcStyle, stormReportStyle } from '@/components/radar/radar-styles'
+import { buildRadarXyzUrl } from '@/components/radar/radar-tile-utils'
+import {
   buildRadarFrames,
   DEFAULT_RADAR_ZOOM,
+  GOES_IR_ATTRIBUTION,
+  GOES_IR_TIME_PARAM,
+  GOES_IR_WMS_PARAMS,
+  GOES_IR_WMS_PROXY_PATH,
   mergeRadarUrlParams,
   parseRadarUrlState,
   serializeRadarUrlParams,
+  captureRadarMetadataClientError,
+  recordRadarMetadataClientLoad,
+  recordRadarProviderFallback,
+  recordRadarTileError,
   type RadarFrame,
   type RadarMetadata,
   type RadarProvider,
@@ -32,89 +57,6 @@ import VectorLayer from 'ol/layer/Vector'
 import VectorSource from 'ol/source/Vector'
 import GeoJSON from 'ol/format/GeoJSON'
 import { Style, Icon, Fill, Stroke, Circle as CircleStyle } from 'ol/style'
-import type { FeatureLike } from 'ol/Feature'
-
-// Animation tuning constants
-const TILE_TRANSITION_MS = 500 // Smooth crossfade between frames
-const BASE_ANIMATION_INTERVAL_MS = 500 // Fluid playback speed
-const PRELOAD_FRAMES_AHEAD = 3 // Number of frames to preload during playback
-const TILE_ERROR_FALLBACK_THRESHOLD = 5
-const URL_SYNC_DEBOUNCE_MS = 300
-
-// CartoDB Dark Matter base map for better radar contrast
-// Note: Removed {r} (Leaflet retina placeholder) - OpenLayers XYZ doesn't support it
-const CARTO_DARK_MATTER_URL = 'https://{a-d}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png'
-
-interface WeatherMapProps {
-  latitude?: number
-  longitude?: number
-  locationName?: string
-  theme?: ThemeType
-  displayMode?: 'full-page' | 'widget'
-}
-
-type FeatureCollection = {
-  type: 'FeatureCollection'
-  features: Array<{
-    type?: string
-    geometry?: unknown
-    properties?: Record<string, unknown>
-  }>
-}
-
-interface StormReport {
-  category: 'tornado' | 'hail' | 'wind'
-  time: string
-  size: string
-  location: string
-  state: string
-  lat: number | null
-  lon: number | null
-  comments: string
-  date: string
-}
-
-function buildRadarXyzUrl(provider: RadarProvider, frame: RadarFrame): string | null {
-  if (!provider.xyz) return null
-  return provider.xyz.urlTemplate.replace('{epochSeconds}', String(frame.epochSeconds))
-}
-
-function alertStyle(feature: FeatureLike): Style {
-  const severity = String(feature.get('severity') ?? 'Minor')
-  const color = severity === 'Extreme'
-    ? '#dc2626'
-    : severity === 'Severe'
-      ? '#ea580c'
-      : severity === 'Moderate'
-        ? '#ca8a04'
-        : '#2563eb'
-
-  return new Style({
-    fill: new Fill({ color: `${color}33` }),
-    stroke: new Stroke({ color, width: 2 }),
-  })
-}
-
-function spcStyle(feature: FeatureLike): Style {
-  const fill = String(feature.get('fill') ?? '#facc15')
-  const stroke = String(feature.get('stroke') ?? '#fef08a')
-  return new Style({
-    fill: new Fill({ color: `${fill}66` }),
-    stroke: new Stroke({ color: stroke, width: 2 }),
-  })
-}
-
-function stormReportStyle(feature: FeatureLike): Style {
-  const category = String(feature.get('category') ?? '')
-  const color = category === 'tornado' ? '#ef4444' : category === 'hail' ? '#a855f7' : '#38bdf8'
-  return new Style({
-    image: new CircleStyle({
-      radius: 6,
-      fill: new Fill({ color: `${color}dd` }),
-      stroke: new Stroke({ color: '#020617', width: 1 }),
-    }),
-  })
-}
 
 const WeatherMapOpenLayers = ({
   latitude,
@@ -132,6 +74,8 @@ const WeatherMapOpenLayers = ({
   const mapInstanceRef = useRef<Map | null>(null)
   const radarLayerRef = useRef<TileLayer<TileWMS | XYZ> | null>(null)
   const radarSourceRef = useRef<TileWMS | XYZ | null>(null)
+  const satelliteLayerRef = useRef<TileLayer<TileWMS> | null>(null)
+  const satelliteSourceRef = useRef<TileWMS | null>(null)
   const alertsLayerRef = useRef<VectorLayer<VectorSource> | null>(null)
   const spcLayerRef = useRef<VectorLayer<VectorSource> | null>(null)
   const stormReportsLayerRef = useRef<VectorLayer<VectorSource> | null>(null)
@@ -141,21 +85,17 @@ const WeatherMapOpenLayers = ({
   const [activeFrames, setActiveFrames] = useState<RadarFrame[]>([])
   const [usingFallbackProvider, setUsingFallbackProvider] = useState(false)
   const [radarStateReady, setRadarStateReady] = useState(false)
-  const [alertsGeoJson, setAlertsGeoJson] = useState<FeatureCollection | null>(null)
-  const [spcGeoJson, setSpcGeoJson] = useState<FeatureCollection | null>(null)
-  const [stormReports, setStormReports] = useState<StormReport[]>([])
-  const [selectedOverlay, setSelectedOverlay] = useState<{
-    x: number
-    y: number
-    title: string
-    body: string
-  } | null>(null)
+  const [alertsGeoJson, setAlertsGeoJson] = useState<RadarFeatureCollection | null>(null)
+  const [spcGeoJson, setSpcGeoJson] = useState<RadarFeatureCollection | null>(null)
+  const [stormReports, setStormReports] = useState<RadarStormReport[]>([])
+  const [selectedOverlay, setSelectedOverlay] = useState<RadarSelectedOverlay | null>(null)
 
   const [activeLayers, setActiveLayers] = useState<Record<string, boolean>>(() => ({
     precipitation: parsedUrlStateRef.current.layers.precipitation,
     alerts: parsedUrlStateRef.current.layers.alerts,
     spc: parsedUrlStateRef.current.layers.spc,
     stormReports: parsedUrlStateRef.current.layers.stormReports,
+    satellite: parsedUrlStateRef.current.layers.satellite,
     clouds: false,
     wind: false,
     pressure: false,
@@ -199,6 +139,7 @@ const WeatherMapOpenLayers = ({
 
     async function loadRadarMetadata() {
       setMetadataError(null)
+      const startedAt = performance.now()
       try {
         const params = new URLSearchParams({
           lat: String(latitude),
@@ -240,8 +181,11 @@ const WeatherMapOpenLayers = ({
           setFrameIndex(Math.max(0, refreshedFrames.length - 1))
         }
         setRadarStateReady(true)
+        recordRadarMetadataClientLoad(performance.now() - startedAt, true, latitude, longitude)
       } catch (error) {
         if ((error as Error).name === 'AbortError') return
+        recordRadarMetadataClientLoad(performance.now() - startedAt, false, latitude, longitude)
+        captureRadarMetadataClientError(error, latitude, longitude)
         console.error('[radar-map] metadata load failed', error)
         setRadarMetadata(null)
         setMetadataError('Radar metadata unavailable. Try again shortly.')
@@ -276,6 +220,7 @@ const WeatherMapOpenLayers = ({
       alerts: parsedUrlStateRef.current.layers.alerts,
       spc: parsedUrlStateRef.current.layers.spc,
       stormReports: parsedUrlStateRef.current.layers.stormReports,
+      satellite: parsedUrlStateRef.current.layers.satellite,
     }))
   }, [locationQueryKey])
 
@@ -300,6 +245,7 @@ const WeatherMapOpenLayers = ({
     frameIndexRef.current = nextIndex
     setFrameIndex(nextIndex)
     setMetadataError(null)
+    recordRadarProviderFallback(current?.id, fallback.id, TILE_ERROR_FALLBACK_THRESHOLD)
     console.warn('[radar-map] switched to fallback provider', {
       from: current?.id,
       to: fallback.id,
@@ -329,21 +275,21 @@ const WeatherMapOpenLayers = ({
         if (controller.signal.aborted) return
 
         if (alertsRes.ok) {
-          const alerts = (await alertsRes.json()) as FeatureCollection
+          const alerts = (await alertsRes.json()) as RadarFeatureCollection
           setAlertsGeoJson(alerts.type === 'FeatureCollection' ? alerts : null)
         } else {
           setAlertsGeoJson(null)
         }
 
         if (spcRes.ok) {
-          const spc = (await spcRes.json()) as FeatureCollection
+          const spc = (await spcRes.json()) as RadarFeatureCollection
           setSpcGeoJson(spc.type === 'FeatureCollection' ? spc : null)
         } else {
           setSpcGeoJson(null)
         }
 
         if (reportsRes.ok) {
-          const reportsJson = (await reportsRes.json()) as { reports?: StormReport[] }
+          const reportsJson = (await reportsRes.json()) as { reports?: RadarStormReport[] }
           setStormReports(reportsJson.reports ?? [])
         } else {
           setStormReports([])
@@ -376,8 +322,8 @@ const WeatherMapOpenLayers = ({
   useEffect(() => {
     if (!mapRef.current || mapInstanceRef.current) return
 
-    const centerLon = -98.5795
-    const centerLat = 39.8283
+    const centerLon = DEFAULT_MAP_CENTER[0]
+    const centerLat = DEFAULT_MAP_CENTER[1]
 
 
     // Create base layer (CartoDB Dark Matter - better radar visibility)
@@ -729,6 +675,7 @@ const WeatherMapOpenLayers = ({
         setIsLoading(false)
       }
       tileErrorCountRef.current += 1
+      recordRadarTileError(radarProvider.id, tileErrorCountRef.current)
       console.warn('[radar-map] Tile load error', {
         provider: radarProvider.id,
         count: tileErrorCountRef.current,
@@ -774,6 +721,58 @@ const WeatherMapOpenLayers = ({
     }
   }, [radarProvider, activeLayers.precipitation, radarFrames, timestamps.length, activateFallbackProvider])
 
+  useEffect(() => {
+    if (!mapInstanceRef.current || !activeLayers.satellite || radarFrames.length === 0) {
+      if (satelliteLayerRef.current && mapInstanceRef.current) {
+        mapInstanceRef.current.removeLayer(satelliteLayerRef.current)
+        satelliteLayerRef.current = null
+        satelliteSourceRef.current = null
+      }
+      return
+    }
+
+    const map = mapInstanceRef.current
+    if (satelliteLayerRef.current) {
+      map.removeLayer(satelliteLayerRef.current)
+    }
+
+    const currentIndex = Math.min(
+      Math.max(frameIndexRef.current, 0),
+      radarFrames.length - 1,
+    )
+    const currentFrame = radarFrames[currentIndex]
+
+    const satelliteSource = new TileWMS({
+      url: GOES_IR_WMS_PROXY_PATH,
+      params: {
+        ...GOES_IR_WMS_PARAMS,
+        [GOES_IR_TIME_PARAM]: currentFrame.isoTime,
+      },
+      serverType: 'mapserver',
+      transition: TILE_TRANSITION_MS,
+      crossOrigin: 'anonymous',
+    })
+
+    const satelliteLayer = new TileLayer({
+      source: satelliteSource,
+      opacity: 0.55,
+      zIndex: 450,
+    })
+
+    satelliteLayer.set('name', 'goes-ir-satellite')
+    map.addLayer(satelliteLayer)
+    satelliteLayerRef.current = satelliteLayer
+    satelliteSourceRef.current = satelliteSource
+
+    return () => {
+      if (satelliteLayerRef.current && mapInstanceRef.current) {
+        mapInstanceRef.current.removeLayer(satelliteLayerRef.current)
+        satelliteLayerRef.current = null
+        satelliteSourceRef.current = null
+      }
+    }
+  }, [activeLayers.satellite, radarFrames, timestamps.length])
+
   // Update opacity when it changes
   useEffect(() => {
     opacityRef.current = opacity
@@ -808,7 +807,11 @@ const WeatherMapOpenLayers = ({
       const nextUrl = buildRadarXyzUrl(radarProvider, currentFrame)
       if (nextUrl) source.setUrl(nextUrl)
     }
-  }, [frameIndex, radarFrames, radarProvider])
+
+    if (satelliteSourceRef.current && activeLayers.satellite) {
+      satelliteSourceRef.current.updateParams({ [GOES_IR_TIME_PARAM]: currentFrame.isoTime })
+    }
+  }, [activeLayers.satellite, frameIndex, radarFrames, radarProvider])
 
   // Clear preload cache when location changes (fixes CodeRabbit memory leak issue)
   useEffect(() => {
@@ -891,6 +894,7 @@ const WeatherMapOpenLayers = ({
           alerts: activeLayers.alerts,
           spc: activeLayers.spc,
           stormReports: activeLayers.stormReports,
+          satellite: activeLayers.satellite,
         },
         frameIndex: frameForUrl,
         zoom: currentZoom,
@@ -909,6 +913,7 @@ const WeatherMapOpenLayers = ({
     activeLayers.precipitation,
     activeLayers.spc,
     activeLayers.stormReports,
+    activeLayers.satellite,
     frameIndex,
     pathname,
     radarStateReady,
@@ -1126,6 +1131,7 @@ const WeatherMapOpenLayers = ({
       {radarProvider && (
         <div className="absolute bottom-3 right-3 z-[1900] max-w-[70vw] rounded bg-gray-950/80 px-2 py-1 text-right font-mono text-[9px] uppercase tracking-wide text-gray-300 backdrop-blur-sm max-sm:bottom-16">
           Source: {radarProvider.attribution}
+          {activeLayers.satellite ? ` · ${GOES_IR_ATTRIBUTION}` : ''}
         </div>
       )}
 
@@ -1175,6 +1181,14 @@ const WeatherMapOpenLayers = ({
                 }`}
             >
               {activeLayers.stormReports ? '✓' : '○'} Storm Reports ({stormReports.length})
+            </button>
+
+            <button
+              onClick={() => setActiveLayers(prev => ({ ...prev, satellite: !prev.satellite }))}
+              className={`w-full px-3 py-2 text-left font-mono text-xs hover:bg-gray-700 transition-colors ${activeLayers.satellite ? 'bg-sky-600/30 text-sky-300' : 'text-gray-300'
+                }`}
+            >
+              {activeLayers.satellite ? '✓' : '○'} GOES IR Satellite
             </button>
 
             {/* Opacity slider */}

--- a/lib/radar/goes-satellite.ts
+++ b/lib/radar/goes-satellite.ts
@@ -1,0 +1,15 @@
+export const GOES_IR_WMS_PROXY_PATH = '/api/weather/noaa-goes-wms'
+
+export const GOES_IR_WMS_LAYER = '9'
+
+export const GOES_IR_ATTRIBUTION = 'NOAA nowCOAST GOES IR'
+
+export const GOES_IR_WMS_PARAMS: Record<string, string> = {
+  LAYERS: GOES_IR_WMS_LAYER,
+  FORMAT: 'image/png',
+  TRANSPARENT: 'true',
+  VERSION: '1.3.0',
+  STYLES: '',
+}
+
+export const GOES_IR_TIME_PARAM = 'TIME'

--- a/lib/radar/index.ts
+++ b/lib/radar/index.ts
@@ -1,5 +1,7 @@
+export * from '@/lib/radar/goes-satellite'
 export * from '@/lib/radar/radar-timestamps'
 export * from '@/lib/radar/radar-url-state'
+export * from '@/lib/radar/telemetry'
 export * from '@/lib/radar/providers/coverage'
 export * from '@/lib/radar/providers/registry'
 export type * from '@/lib/radar/providers/types'

--- a/lib/radar/providers/registry.ts
+++ b/lib/radar/providers/registry.ts
@@ -159,17 +159,18 @@ export function buildRadarMetadata(
   longitude: number,
   now = Date.now()
 ): RadarMetadata {
+  const safeNow = Number.isFinite(now) ? now : Date.now()
   const selection = selectRadarProvider(latitude, longitude)
   const provider = selection.selectedProvider
   const frames = buildRadarFrames({
-    now,
+    now: safeNow,
     stepMinutes: provider.frameStepMinutes,
     pastMinutes: provider.pastMinutes,
   })
 
   return {
     location: { lat: latitude, lon: longitude },
-    generatedAt: new Date(now).toISOString(),
+    generatedAt: new Date(safeNow).toISOString(),
     selectedProvider: provider,
     fallbackProvider: selection.fallbackProvider,
     frames,

--- a/lib/radar/radar-timestamps.ts
+++ b/lib/radar/radar-timestamps.ts
@@ -38,13 +38,15 @@ function quantizeTime(ms: number, stepMinutes: number): number {
 
 export function buildRadarFrames(options: BuildRadarFramesOptions = {}): RadarFrame[] {
   const stepMinutes = normalizeRadarStepMinutes(options.stepMinutes)
+  const maxPastSteps = Math.floor(MAX_PAST_MINUTES / stepMinutes)
   const now = typeof options.now === 'number' && Number.isFinite(options.now)
     ? options.now
     : Date.now()
   const base = quantizeTime(now, stepMinutes)
+  const pastStepsFromMinutes = Math.floor(normalizeRadarPastMinutes(options.pastMinutes) / stepMinutes)
   const pastSteps = typeof options.pastSteps === 'number' && Number.isFinite(options.pastSteps)
-    ? Math.max(0, Math.floor(options.pastSteps))
-    : Math.floor(normalizeRadarPastMinutes(options.pastMinutes) / stepMinutes)
+    ? Math.min(maxPastSteps, Math.max(0, Math.floor(options.pastSteps)))
+    : pastStepsFromMinutes
 
   const frames: RadarFrame[] = []
   for (let i = pastSteps; i >= 0; i -= 1) {

--- a/lib/radar/radar-url-state.ts
+++ b/lib/radar/radar-url-state.ts
@@ -1,12 +1,13 @@
 export const DEFAULT_RADAR_ZOOM = 10
 
-export type RadarLayerParam = 'precip' | 'alerts' | 'spc' | 'stormReports'
+export type RadarLayerParam = 'precip' | 'alerts' | 'spc' | 'stormReports' | 'satellite'
 
 export interface RadarShareLayerState {
   precipitation: boolean
   alerts: boolean
   spc: boolean
   stormReports: boolean
+  satellite: boolean
 }
 
 export const DEFAULT_RADAR_LAYERS: RadarShareLayerState = {
@@ -14,6 +15,7 @@ export const DEFAULT_RADAR_LAYERS: RadarShareLayerState = {
   alerts: true,
   spc: false,
   stormReports: false,
+  satellite: false,
 }
 
 export interface ParsedRadarUrlState {
@@ -27,6 +29,7 @@ const LAYER_PARAM_TO_STATE: Record<RadarLayerParam, keyof RadarShareLayerState> 
   alerts: 'alerts',
   spc: 'spc',
   stormReports: 'stormReports',
+  satellite: 'satellite',
 }
 
 const STATE_TO_LAYER_PARAM: Record<keyof RadarShareLayerState, RadarLayerParam> = {
@@ -34,6 +37,7 @@ const STATE_TO_LAYER_PARAM: Record<keyof RadarShareLayerState, RadarLayerParam> 
   alerts: 'alerts',
   spc: 'spc',
   stormReports: 'stormReports',
+  satellite: 'satellite',
 }
 
 function normalizeLayerToken(token: string): RadarLayerParam | null {
@@ -44,6 +48,7 @@ function normalizeLayerToken(token: string): RadarLayerParam | null {
   if (normalized === 'stormreports' || normalized === 'storm' || normalized === 'reports') {
     return 'stormReports'
   }
+  if (normalized === 'satellite' || normalized === 'goes' || normalized === 'ir') return 'satellite'
   return null
 }
 
@@ -56,11 +61,13 @@ export function parseRadarUrlState(searchParams: URLSearchParams): ParsedRadarUr
     layers.alerts = false
     layers.spc = false
     layers.stormReports = false
+    layers.satellite = false
   } else if (layersParam) {
     layers.precipitation = false
     layers.alerts = false
     layers.spc = false
     layers.stormReports = false
+    layers.satellite = false
 
     for (const token of layersParam.split(',')) {
       const key = normalizeLayerToken(token)
@@ -87,6 +94,7 @@ export function layersMatchDefault(layers: RadarShareLayerState): boolean {
     && layers.alerts === DEFAULT_RADAR_LAYERS.alerts
     && layers.spc === DEFAULT_RADAR_LAYERS.spc
     && layers.stormReports === DEFAULT_RADAR_LAYERS.stormReports
+    && layers.satellite === DEFAULT_RADAR_LAYERS.satellite
   )
 }
 

--- a/lib/radar/telemetry.ts
+++ b/lib/radar/telemetry.ts
@@ -1,0 +1,85 @@
+import * as Sentry from '@sentry/nextjs'
+import { captureError } from '@/lib/error-utils'
+
+type RadarProviderId = string
+
+export function trackRadarMetadataApi(
+  responseTimeMs: number,
+  success: boolean,
+): void {
+  Sentry.metrics.distribution('api.radar_metadata.response_time', responseTimeMs, {
+    unit: 'millisecond',
+  })
+  Sentry.metrics.count('api.radar_metadata.requests')
+  if (!success) {
+    Sentry.metrics.count('api.radar_metadata.errors')
+  }
+}
+
+export function captureRadarMetadataRouteError(error: unknown): void {
+  captureError(error, 'radar:metadata-route')
+}
+
+export function recordRadarTileError(providerId: RadarProviderId, errorCount: number): void {
+  Sentry.addBreadcrumb({
+    category: 'radar.tile',
+    level: 'warning',
+    message: 'Radar tile load error',
+    data: { providerId, errorCount },
+  })
+}
+
+export function recordRadarProviderFallback(
+  fromProviderId: RadarProviderId | undefined,
+  toProviderId: RadarProviderId,
+  tileErrorCount: number,
+): void {
+  Sentry.addBreadcrumb({
+    category: 'radar.provider',
+    level: 'warning',
+    message: 'Radar provider fallback activated',
+    data: { fromProviderId, toProviderId, tileErrorCount },
+  })
+  Sentry.captureMessage('[radar] provider fallback activated', {
+    level: 'warning',
+    tags: {
+      context: 'radar',
+      fromProvider: fromProviderId ?? 'unknown',
+      toProvider: toProviderId,
+    },
+    extra: { tileErrorCount },
+  })
+  Sentry.metrics.count('radar.provider.fallback', 1, {
+    attributes: {
+      from: fromProviderId ?? 'unknown',
+      to: toProviderId,
+    },
+  })
+}
+
+export function recordRadarMetadataClientLoad(
+  responseTimeMs: number,
+  success: boolean,
+  latitude?: number,
+  longitude?: number,
+): void {
+  Sentry.metrics.distribution('radar.metadata.client_latency', responseTimeMs, {
+    unit: 'millisecond',
+  })
+  if (!success) {
+    Sentry.addBreadcrumb({
+      category: 'radar.metadata',
+      level: 'warning',
+      message: 'Client radar metadata load failed',
+      data: { latitude, longitude, responseTimeMs },
+    })
+  }
+}
+
+export function captureRadarMetadataClientError(
+  error: unknown,
+  latitude?: number,
+  longitude?: number,
+): void {
+  captureError(error, 'radar:metadata-load', { latitude, longitude })
+}

--- a/tests/fixtures/utils.ts
+++ b/tests/fixtures/utils.ts
@@ -726,6 +726,12 @@ export async function stubRadarApis(page: Page): Promise<void> {
     body: transparentPng,
   }));
 
+  await page.route('**/api/weather/noaa-goes-wms**', (route) => route.fulfill({
+    status: 200,
+    contentType: 'image/png',
+    body: transparentPng,
+  }));
+
   await page.route('**/geo.weather.gc.ca/geomet/**', (route) => route.fulfill({
     status: 200,
     contentType: 'image/png',


### PR DESCRIPTION
## Summary

- Harden radar frame generation (`pastSteps` clamp) and metadata timestamp sanitization from CodeRabbit review on #445.
- Add Sentry telemetry for metadata API latency, client load failures, tile error breadcrumbs, and provider fallback events.
- Add NOAA GOES longwave IR satellite overlay via a dedicated WMS proxy, layer toggle, and shareable URL state.
- Extract radar map constants, types, styles, and tile helpers into `components/radar/` modules.

## Not in this PR (deferred)

- Future radar / nowcast (requires paid provider trial per `planning/radar-paid-provider-spike.md`)
- Full orchestrator split (`radar-provider-layer`, `radar-controls`, `useRadarUrlSync`) — partial module extraction only
- Production metrics review / paid provider selection (needs live traffic data)

## Test plan

- [x] `npm run typecheck`
- [x] `npm test -- radar` (19 tests)
- [x] `npx playwright test tests/e2e/radar.spec.ts --project=chromium` (8 tests)
- [ ] CI on PR


Made with [Cursor](https://cursor.com)