### PR TITLE
Polish Daybreak theme to reduce generic AI dashboard patterns

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -631,6 +631,25 @@ input:focus-visible,
     hsl(42 72% 95%) 46%,
     hsl(28 88% 88%) 100%
   );
+  /* Drop the dark-theme left accent bar — it reads as generic "AI dashboard"
+     slop on cream. A warm top hairline + soft shadow gives structure instead. */
+  border-left-width: 0;
+  border-top: 2px solid hsl(28 58% 74%);
+  box-shadow:
+    0 1px 3px rgba(60, 45, 30, 0.08),
+    0 10px 28px -14px rgba(60, 45, 30, 0.16);
+}
+
+/* Location heading: plain primary text, no neon glow on a light surface. */
+[data-theme="daybreak"] .hero-weather-card h1 {
+  text-shadow: none;
+}
+
+/* Metric cards (moon phase, etc.): top accent instead of left stripe. */
+[data-theme="daybreak"] .weather-card-enter.border-l-4:not(.hero-weather-card) {
+  border-left-width: 0;
+  border-top-width: 2px;
+  border-top-color: hsl(var(--primary) / 0.28);
 }
 
 /* Sun-embossed hero number instead of a muddy blue halo: a crisp white top
@@ -640,6 +659,106 @@ input:focus-visible,
   text-shadow:
     0 1px 0 rgba(255, 255, 255, 0.7),
     0 3px 10px rgba(190, 95, 25, 0.30);
+}
+
+/* Lighter backdrop: keep the watermark sun, drop grid + rotating sweep. */
+[data-theme="daybreak"] .hero-backdrop-grid,
+[data-theme="daybreak"] .hero-backdrop-sweep {
+  display: none;
+}
+
+[data-theme="daybreak"] .hero-backdrop-watermark {
+  opacity: 0.05;
+}
+
+/* No neon text-shadow on light surfaces — catches hardcoded `.glow` in JSX too. */
+[data-theme="daybreak"] .glow {
+  text-shadow: none;
+}
+
+/* Hero + metric cards: skip the hover "lift" micro-interaction (overused template trope). */
+[data-theme="daybreak"] .hero-weather-card:hover,
+[data-theme="daybreak"] .weather-metric-card:hover,
+[data-theme="daybreak"] .hourly-forecast-card:hover,
+[data-theme="daybreak"] .forecast-day-card:hover {
+  transform: none;
+}
+
+/* Metric grid: flat cream cards with warm hairlines — not gradient + top-accent stacks. */
+[data-theme="daybreak"] .weather-metric-card {
+  background: hsl(var(--card)) !important;
+  border: 1px solid var(--border-subtle) !important;
+  border-top-width: 1px !important;
+  box-shadow: 0 1px 2px rgba(60, 45, 30, 0.05);
+}
+
+[data-theme="daybreak"] .weather-metric-card:hover {
+  border-color: var(--border-hover);
+  box-shadow: 0 2px 8px rgba(60, 45, 30, 0.08);
+}
+
+[data-theme="daybreak"] .weather-metric-card.weather-metric-glow,
+[data-theme="daybreak"] .weather-metric-card.weather-metric-glow:hover {
+  box-shadow: 0 1px 2px rgba(60, 45, 30, 0.05);
+}
+
+[data-theme="daybreak"] .weather-metric-card.weather-metric-glow:hover {
+  box-shadow: 0 2px 8px rgba(60, 45, 30, 0.08);
+}
+
+/* Hourly strip: warm shadows instead of heavy dark drop shadows. */
+[data-theme="daybreak"] .hourly-forecast-card {
+  box-shadow: 0 1px 3px rgba(60, 45, 30, 0.07);
+}
+
+[data-theme="daybreak"] .hourly-forecast-card.current-hour {
+  box-shadow: 0 0 0 1px hsl(var(--primary) / 0.22);
+  background: hsl(var(--primary) / 0.07);
+}
+
+[data-theme="daybreak"] .hourly-forecast-card:hover {
+  box-shadow: 0 2px 8px rgba(60, 45, 30, 0.10);
+}
+
+/* 7-day forecast day tiles */
+[data-theme="daybreak"] .forecast-day-card {
+  box-shadow: 0 1px 3px rgba(60, 45, 30, 0.06);
+  background: hsl(var(--card) / 0.92);
+}
+
+[data-theme="daybreak"] .forecast-day-card:hover {
+  box-shadow: 0 2px 10px rgba(60, 45, 30, 0.10);
+}
+
+[data-theme="daybreak"] .forecast-day-card[class*="ring-2"] {
+  box-shadow: 0 0 0 1px hsl(var(--primary) / 0.35);
+}
+
+/* Radar / AQI panels */
+[data-theme="daybreak"] .dashboard-surface {
+  border: 1px solid var(--border-subtle);
+  box-shadow: 0 1px 3px rgba(60, 45, 30, 0.07);
+}
+
+/* AQI severity: top edge instead of left stripe on light theme */
+[data-theme="daybreak"] .aqi-panel.border-l-orange-400\/70 {
+  border-left-width: 0;
+  border-top: 3px solid rgb(251 146 60 / 0.75);
+}
+
+[data-theme="daybreak"] .aqi-panel.border-l-red-400\/80 {
+  border-left-width: 0;
+  border-top: 3px solid rgb(248 113 113 / 0.85);
+}
+
+[data-theme="daybreak"] .aqi-panel.border-l-purple-400\/80 {
+  border-left-width: 0;
+  border-top: 3px solid rgb(192 132 252 / 0.85);
+}
+
+[data-theme="daybreak"] .aqi-panel.border-l-red-900 {
+  border-left-width: 0;
+  border-top: 3px solid rgb(127 29 29);
 }
 
 /* ═══════════════════════════════════════════════════════════

--- a/components/air-quality-display.tsx
+++ b/components/air-quality-display.tsx
@@ -83,7 +83,7 @@ export function AirQualityDisplay({ aqi, theme, className, minimal = false, poll
   return (
     <div
       className={cn(
-        !minimal && "p-4 rounded-lg text-center",
+        !minimal && "aqi-panel p-4 rounded-lg text-center",
         !minimal && styles.container,
         severity?.borderStripeClass,
         severity?.pulse && "motion-safe:animate-pulse",

--- a/components/forecast.tsx
+++ b/components/forecast.tsx
@@ -29,7 +29,7 @@ export default function Forecast({ forecast, onDayClick, selectedDay }: Forecast
     : "grid-cols-2 sm:grid-cols-3 lg:grid-cols-5";
 
   return (
-    <Card className="p-3 sm:p-4 lg:p-6 border-0 rounded-xl dashboard-surface bg-card/55 backdrop-blur-md transition-shadow duration-300 animate-slide-in">
+    <Card className="forecast-panel p-3 sm:p-4 lg:p-6 border-0 rounded-xl dashboard-surface bg-card/55 backdrop-blur-md transition-shadow duration-300 animate-slide-in">
       <CardHeader className="p-0 mb-3 sm:mb-4">
         <CardTitle className="text-center text-base sm:text-lg lg:text-xl font-extrabold uppercase tracking-wider text-primary glow">
           {title}
@@ -91,7 +91,7 @@ function ForecastCard({ day, index, onDayClick, isSelected }: {
   return (
     <Card
       className={cn(
-        "cursor-pointer transition-all duration-200 hover:-translate-y-0.5 card-interactive",
+        "forecast-day-card cursor-pointer transition-all duration-200 hover:-translate-y-0.5 card-interactive",
         "flex flex-col justify-between min-h-[120px] sm:min-h-[140px] lg:min-h-[160px]",
         "backdrop-blur-sm bg-card/70 border border-[var(--border-invisible)] shadow-[0_10px_28px_-14px_rgba(0,0,0,0.55)]",
         "hover:border-[var(--border-subtle)] hover:shadow-[0_14px_36px_-14px_rgba(0,0,0,0.55)]",

--- a/components/hero-weather-card.tsx
+++ b/components/hero-weather-card.tsx
@@ -5,8 +5,29 @@ import { Card, CardContent } from "@/components/ui/card"
 import { cn } from "@/lib/utils"
 import WeatherIconModern from "@/components/weather-icon-modern"
 import { ShareButton } from "@/components/share-weather-modal"
+import { useTheme } from "@/components/theme-provider"
 import { getHeroAccent } from "@/lib/weather/hero-utils"
 import { ArrowDown, ArrowUp, CloudRain, Droplets, Thermometer, Wind } from "lucide-react"
+
+/** Icon tints tuned per theme — dark themes use pastel /90; daybreak uses saturated hues for cream bg. */
+const HERO_CHIP_ICON = {
+  dark: {
+    hi: "text-rose-300/90",
+    lo: "text-sky-300/90",
+    feels: "text-amber-300/90",
+    hum: "text-sky-300/90",
+    wind: "text-emerald-300/90",
+    rain: "text-blue-300/90",
+  },
+  daybreak: {
+    hi: "text-rose-600",
+    lo: "text-primary",
+    feels: "text-accent",
+    hum: "text-primary/80",
+    wind: "text-emerald-700",
+    rain: "text-blue-700",
+  },
+} as const
 
 const HERO_CARD_BASE =
   "hero-weather-card weather-card-enter border-0 border-l-4 border-l-primary shadow-md weather-metric-glow weather-card-gradient hover:-translate-y-0.5 hover:shadow-lg transition-all duration-300"
