### PR TITLE
fix(newsletter): filter mismatched Wednesday image picks before validation

### DIFF
--- a/__tests__/newsletter/content-match.test.ts
+++ b/__tests__/newsletter/content-match.test.ts
@@ -1,4 +1,4 @@
-import { embedImagesInDraft, stripBareImageMarkdown } from '../../scripts/newsletter/content-match';
+import { embedImagesInDraft, filterPlacementsByNarrativeFit, stripBareImageMarkdown } from '../../scripts/newsletter/content-match';
 import type { ImageEntry } from '../../scripts/newsletter/images';
 
 const liveImage: ImageEntry = {
@@ -21,6 +21,46 @@ const archivalImage: ImageEntry = {
   kind: 'archival',
   archival_year: 1981,
 };
+
+const supercomputerImage: ImageEntry = {
+  id: 'supercomputer-rack',
+  url: 'https://example.com/cray.jpg',
+  caption: 'Cray-1 supercomputer — early generation of weather modeling hardware.',
+  credit: 'Wikimedia Commons',
+  topic_tags: ['tech_and_models', 'historical_events'],
+  license: 'CC-BY-4.0',
+};
+
+const faultImage: ImageEntry = {
+  id: 'fault-types-usgs',
+  url: 'https://example.com/fault.svg',
+  caption: 'USGS diagram of normal, reverse, and strike-slip fault motion.',
+  credit: 'USGS',
+  topic_tags: ['earthquakes'],
+  license: 'PD-USGov',
+};
+
+describe('filterPlacementsByNarrativeFit', () => {
+  it('drops modeling hardware from an earthquake draft and backfills on-topic imagery', () => {
+    const draft = [
+      '## The rupture',
+      '',
+      'On January 17, 1994 at 4:30 a.m., a M6.7 earthquake struck near Northridge, California.',
+      '',
+      'The seismic waves traveled through a strike-slip fault system.',
+    ].join('\n');
+
+    const filtered = filterPlacementsByNarrativeFit(
+      draft,
+      [{ image: supercomputerImage, insertAfter: 'Northridge, California' }],
+      [supercomputerImage, faultImage],
+      1,
+    );
+
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].image.id).toBe('fault-types-usgs');
+  });
+});
 
 describe('embedImagesInDraft', () => {
   it('inserts an image after the paragraph containing the anchor snippet', () => {

--- a/scripts/newsletter/content-match.ts
+++ b/scripts/newsletter/content-match.ts
@@ -22,6 +22,7 @@
 
 import { callAnthropic, DEFAULT_MODEL } from './repetition';
 import type { ImageEntry } from './images';
+import { passesNarrativeFit } from './narrative-fit';
 
 export interface ImagePlacement {
   image: ImageEntry;
@@ -62,6 +63,8 @@ Selection rules:
 - Strongly prefer images whose subject the prose actually dwells on (multiple sentences, a named region, a specific event), not topics the prose only name-checks.
 - Prefer kind=live and kind=reference over kind=archival. Pick archival only if the prose invokes the historical event it depicts, OR if no live/reference image fits.
 - Do not pick two images on the same narrow subject (e.g., two solar images for a draft that mentions space weather once).
+- Do not pick modeling hardware (supercomputer, Cray) unless the prose discusses forecast models or numerical weather prediction.
+- Do not pick drought, pollen, marine, or tropical imagery unless the prose actually develops that subject.
 - For each pick, return a 3-8 word verbatim snippet from the draft after which the image should appear. The snippet must occur exactly once in the draft so we can find the insertion point unambiguously. Pick a snippet at a paragraph boundary.
 
 Return JSON only, no prose, no fences:
@@ -103,6 +106,40 @@ ${catalog}`;
     placements.push({ image, insertAfter: pick.insert_after });
   }
   return placements;
+}
+
+/**
+ * Drops judge picks that fail the same narrative-fit rules used by
+ * validate-post.ts, then backfills from the remaining pool so the cron
+ * does not fail on a single mismatched image.
+ */
+export function filterPlacementsByNarrativeFit(
+  draft: string,
+  placements: ImagePlacement[],
+  pool: ImageEntry[],
+  count: number,
+): ImagePlacement[] {
+  const accepted: ImagePlacement[] = [];
+  const usedIds = new Set<string>();
+
+  for (const placement of placements) {
+    if (passesNarrativeFit(draft, placement.image)) {
+      accepted.push(placement);
+      usedIds.add(placement.image.id);
+      continue;
+    }
+    console.warn(`[content-match] dropping ${placement.image.id}: narrative mismatch`);
+  }
+
+  for (const image of pool) {
+    if (accepted.length >= count) break;
+    if (usedIds.has(image.id)) continue;
+    if (!passesNarrativeFit(draft, image)) continue;
+    usedIds.add(image.id);
+    accepted.push({ image, insertAfter: '##' });
+  }
+
+  return accepted.slice(0, count);
 }
 
 /**

--- a/scripts/newsletter/narrative-fit.ts
+++ b/scripts/newsletter/narrative-fit.ts
@@ -1,0 +1,43 @@
+import type { ImageEntry } from './images';
+
+export function proseOnly(content: string): string {
+  return content.replace(/!\[[^\]]*\]\([^)]+\)\s*\n?\*[^*\n]+\*/g, '');
+}
+
+export function getNarrativeFitErrors(content: string, image: ImageEntry): string[] {
+  const errors: string[] = [];
+  const body = proseOnly(content).toLowerCase();
+  const imageText = `${image.id} ${image.caption} ${image.topic_tags.join(' ')}`.toLowerCase();
+  const hasSevereOrQuakeLead = /tornado|supercell|severe convective|spc storm|earthquake|seismic|aftershock|subduction/.test(body);
+  const hasMeaningfulSpace = /geomagnetic storm|aurora|x-class|m-class|\bkp\s*[4-9]\b|kp index maxed at [4-9]/.test(body);
+
+  if (hasSevereOrQuakeLead && !hasMeaningfulSpace && /solar|sun|sdo|aurora|corona|magnetogram/.test(imageText)) {
+    errors.push(`Image "${image.id}" is solar/space imagery, but the post lead is severe or seismic.`);
+  }
+
+  if (!/drought|soil moisture|agricultur|crop|dryness/.test(body) && /drought|cracked soil|agricultur/.test(imageText)) {
+    errors.push(`Image "${image.id}" is drought/agriculture imagery without a matching drought story.`);
+  }
+
+  if (!/supercomputer|forecast model|model guidance|numerical model|weather modeling/.test(body) && /supercomputer|cray-1/.test(imageText)) {
+    errors.push(`Image "${image.id}" is modeling hardware without a matching modeling story.`);
+  }
+
+  if (!/hurricane|tropical|enso|sea surface|ocean current|pacific surface/.test(body) && /hurricane|enso|ocean current/.test(imageText)) {
+    errors.push(`Image "${image.id}" is tropical/ocean imagery without a matching tropical or ocean story.`);
+  }
+
+  if (!/\bpollen\b|allerg|aeroallergen|\bragweed\b|\bspore\b|\bplant/.test(body) && /\bpollen\b|aeroallergen|\bragweed\b|\bspore\b/.test(imageText)) {
+    errors.push(`Image "${image.id}" is pollen/biometeorology imagery without a matching pollen or plant-health story.`);
+  }
+
+  if (!/\bmarine\b|\bcoast(?:al)?\b|\bocean\b|\bsurf(?:ing)?\b|\bshore\b|\brip current\b|\bsea state\b|\bbreaking wave\b/.test(body) && /\bbreaking wave\b|\bsurf(?:ing)?\b/.test(imageText)) {
+    errors.push(`Image "${image.id}" is marine imagery without a matching marine or coastal story.`);
+  }
+
+  return errors;
+}
+
+export function passesNarrativeFit(content: string, image: ImageEntry): boolean {
+  return getNarrativeFitErrors(content, image).length === 0;
+}

--- a/scripts/newsletter/validate-post.ts
+++ b/scripts/newsletter/validate-post.ts
@@ -11,6 +11,7 @@ import path from 'node:path';
 import matter from 'gray-matter';
 
 import { allowedBlogUrl } from '@/lib/blog/allowed-hosts';
+import { getNarrativeFitErrors } from './narrative-fit';
 import { IMAGES, type ImageEntry } from './images';
 
 interface MarkdownImage {
@@ -73,7 +74,7 @@ export function validateGeneratedPost(filePath: string): ValidationResult {
       if (!catalogHero) {
         errors.push(`External hero image is not present in scripts/newsletter/images.ts: ${heroImage}`);
       } else {
-        validateNarrativeFit(content, catalogHero, errors);
+        errors.push(...getNarrativeFitErrors(content, catalogHero));
       }
     }
   }
@@ -118,7 +119,7 @@ export function validateGeneratedPost(filePath: string): ValidationResult {
   for (const image of markdownImages) {
     const catalogImage = imagesByUrl.get(image.url);
     if (catalogImage) {
-      validateNarrativeFit(content, catalogImage, errors);
+      errors.push(...getNarrativeFitErrors(content, catalogImage));
     }
   }
 
@@ -157,41 +158,6 @@ function parseAuditEntries(value: unknown): ParsedAuditEntry[] {
         caption: fields.get('caption') ?? '',
       };
     });
-}
-
-function validateNarrativeFit(content: string, image: ImageEntry, errors: string[]): void {
-  const body = proseOnly(content).toLowerCase();
-  const imageText = `${image.id} ${image.caption} ${image.topic_tags.join(' ')}`.toLowerCase();
-  const hasSevereOrQuakeLead = /tornado|supercell|severe convective|spc storm|earthquake|seismic|aftershock|subduction/.test(body);
-  const hasMeaningfulSpace = /geomagnetic storm|aurora|x-class|m-class|\bkp\s*[4-9]\b|kp index maxed at [4-9]/.test(body);
-
-  if (hasSevereOrQuakeLead && !hasMeaningfulSpace && /solar|sun|sdo|aurora|corona|magnetogram/.test(imageText)) {
-    errors.push(`Image "${image.id}" is solar/space imagery, but the post lead is severe or seismic.`);
-  }
-
-  if (!/drought|soil moisture|agricultur|crop|dryness/.test(body) && /drought|cracked soil|agricultur/.test(imageText)) {
-    errors.push(`Image "${image.id}" is drought/agriculture imagery without a matching drought story.`);
-  }
-
-  if (!/supercomputer|forecast model|model guidance|numerical model|weather modeling/.test(body) && /supercomputer|cray-1/.test(imageText)) {
-    errors.push(`Image "${image.id}" is modeling hardware without a matching modeling story.`);
-  }
-
-  if (!/hurricane|tropical|enso|sea surface|ocean current|pacific surface/.test(body) && /hurricane|enso|ocean current/.test(imageText)) {
-    errors.push(`Image "${image.id}" is tropical/ocean imagery without a matching tropical or ocean story.`);
-  }
-
-  if (!/\bpollen\b|allerg|aeroallergen|\bragweed\b|\bspore\b|\bplant/.test(body) && /\bpollen\b|aeroallergen|\bragweed\b|\bspore\b/.test(imageText)) {
-    errors.push(`Image "${image.id}" is pollen/biometeorology imagery without a matching pollen or plant-health story.`);
-  }
-
-  if (!/\bmarine\b|\bcoast(?:al)?\b|\bocean\b|\bsurf(?:ing)?\b|\bshore\b|\brip current\b|\bsea state\b|\bbreaking wave\b/.test(body) && /\bbreaking wave\b|\bsurf(?:ing)?\b/.test(imageText)) {
-    errors.push(`Image "${image.id}" is marine imagery without a matching marine or coastal story.`);
-  }
-}
-
-function proseOnly(content: string): string {
-  return content.replace(/!\[[^\]]*\]\([^)]+\)\s*\n?\*[^*\n]+\*/g, '');
 }
 
 function renderAuditMarkdown(

--- a/scripts/newsletter/wednesday.ts
+++ b/scripts/newsletter/wednesday.ts
@@ -5,7 +5,7 @@
 
 import { getSpotlight } from '../blog-spotlight';
 import { pickCloser, type CloserChoice } from './closers';
-import { embedImagesInDraft, pickImagesForContent, type ImagePlacement } from './content-match';
+import { embedImagesInDraft, filterPlacementsByNarrativeFit, pickImagesForContent, type ImagePlacement } from './content-match';
 import { selectImages, type ImageAuditEntry, type ImageEntry } from './images';
 import { findAngleForTopic, fetchHeadlines, type NewsAngle } from './news';
 import {
@@ -169,7 +169,8 @@ export async function runWednesday(): Promise<WednesdayResult> {
   // Content-aware image picks: judge ranks the candidate pool against
   // the actual prose, then we splice the picks in. Falls back to the
   // first three pool entries if the judge call fails or returns nothing.
-  const placements = await pickImagesForContent({ draft, pool: candidatePool, count: 3 });
+  const rawPlacements = await pickImagesForContent({ draft, pool: candidatePool, count: 3 });
+  const placements = filterPlacementsByNarrativeFit(draft, rawPlacements, candidatePool, 3);
   let images: ImageEntry[];
   let finalPlacements: ImagePlacement[];
   let finalDraft: string;


### PR DESCRIPTION
## Summary
- Wednesday cron failed at validate-post because the content-match judge picked `supercomputer-rack` for a Northridge earthquake deep-dive.
- Extract shared narrative-fit rules and apply them when filtering judge picks, with backfill from the remaining candidate pool.
- Tighten the content-match judge prompt to avoid modeling/drought/pollen/marine filler images.

## Test plan
- [x] `npm test -- __tests__/newsletter/` (93 tests)
- [x] `npm run typecheck`
- [ ] Merge to main, then re-run **Newsletter (Wednesday Topic Deep-Dive)** via workflow_dispatch


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added narrative-fit checks for newsletter images to better match visuals with the story being told.
  * Improved image selection so unsuitable placements are filtered out and replaced with better-fitting alternatives when available.

* **Bug Fixes**
  * Reduced mismatched imagery in newsletter drafts, especially for topics like earthquakes, modeling hardware, drought, pollen, and marine or tropical stories.

* **Tests**
  * Added coverage for narrative-fit filtering to verify off-topic images are removed and relevant images remain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->