### PR TITLE
fix(radar): restore Iowa NEXRAD after MRMS outage

### DIFF
--- a/__tests__/radar-metadata-route.test.ts
+++ b/__tests__/radar-metadata-route.test.ts
@@ -35,13 +35,13 @@ describe('GET /api/radar/metadata', () => {
     await expect(res.json()).resolves.toEqual({ error: 'Coordinates out of valid range' })
   })
 
-  it('returns US radar metadata with fallback provider', async () => {
+  it('returns US radar metadata with Iowa NEXRAD provider', async () => {
     const res = await GET(new NextRequest('http://localhost/api/radar/metadata?lat=40.7128&lon=-74.006'))
     const body = await res.json()
 
     expect(res.status).toBe(200)
-    expect(body.selectedProvider.id).toBe('noaa-mrms')
-    expect(body.fallbackProvider.id).toBe('iowa-nexrad')
+    expect(body.selectedProvider.id).toBe('iowa-nexrad')
+    expect(body.fallbackProvider).toBeUndefined()
     expect(body.frames.length).toBeGreaterThan(0)
     expect(res.headers['Cache-Control']).toContain('s-maxage=120')
   })

--- a/__tests__/radar-providers.test.ts
+++ b/__tests__/radar-providers.test.ts
@@ -7,11 +7,11 @@ import {
 describe('radar providers', () => {
   const now = Date.UTC(2026, 5, 18, 21, 40, 0)
 
-  it('selects NOAA MRMS with Iowa fallback for US locations', () => {
+  it('selects Iowa NEXRAD for US locations', () => {
     const selection = selectRadarProvider(40.7128, -74.006)
 
-    expect(selection.selectedProvider.id).toBe('noaa-mrms')
-    expect(selection.fallbackProvider?.id).toBe('iowa-nexrad')
+    expect(selection.selectedProvider.id).toBe('iowa-nexrad')
+    expect(selection.fallbackProvider).toBeUndefined()
   })
 
   it('selects MSC GeoMet with RainViewer fallback for Canada locations', () => {
@@ -35,7 +35,7 @@ describe('radar providers', () => {
     const us = buildRadarMetadata(40.7128, -74.006, now)
     const canada = buildRadarMetadata(53.5461, -113.4938, now)
 
-    expect(us.selectedProvider.id).toBe('noaa-mrms')
+    expect(us.selectedProvider.id).toBe('iowa-nexrad')
     expect(us.frames).toHaveLength(49)
     expect(canada.selectedProvider.id).toBe('canada-geomet')
     expect(canada.frames).toHaveLength(31)

--- a/lib/radar/providers/registry.ts
+++ b/lib/radar/providers/registry.ts
@@ -134,9 +134,8 @@ export function selectRadarProvider(latitude: number, longitude: number): RadarP
 
   if (region === 'us') {
     return {
-      selectedProvider: RADAR_PROVIDERS['noaa-mrms'],
-      fallbackProvider: RADAR_PROVIDERS['iowa-nexrad'],
-      reason: 'US location selected official NOAA MRMS radar with Iowa NEXRAD fallback.',
+      selectedProvider: RADAR_PROVIDERS['iowa-nexrad'],
+      reason: 'US location selected Iowa NEXRAD direct because nowCOAST MRMS WMS is unavailable.',
     }
   }
 

--- a/lib/radar/radar-url-state.ts
+++ b/lib/radar/radar-url-state.ts
@@ -11,7 +11,7 @@ export interface RadarShareLayerState {
 
 export const DEFAULT_RADAR_LAYERS: RadarShareLayerState = {
   precipitation: true,
-  alerts: true,
+  alerts: false,
   spc: false,
   stormReports: false,
 }

--- a/tests/e2e/radar.spec.ts
+++ b/tests/e2e/radar.spec.ts
@@ -21,7 +21,7 @@ test.describe('Radar Map', () => {
     
     const radarContainer = page.locator('[data-radar-container]').first();
     await expect(radarContainer).toBeVisible();
-    await expect(page.getByText(/MRMS RADAR/i)).toBeVisible({ timeout: 15000 });
+    await expect(page.getByText(/NEXRAD RADAR/i)).toBeVisible({ timeout: 15000 });
   });
 
   test('radar visible in synthwave theme', async ({ page }) => {
@@ -68,8 +68,8 @@ test.describe('Radar Map', () => {
     await navigateToRadarPage(page);
     await waitForRadarToLoad(page);
     
-    await expect(page.getByText(/MRMS RADAR/i)).toBeVisible();
-    await expect(page.getByText(/Source: NOAA\/NWS MRMS/i)).toBeVisible();
+    await expect(page.getByText(/NEXRAD RADAR/i)).toBeVisible();
+    await expect(page.getByText(/Source: Iowa Environmental Mesonet/i)).toBeVisible();
   });
 
   test('Canada location selects GeoMet provider', async ({ page }) => {

--- a/tests/fixtures/utils.ts
+++ b/tests/fixtures/utils.ts
@@ -726,6 +726,12 @@ export async function stubRadarApis(page: Page): Promise<void> {
     body: transparentPng,
   }));
 
+  await page.route('**/mesonet.agron.iastate.edu/cgi-bin/wms/nexrad/**', (route) => route.fulfill({
+    status: 200,
+    contentType: 'image/png',
+    body: transparentPng,
+  }));
+
   await page.route('**/geo.weather.gc.ca/geomet/**', (route) => route.fulfill({
     status: 200,
     contentType: 'image/png',


### PR DESCRIPTION
## Summary
- Switch US radar primary from NOAA MRMS (nowCOAST WMS returning 403) to Iowa NEXRAD direct WMS, which is working and was the pre-modernization source.
- Default NWS alert overlay off so active alert polygons no longer wash the map on load.
- Update unit tests, E2E expectations, and Playwright stubs for the Iowa tile endpoint.

## Root cause
PR #445 defaulted US locations to MRMS via `/api/weather/noaa-wms`. Upstream nowCOAST returns HTTP 403; the proxy responds with HTTP 200 and a transparent 1x1 PNG, so OpenLayers never triggers tile-load fallback. With alerts enabled by default, semi-transparent warning polygons stacked over empty radar tiles produced a muddy colored overlay.

## Test plan
- [x] `npm test -- radar-providers.test.ts radar-metadata-route.test.ts radar-timestamps.test.ts`
- [x] `npx playwright test tests/e2e/radar.spec.ts --project=chromium`
- [ ] Verify `/radar` on production after deploy shows reflectivity and no alert wash by default


Made with [Cursor](https://cursor.com)