@@ -44,8 +65,10 @@ export function HeroWeatherCard({
   precipChance,
   glowClass,
 }: HeroWeatherCardProps) {
+  const { theme } = useTheme()
   const accent = getHeroAccent(condition)
   const displayTemp = typeof temperature === 'number' ? Math.round(temperature) : null
+  const chipIcon = theme === 'daybreak' ? HERO_CHIP_ICON.daybreak : HERO_CHIP_ICON.dark
 
   return (
     <Card className={cn(HERO_CARD_BASE, accent, "relative overflow-hidden")}>
@@ -102,35 +125,35 @@ export function HeroWeatherCard({
 
             <div className="grid grid-cols-3 gap-1.5 text-xs sm:text-sm font-mono w-full">
               {highTemp !== undefined && (
-                <HeroChip icon={<ArrowUp size={12} className="text-rose-300/90" />} label="HI" value={`${Math.round(highTemp)}°`} />
+                <HeroChip icon={<ArrowUp size={12} className={chipIcon.hi} />} label="HI" value={`${Math.round(highTemp)}°`} />
               )}
               {lowTemp !== undefined && (
-                <HeroChip icon={<ArrowDown size={12} className="text-sky-300/90" />} label="LO" value={`${Math.round(lowTemp)}°`} />
+                <HeroChip icon={<ArrowDown size={12} className={chipIcon.lo} />} label="LO" value={`${Math.round(lowTemp)}°`} />
               )}
               {feelsLike != null && (
                 <HeroChip
-                  icon={<Thermometer size={12} className="text-amber-300/90" />}
+                  icon={<Thermometer size={12} className={chipIcon.feels} />}
                   label="FEELS"
                   value={`${feelsLike}°${feelsLikeDelta !== 0 ? (feelsLikeDelta > 0 ? ' ↑' : ' ↓') : ''}`}
                 />
               )}
               {humidity !== undefined && (
                 <HeroChip
-                  icon={<Droplets size={12} className="text-sky-300/90" />}
+                  icon={<Droplets size={12} className={chipIcon.hum} />}
                   label="HUM"
                   value={`${Math.round(humidity)}%`}
                 />
               )}
               {windSpeed !== undefined && (
                 <HeroChip
-                  icon={<Wind size={12} className="text-emerald-300/90" />}
+                  icon={<Wind size={12} className={chipIcon.wind} />}
                   label="WIND"
                   value={`${Math.round(windSpeed)} ${windUnit}`}
                 />
               )}
               {precipChance !== undefined && (
                 <HeroChip
-                  icon={<CloudRain size={12} className="text-blue-300/90" />}
+                  icon={<CloudRain size={12} className={chipIcon.rain} />}
                   label="RAIN"
                   value={`${Math.round(precipChance)}%`}
                 />
@@ -177,7 +200,7 @@ function HeroAmbientBackdrop({ condition }: { condition: string }) {
     <div aria-hidden="true" className="pointer-events-none absolute inset-0 overflow-hidden">
       {/* 1. Pixel grid — 16-bit texture, matches radar card */}
       <div
-        className="absolute inset-0 opacity-[0.045]"
+        className="hero-backdrop-grid absolute inset-0 opacity-[0.045]"
         style={{
           backgroundImage:
             'repeating-linear-gradient(0deg, rgba(var(--theme-accent-rgb),0.8) 0 1px, transparent 1px 28px), repeating-linear-gradient(90deg, rgba(var(--theme-accent-rgb),0.8) 0 1px, transparent 1px 28px)',
@@ -185,7 +208,7 @@ function HeroAmbientBackdrop({ condition }: { condition: string }) {
       />
 
       {/* 2. Rotating sweep arc — center-anchored, GPU-accelerated */}
-      <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
+      <div className="hero-backdrop-sweep absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
         <div
           className="h-[700px] w-[700px] motion-safe:animate-spin"
           style={{
@@ -203,7 +226,7 @@ function HeroAmbientBackdrop({ condition }: { condition: string }) {
           (No pulse animation: Tailwind animate-pulse overrides opacity-[0.06]
           up to 0.5–1 cycles, which both defeats the watermark subtlety and
           costs compositor work every frame.) */}
-      <div className="absolute top-1/2 left-[45%] -translate-y-1/2 opacity-[0.08]">
+      <div className="hero-backdrop-watermark absolute top-1/2 left-[45%] -translate-y-1/2 opacity-[0.08]">
         <WeatherIconModern condition={condition} size={320} />
       </div>
     </div>

--- a/components/hourly-forecast.tsx
+++ b/components/hourly-forecast.tsx
@@ -130,7 +130,7 @@ function HourlyCard({
   return (
     <Card
       className={cn(
-        "flex-shrink-0 flex flex-col items-center justify-between snap-start",
+        "hourly-forecast-card flex-shrink-0 flex flex-col items-center justify-between snap-start",
         "rounded-xl p-3 sm:p-4 min-w-[100px] sm:min-w-[110px]",
         "transition-all duration-200 hover:-translate-y-0.5",
         "backdrop-blur-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",

--- a/components/weather-display.tsx
+++ b/components/weather-display.tsx
@@ -60,7 +60,7 @@ interface WeatherDisplayProps {
 
 // Card style constants
 const HERO_CARD = "weather-card-enter border-0 border-l-4 border-l-primary shadow-md weather-metric-glow weather-card-gradient hover:-translate-y-0.5 hover:shadow-lg transition-all duration-300"
-const METRIC_CARD = "group weather-card-enter border-0 border-t-2 border-t-primary/40 shadow-md weather-metric-glow weather-card-gradient hover:border-t-primary hover:-translate-y-0.5 hover:shadow-lg transition-all duration-300 min-h-[140px]"
+const METRIC_CARD = "weather-metric-card group weather-card-enter border-0 border-t-2 border-t-primary/40 shadow-md weather-metric-glow weather-card-gradient hover:border-t-primary hover:-translate-y-0.5 hover:shadow-lg transition-all duration-300 min-h-[140px]"
 
 export function WeatherDisplay({
   weather,
@@ -89,6 +89,9 @@ export function WeatherDisplay({
     ? Math.round((feelsLike - weather.temperature) * 10) / 10
     : 0
 
+  const deltaWarmClass = theme === 'daybreak' ? 'text-rose-600' : 'text-rose-400'
+  const deltaSameClass = theme === 'daybreak' ? 'text-emerald-700' : 'text-emerald-400'
+
   return (
     <div className="space-y-5 sm:space-y-7">
       {/* 1. Hero Weather Card */}
@@ -106,7 +109,7 @@ export function WeatherDisplay({
         windSpeed={weather.wind?.speed}
         windUnit={weather.unit === '°C' ? 'km/h' : 'mph'}
         precipChance={weather.forecast?.[0]?.details?.precipitationChance}
-        glowClass={themeClasses.glow}
+        glowClass={theme === 'daybreak' ? undefined : themeClasses.glow}
       />
 
       {/* 2. Hourly Forecast - Always visible if data exists */}
@@ -279,17 +282,20 @@ export function WeatherDisplay({
             {feelsLikeDelta !== 0 && (
               <div className="flex items-center justify-center gap-1 mt-2">
                 {feelsLikeDelta < 0 ? (
-                  <ArrowDown size={14} style={{ color: '#88C0D0' }} />
+                  <ArrowDown size={14} className="text-primary" />
                 ) : (
-                  <ArrowUp size={14} style={{ color: '#BF616A' }} />
+                  <ArrowUp size={14} className={deltaWarmClass} />
                 )}
-                <span className="text-sm" style={{ color: feelsLikeDelta < 0 ? '#88C0D0' : '#BF616A' }}>
+                <span className={cn(
+                  "text-sm",
+                  feelsLikeDelta < 0 ? "text-primary" : deltaWarmClass,
+                )}>
                   {Math.abs(feelsLikeDelta)}° {feelsLikeDelta < 0 ? 'cooler' : 'warmer'}
                 </span>
               </div>
             )}
             {feelsLikeDelta === 0 && (
-              <p className="text-sm mt-2" style={{ color: '#A3BE8C' }}>Same as actual</p>
+              <p className={cn("text-sm mt-2", deltaSameClass)}>Same as actual</p>
             )}
           </CardContent>
         </Card>

--- a/components/weather-search.tsx
+++ b/components/weather-search.tsx
@@ -178,19 +178,31 @@ export default function WeatherSearch({
     }
   }
 
+  const handleExamplePick = (value: string) => {
+    if (controlsDisabled) return
+    handleInputChange(value)
+    requestAnimationFrame(() => {
+      document.querySelector<HTMLInputElement>('[data-testid="location-search-input"]')?.focus()
+    })
+  }
+
   const controlsDisabled = isLoading || isDisabled
 
   return (
     <div className="mb-4 sm:mb-6 w-full max-w-2xl mx-auto">
-      {/* Format hints with AI indicator for logged-in users */}
-      <div className="mb-2 sm:mb-3 text-center px-2">
-        <div className={`text-xs sm:text-sm ${themeClasses.secondaryText} uppercase tracking-wider break-words`}>
-          <>
-            <span className="hidden sm:inline">► 90210 • NEW YORK, NY • LONDON, UK ◄</span>
-            <span className="sm:hidden">► ZIP • CITY, STATE • CITY, COUNTRY ◄</span>
-          </>
-        </div>
-      </div>
+      <p className="mb-2 sm:mb-3 text-center px-2 text-xs sm:text-sm text-muted-foreground leading-relaxed">
+        <span className="hidden sm:inline">
+          Try{' '}
+          <SearchExample value="90210" onPick={handleExamplePick} disabled={controlsDisabled} />
+          {', '}
+          <SearchExample value="New York, NY" onPick={handleExamplePick} disabled={controlsDisabled} />
+          {', or '}
+          <SearchExample value="London, UK" onPick={handleExamplePick} disabled={controlsDisabled} />
+        </span>
+        <span className="sm:hidden">
+          Search by ZIP, city and state, or city and country
+        </span>
+      </p>
 
       {/* Search Form - Mobile optimized */}
       <form onSubmit={handleSubmit} className="mb-3 sm:mb-4 px-2 sm:px-0">
@@ -202,18 +214,20 @@ export default function WeatherSearch({
             onChange={(e) => handleInputChange(e.target.value)}
             onKeyDown={handleInputKeyDown}
             onFocus={() => searchTerm.length >= 2 && setShowAutocomplete(true)}
-            placeholder={isDisabled ? "Rate limit reached..." : "ZIP, City+State, or City+Country..."}
+            placeholder={isDisabled ? "Rate limit reached…" : "Search city, state, or ZIP…"}
             disabled={controlsDisabled}
             aria-label="Search location"
-            className={`w-full pr-10 sm:pr-12 ${themeClasses.cardBg} border-0 ${themeClasses.text} ${themeClasses.placeholderText}
-                     font-mono text-sm sm:text-base uppercase tracking-wider
-                     transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed pixel-font
-                     min-h-[48px] touch-manipulation py-3 sm:py-4 px-3 sm:px-4`}
-            style={{
-              imageRendering: "pixelated",
-              fontFamily: "monospace",
-              fontSize: "clamp(12px, 3vw, 16px)"
-            }}
+            className={cn(
+              "location-search-input w-full pr-10 sm:pr-12 border border-[var(--border-subtle)]",
+              themeClasses.cardBg,
+              themeClasses.text,
+              themeClasses.placeholderText,
+              "text-sm sm:text-base font-sans",
+              "transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed",
+              "min-h-[48px] touch-manipulation py-3 sm:py-4 px-3 sm:px-4",
+              "shadow-[0_1px_2px_rgba(60,45,30,0.04)]",
+              "focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+            )}
           />
           <div className="absolute right-2 sm:right-3 top-1/2 transform -translate-y-1/2 flex items-center gap-1">
             {/* Clear button */}
@@ -314,11 +328,11 @@ export default function WeatherSearch({
                     "justify-start h-auto py-2",
                     themeClasses.warningText,
                     "hover:text-terminal-accent",
-                    themeClasses.glow
+                    theme !== 'daybreak' && themeClasses.glow
                   )}
                   disabled={isDisabled}
                 >
-                  ZIP: 90210
+                  90210
                 </Button>
                 <Button
                   variant="link"
@@ -327,11 +341,11 @@ export default function WeatherSearch({
                     "justify-start h-auto py-2",
                     themeClasses.warningText,
                     "hover:text-terminal-accent",
-                    themeClasses.glow
+                    theme !== 'daybreak' && themeClasses.glow
                   )}
                   disabled={isDisabled}
                 >
-                  City + State: New York, NY
+                  New York, NY
                 </Button>
                 <Button
                   variant="link"
@@ -340,11 +354,11 @@ export default function WeatherSearch({
                     "justify-start h-auto py-2",
                     themeClasses.warningText,
                     "hover:text-terminal-accent",
-                    themeClasses.glow
+                    theme !== 'daybreak' && themeClasses.glow
                   )}
                   disabled={isDisabled}
                 >
-                  City + Country: London, UK
+                  London, UK
                 </Button>
               </div>
             </div>
@@ -370,5 +384,26 @@ export default function WeatherSearch({
         </div>
       )}
     </div>
+  )
+}
+
+function SearchExample({
+  value,
+  onPick,
+  disabled,
+}: {
+  value: string
+  onPick: (value: string) => void
+  disabled?: boolean
+}) {
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={() => onPick(value)}
+      className="font-medium text-primary hover:underline disabled:opacity-50 disabled:pointer-events-none"
+    >
+      {value}
+    </button>
   )
 }

--- a/components/weather-search.tsx
+++ b/components/weather-search.tsx
@@ -245,7 +245,7 @@ export default function WeatherSearch({
                 "h-10 w-10",
                 themeClasses.secondaryText,
                 "hover:text-terminal-accent-warning",
-                themeClasses.glow
+                theme !== 'daybreak' && themeClasses.glow
               )}
               aria-label={isLoading ? "Searching..." : "Search for weather"}
             >

--- a/lib/theme-utils.ts
+++ b/lib/theme-utils.ts
@@ -52,7 +52,7 @@ export const getThemeStyles = (theme?: ThemeType): ThemeStyles => {
     accentText: 'text-primary-foreground',
     cardBg: 'bg-card',
     hoverBg: 'hover:bg-primary/20',
-    glow: 'glow',
+    glow: theme === 'daybreak' ? '' : 'glow',
     secondary: 'text-secondary-foreground',
     headerText: 'text-primary font-mono font-bold',
     secondaryText: 'text-muted-foreground',


### PR DESCRIPTION
## Summary
- Remove the Daybreak hero left accent stripe, neon glows, hover lifts, and dark-theme shadows so the light theme uses its horizon gradient and warm card treatment instead of dark-theme chrome.
- Flatten metric, hourly, forecast, and AQI panels on Daybreak with warm hairlines and theme-aware icon colors.
- Replace the faux ticker search hint with subtle clickable examples and normal-case input styling.

## Test plan
- [x] `npm run typecheck`
- [x] `npx playwright test tests/e2e/weather-app.spec.ts --project=chromium` (9 passed)
- [ ] Visual check on homepage and `/weather/san-ramon-ca` in Daybreak
- [ ] Confirm Nord and premium themes are unchanged


Made with [Cursor](https://cursor.com)