### PR TITLE
fix(radar): restore full-screen map layout on /radar

### DIFF
--- a/app/radar/page.tsx
+++ b/app/radar/page.tsx
@@ -197,11 +197,11 @@ export default function MapPage() {
   }
 
   return (
-    <div className="min-h-screen w-full flex flex-col">
+    <div className="flex h-screen w-full flex-col overflow-hidden">
       <Navigation />
 
       {/* Breadcrumb Header */}
-      <div className="p-3 bg-gray-900 border-b border-gray-700 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+      <div className="shrink-0 p-3 bg-gray-900 border-b border-gray-700 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
         <div className="flex flex-wrap items-center gap-3">
           <Link href="/" className="inline-flex items-center gap-2 text-xs font-mono px-3 py-1.5 border-2 border-gray-600 hover:bg-gray-700 transition-colors rounded" aria-label="Return to Home">
             <Home className="w-3 h-3" />
@@ -240,8 +240,8 @@ export default function MapPage() {
         />
       </div>
 
-      {/* Map Container */}
-      <div className="flex-1 min-h-[500px] overflow-visible">
+      {/* Map Container - flex-1 + min-h-0 fills remaining viewport below nav/header */}
+      <div className="min-h-0 flex-1 overflow-visible">
         <WeatherMap
           latitude={weatherData.coordinates!.lat}
           longitude={weatherData.coordinates!.lon}

--- a/components/weather-map-openlayers.tsx
+++ b/components/weather-map-openlayers.tsx
@@ -1051,19 +1051,21 @@ const WeatherMapOpenLayers = ({
     setFrameIndex(Math.max(0, timestamps.length - 1))
   }, [timestamps.length])
 
+  const isFullPage = displayMode === 'full-page'
+
   return (
     <div
       data-radar-container
-      className={`flex w-full flex-col gap-2 rounded-lg sm:flex-row ${themeStyles.container}`}
-      style={{ height: '100%', minHeight: '350px' }}
+      className={`flex w-full flex-col gap-2 rounded-lg sm:flex-row ${isFullPage ? 'h-full min-h-0' : ''} ${themeStyles.container}`}
+      style={isFullPage ? undefined : { height: '100%', minHeight: '350px' }}
     >
       {/* Main Map Area */}
-      <div className="relative min-h-[350px] flex-1 overflow-visible">
+      <div className={`relative flex-1 overflow-visible ${isFullPage ? 'min-h-0 h-full' : 'min-h-[350px]'}`}>
       {/* Map Container - explicit dimensions for production */}
       <div
         ref={mapRef}
-        className="w-full bg-gray-900 rounded-lg overflow-hidden"
-        style={{ zIndex: 1, height: '100%', minHeight: '350px', position: 'relative' }}
+        className={`w-full bg-gray-900 rounded-lg overflow-hidden ${isFullPage ? 'h-full' : ''}`}
+        style={{ zIndex: 1, position: 'relative', ...(isFullPage ? {} : { height: '100%', minHeight: '350px' }) }}
       />
 
       {/* Loading Indicator - Skeleton placeholder with shimmer effect */}

--- a/tests/e2e/radar.spec.ts
+++ b/tests/e2e/radar.spec.ts
@@ -86,6 +86,22 @@ test.describe('Radar Map', () => {
     await expect(page.getByText(/GEOMET RADAR/i)).toBeVisible({ timeout: 15000 });
   });
 
+  test('radar map fills the viewport below the page header', async ({ page }) => {
+    await navigateToRadarPage(page);
+    await waitForRadarToLoad(page);
+
+    const viewport = page.viewportSize();
+    expect(viewport).not.toBeNull();
+
+    const viewportHeight = await page.evaluate(() => window.innerHeight);
+    const mapHeight = await page.locator('[data-radar-container] .ol-viewport').evaluate(
+      (element) => element.getBoundingClientRect().height
+    );
+
+    // Full-page radar should use most of the screen, not collapse to the 350px widget minimum.
+    expect(mapHeight).toBeGreaterThan(viewportHeight * 0.5);
+  });
+
   test('radar honors shareable URL layer and frame params', async ({ page }) => {
     await page.goto('/radar?location=Chicago&layers=precip,spc&frame=5&zoom=8');
     await waitForRadarToLoad(page);


### PR DESCRIPTION
## Summary
- Restore full-viewport radar layout on `/radar` after PR #445 accidentally shrank the map to its 350px minimum.
- Use `h-screen` flex column layout with `flex-1 min-h-0` on the map container so height propagates correctly below the nav and header.
- Propagate `h-full` through the OpenLayers map when `displayMode="full-page"`.
- Add an E2E regression test that asserts the map uses at least half the viewport height.

## Root cause
PR #445 replaced `h-[calc(100vh-120px)]` with `flex-1 min-h-[500px]` on a parent that only had `min-h-screen`. Without a fixed parent height, `flex-1` and `height: 100%` collapsed to the map component's 350px minimum.

## Test plan
- [x] `npx playwright test tests/e2e/radar.spec.ts --project=chromium` (9 passed)
- [ ] Verify `/radar` fills the screen below the header after deploy


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved radar map layout and sizing behavior to properly fill available viewport space
  * Enhanced weather map component to responsively adjust sizing based on display context (full-page versus embedded widget mode)
  * Fixed overflow and scrolling behavior in radar page layout

* **Tests**
  * Added end-to-end test to verify radar map viewport height and responsive sizing behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->