### PR TITLE
Add home hub discovery row and unify city forecast UX

### DIFF
--- a/__tests__/city-slug.test.ts
+++ b/__tests__/city-slug.test.ts
@@ -1,0 +1,17 @@
+import {
+  locationInputToSlug,
+  slugToDisplayName,
+  slugToSearchTerm,
+} from '@/lib/city-slug';
+
+describe('city-slug', () => {
+  it('normalizes location input to slugs', () => {
+    expect(locationInputToSlug('New York, NY')).toBe('new-york-ny');
+    expect(locationInputToSlug('  Houston, TX ')).toBe('houston-tx');
+  });
+
+  it('builds search terms from slugs', () => {
+    expect(slugToSearchTerm('denver-co')).toBe('Denver, CO');
+    expect(slugToDisplayName('london-uk')).toBe('London Uk');
+  });
+});

--- a/__tests__/city-slug.test.ts
+++ b/__tests__/city-slug.test.ts
@@ -12,6 +12,7 @@ describe('city-slug', () => {
 
   it('builds search terms from slugs', () => {
     expect(slugToSearchTerm('denver-co')).toBe('Denver, CO');
+    expect(slugToSearchTerm('kansas-city')).toBe('Kansas City');
     expect(slugToDisplayName('london-uk')).toBe('London Uk');
   });
 });

--- a/__tests__/geo-spc-point.test.ts
+++ b/__tests__/geo-spc-point.test.ts
@@ -1,0 +1,62 @@
+import { pointInGeoJsonGeometry } from '@/lib/geo/point-in-polygon';
+import { getHighestSpcRiskAtPoint } from '@/lib/geo/spc-point-risk';
+import type { SPCOutlookGeoJSON } from '@/lib/services/spc-outlook-service';
+
+describe('point-in-polygon', () => {
+  it('detects a point inside a polygon', () => {
+    const inside = pointInGeoJsonGeometry([-74, 40], {
+      type: 'Polygon',
+      coordinates: [[[-75, 39], [-73, 39], [-73, 41], [-75, 41], [-75, 39]]],
+    });
+    expect(inside).toBe(true);
+  });
+
+  it('detects a point outside a polygon', () => {
+    const inside = pointInGeoJsonGeometry([-80, 40], {
+      type: 'Polygon',
+      coordinates: [[[-75, 39], [-73, 39], [-73, 41], [-75, 41], [-75, 39]]],
+    });
+    expect(inside).toBe(false);
+  });
+});
+
+describe('spc-point-risk', () => {
+  const geojson: SPCOutlookGeoJSON = {
+    type: 'FeatureCollection',
+    features: [
+      {
+        type: 'Feature',
+        geometry: {
+          type: 'Polygon',
+          coordinates: [[[-75, 39], [-73, 39], [-73, 41], [-75, 41], [-75, 39]]],
+        },
+        properties: {
+          DN: 1,
+          VALID: '',
+          EXPIRE: '',
+          ISSUE: '',
+          VALID_ISO: '',
+          EXPIRE_ISO: '',
+          ISSUE_ISO: '',
+          FORECASTER: '',
+          LABEL: 'SLGT',
+          LABEL2: 'Slight Risk',
+          stroke: '#000',
+          fill: '#FFE066',
+        },
+      },
+    ],
+  };
+
+  it('returns the highest risk polygon containing the point', () => {
+    expect(getHighestSpcRiskAtPoint(geojson, 40, -74)).toEqual({
+      riskCode: 'SLGT',
+      label: 'Slight',
+      fill: '#FFE066',
+    });
+  });
+
+  it('returns null when the point is outside all risk areas', () => {
+    expect(getHighestSpcRiskAtPoint(geojson, 40, -80)).toBeNull();
+  });
+});

--- a/__tests__/home-hub-utils.test.ts
+++ b/__tests__/home-hub-utils.test.ts
@@ -9,7 +9,6 @@ import {
   truncateText,
   type HubUserLocation,
 } from '@/lib/home/hub-utils';
-import type { NWSAlertDetail } from '@/lib/services/nws-alerts-service';
 import type { RSSItem } from '@/lib/services/rss/rssAggregator';
 
 const NYC: HubUserLocation = {
@@ -18,25 +17,6 @@ const NYC: HubUserLocation = {
   locationLabel: 'New York, NY',
   country: 'US',
 };
-
-function alert(partial: Partial<NWSAlertDetail> & Pick<NWSAlertDetail, 'id' | 'event' | 'severity'>): NWSAlertDetail {
-  return {
-    headline: '',
-    urgency: 'Expected',
-    expires: '',
-    areaDesc: '',
-    sent: '',
-    effective: '',
-    ends: '',
-    description: '',
-    instruction: '',
-    certainty: '',
-    response: '',
-    sender: '',
-    geometry: null,
-    ...partial,
-  };
-}
 
 describe('hub-utils', () => {
   describe('formatUpdatedAgo', () => {

--- a/__tests__/home-hub-utils.test.ts
+++ b/__tests__/home-hub-utils.test.ts
@@ -1,0 +1,130 @@
+import {
+  formatUpdatedAgo,
+  pickHappeningNowHeadline,
+  shouldShowHubAlerts,
+  shouldShowHubHeadline,
+  shouldShowSpcOutlook,
+  shouldShowStargazerCard,
+  summarizeAlerts,
+  truncateText,
+  type HubUserLocation,
+} from '@/lib/home/hub-utils';
+import type { NWSAlertDetail } from '@/lib/services/nws-alerts-service';
+import type { RSSItem } from '@/lib/services/rss/rssAggregator';
+
+const NYC: HubUserLocation = {
+  lat: 40.7128,
+  lon: -74.006,
+  locationLabel: 'New York, NY',
+  country: 'US',
+};
+
+function alert(partial: Partial<NWSAlertDetail> & Pick<NWSAlertDetail, 'id' | 'event' | 'severity'>): NWSAlertDetail {
+  return {
+    headline: '',
+    urgency: 'Expected',
+    expires: '',
+    areaDesc: '',
+    sent: '',
+    effective: '',
+    ends: '',
+    description: '',
+    instruction: '',
+    certainty: '',
+    response: '',
+    sender: '',
+    geometry: null,
+    ...partial,
+  };
+}
+
+describe('hub-utils', () => {
+  describe('formatUpdatedAgo', () => {
+    it('formats recent timestamps', () => {
+      const now = new Date('2026-06-25T12:00:00Z');
+      jest.useFakeTimers().setSystemTime(now);
+      expect(formatUpdatedAgo(new Date('2026-06-25T11:58:00Z'))).toBe('2m ago');
+      jest.useRealTimers();
+    });
+  });
+
+  describe('pickHappeningNowHeadline', () => {
+    it('skips items that are not relevant to the user', () => {
+      const happening = [
+        {
+          id: 'far',
+          title: 'M5.1 - 10 km NE of Palu, Indonesia',
+          category: 'earthquakes',
+          priority: 'high',
+          magnitude: 5.1,
+        },
+        {
+          id: 'near',
+          title: 'Severe Thunderstorm Warning issued for New York NY',
+          category: 'severe',
+          priority: 'high',
+        },
+      ] as RSSItem[];
+      expect(pickHappeningNowHeadline(happening, NYC)?.id).toBe('near');
+    });
+  });
+
+  describe('shouldShowHubAlerts', () => {
+    it('hides when all clear', () => {
+      expect(shouldShowHubAlerts({ count: 0, needsLocation: false, loading: false })).toBe(false);
+    });
+
+    it('shows when alerts are active', () => {
+      expect(shouldShowHubAlerts({ count: 2, needsLocation: false, loading: false })).toBe(true);
+    });
+  });
+
+  describe('shouldShowSpcOutlook', () => {
+    it('shows slight risk or higher in-region', () => {
+      expect(shouldShowSpcOutlook('SLGT', false, true)).toBe(true);
+      expect(shouldShowSpcOutlook('SLGT', false, false)).toBe(false);
+    });
+  });
+
+  describe('shouldShowStargazerCard', () => {
+    it('shows whenever a score is available', () => {
+      expect(
+        shouldShowStargazerCard({ score: 72, needsLocation: false, loading: false }),
+      ).toBe(true);
+      expect(
+        shouldShowStargazerCard({ score: 25, needsLocation: false, loading: false }),
+      ).toBe(true);
+      expect(
+        shouldShowStargazerCard({ score: 50, needsLocation: false, loading: false }),
+      ).toBe(true);
+      expect(
+        shouldShowStargazerCard({ score: null, needsLocation: false, loading: false }),
+      ).toBe(false);
+    });
+  });
+
+  describe('shouldShowHubHeadline', () => {
+    it('shows when a headline is loaded', () => {
+      expect(
+        shouldShowHubHeadline({ title: 'Severe storms in NY', loading: false }),
+      ).toBe(true);
+    });
+  });
+
+  describe('summarizeAlerts', () => {
+    it('returns all clear when empty', () => {
+      expect(summarizeAlerts([])).toEqual({
+        count: 0,
+        headline: 'No active alerts nearby',
+        severity: null,
+        topAlertId: null,
+      });
+    });
+  });
+
+  describe('truncateText', () => {
+    it('truncates long strings', () => {
+      expect(truncateText('abcdefghijklmnop', 10)).toBe('abcdefghij…');
+    });
+  });
+});

--- a/__tests__/hub-links.test.ts
+++ b/__tests__/hub-links.test.ts
@@ -1,0 +1,54 @@
+import {
+  findAlertByQueryParam,
+  getHubAlertsHref,
+  getHubHeadlineHref,
+  getHubStargazerHref,
+  isExternalHubHref,
+} from '@/lib/home/hub-links';
+
+describe('hub-links', () => {
+  it('builds warnings deep links with alert id', () => {
+    expect(getHubAlertsHref('urn:oid:abc123')).toBe('/warnings?alert=urn%3Aoid%3Aabc123');
+    expect(getHubAlertsHref(null)).toBe('/warnings');
+  });
+
+  it('uses external headline urls for severe alerts', () => {
+    expect(
+      getHubHeadlineHref({
+        category: 'severe',
+        url: 'https://forecast.weather.gov/product.php?site=NWS&issuedby=LUB&product=SVR',
+      }),
+    ).toBe('https://forecast.weather.gov/product.php?site=NWS&issuedby=LUB&product=SVR');
+  });
+
+  it('falls back to warnings for severe headlines without urls', () => {
+    expect(getHubHeadlineHref({ category: 'severe', url: null })).toBe('/warnings');
+  });
+
+  it('falls back to news for non-severe headlines without urls', () => {
+    expect(getHubHeadlineHref({ category: 'space', url: null })).toBe('/news');
+  });
+
+  it('builds stargazer links with coordinates and city label', () => {
+    expect(
+      getHubStargazerHref({
+        lat: 33.5779,
+        lon: -101.8552,
+        locationLabel: 'Lubbock, TX',
+        country: 'US',
+      }),
+    ).toBe('/stargazer?lat=33.5779&lon=-101.8552&q=Lubbock%2C+TX');
+  });
+
+  it('detects external hrefs', () => {
+    expect(isExternalHubHref('https://forecast.weather.gov/')).toBe(true);
+    expect(isExternalHubHref('/warnings')).toBe(false);
+  });
+
+  it('matches alert query params to loaded alerts', () => {
+    const alerts = [{ id: 'https://api.weather.gov/alerts/urn:oid:abc' }];
+    expect(findAlertByQueryParam(alerts, 'https://api.weather.gov/alerts/urn:oid:abc')).toBe(
+      alerts[0].id,
+    );
+  });
+});

--- a/__tests__/hub-location.test.ts
+++ b/__tests__/hub-location.test.ts
@@ -38,6 +38,25 @@ describe('hub-location', () => {
     ).toBe(false);
   });
 
+  it('does not false-positive Oregon on the word "or"', () => {
+    const portland = {
+      lat: 45.5152,
+      lon: -122.6784,
+      locationLabel: 'Portland, OR',
+      country: 'US',
+    };
+    expect(isGeographicallyRelatedToUser('hail 1 inch or higher expected', portland)).toBe(false);
+    expect(
+      isGeographicallyRelatedToUser('severe thunderstorm warning for portland, or', portland),
+    ).toBe(true);
+  });
+
+  it('matches space-separated state tokens for unambiguous codes', () => {
+    expect(
+      isGeographicallyRelatedToUser('severe thunderstorm warning for new york ny', NYC),
+    ).toBe(true);
+  });
+
   it('shows nearby moderate quakes but not distant ones', () => {
     expect(
       isHeadlineRelevantToUser(

--- a/__tests__/hub-location.test.ts
+++ b/__tests__/hub-location.test.ts
@@ -1,0 +1,85 @@
+import {
+  isGeographicallyRelatedToUser,
+  isHeadlineRelevantToUser,
+  shouldShowStargazerCard,
+} from '@/lib/home/hub-location';
+import type { RSSItem } from '@/lib/services/rss/rssAggregator';
+
+const NYC = {
+  lat: 40.7128,
+  lon: -74.006,
+  locationLabel: 'New York, NY',
+  country: 'US',
+};
+
+function item(partial: Partial<RSSItem> & Pick<RSSItem, 'id' | 'title' | 'category'>): RSSItem {
+  return {
+    description: '',
+    url: 'https://example.com',
+    source: 'Test',
+    sourceId: 'test',
+    priority: 'high',
+    timestamp: new Date(),
+    ...partial,
+  };
+}
+
+describe('hub-location', () => {
+  it('matches user state and city in text', () => {
+    expect(
+      isGeographicallyRelatedToUser('severe thunderstorm warning for new york ny', NYC),
+    ).toBe(true);
+    expect(isGeographicallyRelatedToUser('earthquake near tokyo', NYC)).toBe(false);
+  });
+
+  it('does not match "us" inside unrelated words', () => {
+    expect(
+      isGeographicallyRelatedToUser('Flood Warning issued June 26 at 10:10PM CDT', NYC),
+    ).toBe(false);
+  });
+
+  it('shows nearby moderate quakes but not distant ones', () => {
+    expect(
+      isHeadlineRelevantToUser(
+        item({
+          id: '1',
+          title: 'M5.3 - 10 km NE of New York, NY',
+          category: 'earthquakes',
+          magnitude: 5.3,
+        }),
+        NYC,
+      ),
+    ).toBe(true);
+    expect(
+      isHeadlineRelevantToUser(
+        item({
+          id: '2',
+          title: 'M5.3 - 10 km NE of Palu, Indonesia',
+          category: 'earthquakes',
+          magnitude: 5.3,
+        }),
+        NYC,
+      ),
+    ).toBe(false);
+  });
+
+  it('shows major global quakes', () => {
+    expect(
+      isHeadlineRelevantToUser(
+        item({
+          id: '3',
+          title: 'M6.4 - 10 km NE of Palu, Indonesia',
+          category: 'earthquakes',
+          magnitude: 6.4,
+        }),
+        NYC,
+      ),
+    ).toBe(true);
+  });
+
+  it('surfaces stargazer whenever a score is available', () => {
+    expect(shouldShowStargazerCard({ score: 70, needsLocation: false, loading: false })).toBe(true);
+    expect(shouldShowStargazerCard({ score: 45, needsLocation: false, loading: false })).toBe(true);
+    expect(shouldShowStargazerCard({ score: null, needsLocation: false, loading: false })).toBe(false);
+  });
+});

--- a/__tests__/news-rails.test.ts
+++ b/__tests__/news-rails.test.ts
@@ -38,12 +38,29 @@ describe('news rails', () => {
     expect(selectFeaturedItem([other, happening], [happening])).toEqual(happening);
   });
 
-  it('includes hurricanes in featured selection during hurricane season', () => {
-    const tropical = item({ id: 'tropical', priority: 'high', category: 'hurricanes' });
+  it('includes active hurricanes in featured selection during hurricane season', () => {
+    const tropical = item({
+      id: 'tropical',
+      priority: 'high',
+      category: 'hurricanes',
+      title: 'Hurricane Warning issued for Example County',
+    });
     const science = item({ id: 'science', priority: 'medium', category: 'science' });
     const july = new Date('2026-07-01T12:00:00Z');
     expect(isHurricaneSeason(july)).toBe(true);
     expect(selectFeaturedItem([science, tropical], [], july)).toEqual(tropical);
+  });
+
+  it('excludes calm tropical posts from featured selection during hurricane season', () => {
+    const tropical = item({
+      id: 'tropical',
+      priority: 'high',
+      category: 'hurricanes',
+      title: 'There are no tropical cyclones at this time.',
+    });
+    const science = item({ id: 'science', priority: 'high', category: 'science' });
+    const july = new Date('2026-07-01T12:00:00Z');
+    expect(selectFeaturedItem([tropical, science], [], july)).toEqual(science);
   });
 
   it('excludes hurricanes from featured selection off-season', () => {

--- a/__tests__/precip-utils.test.ts
+++ b/__tests__/precip-utils.test.ts
@@ -4,6 +4,7 @@ describe('getPrecipSeverity', () => {
   it('returns none tier below 20%', () => {
     expect(getPrecipSeverity(10).tier).toBe('none');
     expect(getPrecipSeverity(10).stripClass).toBe('');
+    expect(getPrecipSeverity(Number.NaN).tier).toBe('none');
   });
 
   it('escalates strip and wash with higher probability', () => {

--- a/__tests__/precip-utils.test.ts
+++ b/__tests__/precip-utils.test.ts
@@ -1,0 +1,21 @@
+import { getPrecipSeverity } from '@/lib/weather/precip-utils';
+
+describe('getPrecipSeverity', () => {
+  it('returns none tier below 20%', () => {
+    expect(getPrecipSeverity(10).tier).toBe('none');
+    expect(getPrecipSeverity(10).stripClass).toBe('');
+  });
+
+  it('escalates strip and wash with higher probability', () => {
+    const light = getPrecipSeverity(25);
+    const moderate = getPrecipSeverity(50);
+    const heavy = getPrecipSeverity(80);
+
+    expect(light.tier).toBe('light');
+    expect(moderate.tier).toBe('moderate');
+    expect(heavy.tier).toBe('heavy');
+    expect(light.stripClass).toContain('h-px');
+    expect(moderate.stripClass).toContain('h-0.5');
+    expect(heavy.stripClass).toContain('h-1');
+  });
+});

--- a/__tests__/tropical-headlines.test.ts
+++ b/__tests__/tropical-headlines.test.ts
@@ -1,0 +1,92 @@
+import {
+  isActiveTropicalHeadline,
+  isDiscoveryHeadline,
+} from '@/lib/news/tropical-headlines';
+import type { RSSItem } from '@/lib/services/rss/rssAggregator';
+
+function item(partial: Partial<RSSItem> & Pick<RSSItem, 'id' | 'title' | 'category'>): RSSItem {
+  return {
+    description: '',
+    url: 'https://example.com',
+    source: 'Test',
+    sourceId: 'test',
+    priority: 'high',
+    timestamp: new Date(),
+    ...partial,
+  };
+}
+
+describe('tropical-headlines', () => {
+  describe('isActiveTropicalHeadline', () => {
+    it('rejects calm-basin NHC posts', () => {
+      expect(
+        isActiveTropicalHeadline({
+          title: 'There are no tropical cyclones at this time.',
+          description: '',
+          category: 'hurricanes',
+        }),
+      ).toBe(false);
+      expect(
+        isActiveTropicalHeadline({
+          title: 'Atlantic Tropical Weather Outlook',
+          description: '',
+          category: 'hurricanes',
+        }),
+      ).toBe(false);
+    });
+
+    it('accepts active tropical warnings and named storms', () => {
+      expect(
+        isActiveTropicalHeadline({
+          title: 'Hurricane Warning issued for Example County',
+          description: '',
+          category: 'hurricanes',
+        }),
+      ).toBe(true);
+      expect(
+        isActiveTropicalHeadline({
+          title: 'Tropical Storm Debby Advisory Number 8',
+          description: '',
+          category: 'hurricanes',
+        }),
+      ).toBe(true);
+    });
+
+    it('passes through non-hurricane categories', () => {
+      expect(
+        isActiveTropicalHeadline({
+          title: 'M6.1 earthquake',
+          description: '',
+          category: 'earthquakes',
+        }),
+      ).toBe(true);
+    });
+  });
+
+  describe('isDiscoveryHeadline', () => {
+    it('requires high priority', () => {
+      expect(
+        isDiscoveryHeadline(
+          item({
+            id: '1',
+            title: 'Hurricane Warning',
+            category: 'hurricanes',
+            priority: 'low',
+          }),
+        ),
+      ).toBe(false);
+    });
+
+    it('filters calm tropical high-priority items', () => {
+      expect(
+        isDiscoveryHeadline(
+          item({
+            id: '1',
+            title: 'There are no tropical cyclones at this time.',
+            category: 'hurricanes',
+          }),
+        ),
+      ).toBe(false);
+    });
+  });
+});

--- a/__tests__/tropical-headlines.test.ts
+++ b/__tests__/tropical-headlines.test.ts
@@ -45,6 +45,13 @@ describe('tropical-headlines', () => {
       ).toBe(true);
       expect(
         isActiveTropicalHeadline({
+          title: 'Special Tropical Weather Outlook issued',
+          description: '',
+          category: 'hurricanes',
+        }),
+      ).toBe(true);
+      expect(
+        isActiveTropicalHeadline({
           title: 'Tropical Storm Debby Advisory Number 8',
           description: '',
           category: 'hurricanes',

--- a/app/api/weather/spc-outlook/route.ts
+++ b/app/api/weather/spc-outlook/route.ts
@@ -6,8 +6,18 @@ import {
   type SPCOutlookType,
   type SPCOutlookGeoJSON,
 } from '@/lib/services/spc-outlook-service';
+import { getHighestSpcRiskAtPoint } from '@/lib/geo/spc-point-risk';
 
 const VALID_TYPES = new Set(['cat', 'torn', 'hail', 'wind']);
+
+function parsePoint(raw: string | null): { lat: number; lon: number } | null {
+  if (!raw) return null;
+  const parts = raw.split(',').map((s) => parseFloat(s.trim()));
+  if (parts.length !== 2 || parts.some((n) => Number.isNaN(n))) return null;
+  const [lat, lon] = parts;
+  if (lat < -90 || lat > 90 || lon < -180 || lon > 180) return null;
+  return { lat, lon };
+}
 
 /**
  * Filter out features with empty GeometryCollections.
@@ -40,6 +50,14 @@ export async function GET(request: NextRequest) {
   try {
     const dayParam = request.nextUrl.searchParams.get('day') ?? '1';
     const typeParam = request.nextUrl.searchParams.get('type') ?? 'cat';
+    const pointParam = request.nextUrl.searchParams.get('point');
+    const point = parsePoint(pointParam);
+    if (pointParam != null && pointParam.trim() !== '' && !point) {
+      return NextResponse.json(
+        { error: 'Invalid point parameter; use lat,lon in decimal degrees (WGS84).' },
+        { status: 400 },
+      );
+    }
 
     if (!/^[123]$/.test(dayParam)) {
       return NextResponse.json({ error: 'day must be 1, 2, or 3' }, { status: 400 });
@@ -52,8 +70,9 @@ export async function GET(request: NextRequest) {
 
     const rawGeojson = await fetchSPCOutlook(day, typeParam as SPCOutlookType);
     const { geojson, noRiskLabel } = filterEmptyGeometries(rawGeojson);
+    const pointRisk = point ? getHighestSpcRiskAtPoint(geojson, point.lat, point.lon) : null;
 
-    return NextResponse.json({ ...geojson, noRiskLabel }, {
+    return NextResponse.json({ ...geojson, noRiskLabel, pointRisk }, {
       headers: {
         'Cache-Control': 'public, s-maxage=900, stale-while-revalidate=300',
       },

--- a/app/globals.css
+++ b/app/globals.css
@@ -734,6 +734,19 @@ input:focus-visible,
   box-shadow: 0 0 0 1px hsl(var(--primary) / 0.35);
 }
 
+/* Wet-day tiles: top strip instead of left accent (matches AQI panel pattern) */
+[data-theme="daybreak"] .forecast-day-card[data-precip-tier="light"] {
+  background: hsl(200 45% 97% / 0.95);
+}
+
+[data-theme="daybreak"] .forecast-day-card[data-precip-tier="moderate"] {
+  background: hsl(200 50% 95% / 0.98);
+}
+
+[data-theme="daybreak"] .forecast-day-card[data-precip-tier="heavy"] {
+  background: hsl(200 55% 93% / 1);
+}
+
 /* Radar / AQI panels */
 [data-theme="daybreak"] .dashboard-surface {
   border: 1px solid var(--border-subtle);

--- a/app/home-client.tsx
+++ b/app/home-client.tsx
@@ -16,6 +16,7 @@
 
 
 import React, { memo } from "react"
+import { useRouter } from "next/navigation"
 import { LoadingSpinner } from "@/components/ui/loading-state"
 import { useTheme } from '@/components/theme-provider'
 import { type ThemeType } from '@/lib/theme-utils'
@@ -35,10 +36,17 @@ const WeatherDisplay = dynamic(() => import('@/components/weather-display').then
   loading: () => <div className="animate-pulse bg-gray-800/30 rounded-lg h-96" />
 })
 
+const HomeHub = dynamic(() => import('@/components/home/home-hub'), {
+  ssr: false,
+  loading: () => <div className="mt-4 h-16 animate-pulse rounded-md bg-gray-800/30" aria-hidden />,
+})
+
 import { ResponsiveContainer } from "@/components/responsive-container"
 import { ErrorBoundary } from "@/components/error-boundary"
 import { WeatherSkeleton } from '@/components/weather-skeleton'
 import { useWeatherController } from "@/hooks/useWeatherController"
+import { locationInputToSlug } from "@/lib/city-slug"
+import { useHubLocation } from "@/hooks/use-hub-location"
 
 // Note: UV Index data is now only available in One Call API 3.0 (paid subscription required)
 // The main weather API handles UV index estimation for free accounts
@@ -47,6 +55,7 @@ import { useWeatherController } from "@/hooks/useWeatherController"
 
 function WeatherApp() {
   const { theme } = useTheme()
+  const router = useRouter()
 
   // Use the new controller hook
   const {
@@ -54,11 +63,12 @@ function WeatherApp() {
     loading,
     error,
     remainingSearches,
-    handleSearch,
     handleLocationSearch,
     isAutoDetecting,
     autoLocationAttempted
   } = useWeatherController()
+
+  const hubLocation = useHubLocation(weather)
 
   const [selectedDay, setSelectedDay] = React.useState<number | null>(null)
   const [precipitation, setPrecipitation] = React.useState<{rain24h: number; snow24h: number} | null>(null)
@@ -75,7 +85,12 @@ function WeatherApp() {
     }
   }, [autoLocationAttempted, loading, isAutoDetecting])
 
-  // Fetch 24h precipitation data when weather loads
+  // Manual searches use the same /weather/[city] experience as footer city links.
+  const handleSearchWrapper = (locationInput: string) => {
+    const trimmed = locationInput.trim()
+    if (trimmed.length < 3) return
+    router.push(`/weather/${locationInputToSlug(trimmed)}`)
+  }
   React.useEffect(() => {
     if (!weather?.coordinates) return
 
@@ -104,10 +119,6 @@ function WeatherApp() {
     return () => controller.abort()
   }, [weather?.coordinates?.lat, weather?.coordinates?.lon])
 
-  const handleSearchWrapper = (locationInput: string) => {
-    handleSearch(locationInput)
-  }
-
   return (
     <PageWrapper
       weatherLocation={weather?.location}
@@ -128,6 +139,7 @@ function WeatherApp() {
             />
           </ErrorBoundary>
 
+          <HomeHub userLocation={hubLocation} />
 
           {/* Welcome Message — START is a clickable affordance that triggers geolocation. */}
           {!weather && !loading && !error && !isAutoDetecting && (
@@ -182,14 +194,16 @@ function WeatherApp() {
 
           {weather && !loading && !error && (
             <ErrorBoundary componentName="Weather Display">
-              <WeatherDisplay
-                weather={weather}
-                theme={theme || 'nord'}
-                selectedDay={selectedDay}
-                onDayClick={(index) => setSelectedDay(selectedDay === index ? null : index)}
-                precipitation={precipitation}
-                showRadar={true}
-              />
+              <div id="live-weather" className="scroll-mt-24">
+                <WeatherDisplay
+                  weather={weather}
+                  theme={theme || 'nord'}
+                  selectedDay={selectedDay}
+                  onDayClick={(index) => setSelectedDay(selectedDay === index ? null : index)}
+                  precipitation={precipitation}
+                  showRadar={true}
+                />
+              </div>
             </ErrorBoundary>
           )}
 

--- a/app/stargazer/layout.tsx
+++ b/app/stargazer/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import { Suspense } from 'react';
 
 export const metadata: Metadata = {
   title: 'Stargazer - Astrophotography Forecast | 16-Bit Weather',
@@ -19,5 +20,15 @@ export default function StargazerLayout({
 }: {
   children: React.ReactNode;
 }) {
-  return <>{children}</>;
+  return (
+    <Suspense
+      fallback={
+        <div className="container mx-auto px-4 py-8 text-center font-mono text-muted-foreground animate-pulse">
+          Loading stargazer…
+        </div>
+      }
+    >
+      {children}
+    </Suspense>
+  );
 }

--- a/app/stargazer/layout.tsx
+++ b/app/stargazer/layout.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from 'next';
-import { Suspense } from 'react';
 
 export const metadata: Metadata = {
   title: 'Stargazer - Astrophotography Forecast | 16-Bit Weather',
@@ -20,15 +19,5 @@ export default function StargazerLayout({
 }: {
   children: React.ReactNode;
 }) {
-  return (
-    <Suspense
-      fallback={
-        <div className="container mx-auto px-4 py-8 text-center font-mono text-muted-foreground animate-pulse">
-          Loading stargazer…
-        </div>
-      }
-    >
-      {children}
-    </Suspense>
-  );
+  return <>{children}</>;
 }

--- a/app/stargazer/page.tsx
+++ b/app/stargazer/page.tsx
@@ -8,7 +8,7 @@
  * tab navigation, and organized content sections.
  */
 
-import React, { useEffect, useState, useCallback, startTransition, useRef } from 'react';
+import React, { useEffect, useState, useCallback, startTransition, useRef, Suspense } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { cn } from '@/lib/utils';
 import { useTheme } from '@/components/theme-provider';
@@ -379,14 +379,57 @@ function LaunchesPanel({ data }: { data: StargazerData }) {
 // Main Page
 // ============================================================================
 
-export default function StargazerPage() {
+function StargazerShell({
+  children,
+  themeClasses,
+}: {
+  children: React.ReactNode;
+  themeClasses: ReturnType<typeof getComponentStyles>;
+}) {
+  return (
+    <PageWrapper>
+      <div className={cn('container mx-auto px-4 py-8', themeClasses.background)}>
+        <div className="mb-8">
+          <h1
+            data-testid="stargazer-page-title"
+            className={cn(
+              'text-4xl sm:text-5xl md:text-6xl font-extrabold mb-4 font-mono',
+              themeClasses.accentText,
+              themeClasses.glow,
+            )}
+          >
+            STARGAZER COMMAND CENTER
+          </h1>
+          <p className={cn('text-base sm:text-lg font-mono max-w-3xl', themeClasses.text)}>
+            Tonight&apos;s astrophotography forecast. Seeing, transparency, moon phase, planet
+            visibility, deep sky targets, ISS passes, and upcoming launches -- all in one place.
+          </p>
+          <p className="text-sm font-mono text-muted-foreground mt-2">
+            Tonight: {formatTonightDate(new Date())}
+          </p>
+        </div>
+
+        <ShareButtons
+          config={{
+            title: 'Stargazer - Astrophotography Forecast',
+            text: "Tonight's stargazing conditions at 16bitweather.co",
+            url: 'https://www.16bitweather.co/stargazer',
+          }}
+          className="mt-3 mb-6"
+        />
+
+        {children}
+      </div>
+    </PageWrapper>
+  );
+}
+
+function StargazerPageContent() {
   const searchParams = useSearchParams();
   const { currentLocation, locationInput } = useLocationContext();
   const latParam = searchParams.get('lat');
   const lonParam = searchParams.get('lon');
   const qParam = searchParams.get('q')?.trim() ?? '';
-  const { theme } = useTheme();
-  const themeClasses = getComponentStyles((theme || 'nord') as ThemeType, 'weather');
   const [data, setData] = useState<StargazerData | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -531,37 +574,7 @@ export default function StargazerPage() {
   }, [resolveAndLoad]);
 
   return (
-    <PageWrapper>
-      <div className={cn('container mx-auto px-4 py-8', themeClasses.background)}>
-        {/* Page Title */}
-        <div className="mb-8">
-          <h1
-            className={cn(
-              'text-4xl sm:text-5xl md:text-6xl font-extrabold mb-4 font-mono',
-              themeClasses.accentText,
-              themeClasses.glow
-            )}
-          >
-            STARGAZER COMMAND CENTER
-          </h1>
-          <p className={cn('text-base sm:text-lg font-mono max-w-3xl', themeClasses.text)}>
-            Tonight&apos;s astrophotography forecast. Seeing, transparency, moon phase, planet
-            visibility, deep sky targets, ISS passes, and upcoming launches -- all in one place.
-          </p>
-          <p className="text-sm font-mono text-muted-foreground mt-2">
-            Tonight: {formatTonightDate(new Date())}
-          </p>
-        </div>
-
-        <ShareButtons
-          config={{
-            title: 'Stargazer - Astrophotography Forecast',
-            text: "Tonight's stargazing conditions at 16bitweather.co",
-            url: 'https://www.16bitweather.co/stargazer',
-          }}
-          className="mt-3 mb-6"
-        />
-
+    <>
         {/* Location Search */}
         <form onSubmit={handleLocationSearch} className="mb-6 flex gap-2 max-w-md">
           <input
@@ -626,7 +639,23 @@ export default function StargazerPage() {
             <StargazerAttribution />
           </div>
         )}
-      </div>
-    </PageWrapper>
+    </>
+  );
+}
+
+export default function StargazerPage() {
+  const { theme } = useTheme();
+  const themeClasses = getComponentStyles((theme || 'nord') as ThemeType, 'weather');
+
+  return (
+    <StargazerShell themeClasses={themeClasses}>
+      <Suspense
+        fallback={
+          <p className="font-mono text-sm text-muted-foreground animate-pulse">Loading location…</p>
+        }
+      >
+        <StargazerPageContent />
+      </Suspense>
+    </StargazerShell>
   );
 }

--- a/app/stargazer/page.tsx
+++ b/app/stargazer/page.tsx
@@ -8,12 +8,14 @@
  * tab navigation, and organized content sections.
  */
 
-import React, { useEffect, useState, useCallback, startTransition } from 'react';
+import React, { useEffect, useState, useCallback, startTransition, useRef } from 'react';
+import { useSearchParams } from 'next/navigation';
 import { cn } from '@/lib/utils';
 import { useTheme } from '@/components/theme-provider';
 import { getComponentStyles, type ThemeType } from '@/lib/theme-utils';
 import PageWrapper from '@/components/page-wrapper';
 import { ShareButtons } from '@/components/share-buttons';
+import { useLocationContext } from '@/components/location-context';
 import type { StargazerData } from '@/lib/stargazer/types';
 import { getSubScoreLabel } from '@/lib/stargazer/score';
 import { formatTonightDate } from '@/lib/stargazer/bortle';
@@ -66,6 +68,27 @@ function getTabFromHash(): StargazerTabId {
   if (typeof window === 'undefined') return 'conditions';
   const hash = window.location.hash.replace('#', '') as StargazerTabId;
   return VALID_TABS.includes(hash) ? hash : 'conditions';
+}
+
+function parseCoord(value: string | null): number | null {
+  if (!value) return null;
+  const n = Number.parseFloat(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+async function geocodeLabel(label: string): Promise<{ lat: number; lon: number } | null> {
+  try {
+    const geoRes = await fetch(`/api/weather/geocoding?q=${encodeURIComponent(label)}&limit=1`);
+    if (!geoRes.ok) return null;
+    const geoData = await geoRes.json();
+    const result = Array.isArray(geoData) ? geoData[0] : geoData;
+    if (result?.lat != null && result?.lon != null) {
+      return { lat: result.lat, lon: result.lon };
+    }
+  } catch {
+    return null;
+  }
+  return null;
 }
 
 // ============================================================================
@@ -357,14 +380,24 @@ function LaunchesPanel({ data }: { data: StargazerData }) {
 // ============================================================================
 
 export default function StargazerPage() {
+  const searchParams = useSearchParams();
+  const { currentLocation, locationInput } = useLocationContext();
+  const latParam = searchParams.get('lat');
+  const lonParam = searchParams.get('lon');
+  const qParam = searchParams.get('q')?.trim() ?? '';
   const { theme } = useTheme();
   const themeClasses = getComponentStyles((theme || 'nord') as ThemeType, 'weather');
   const [data, setData] = useState<StargazerData | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<StargazerTabId>('conditions');
-  const [searchQuery, setSearchQuery] = useState('');
+  const [searchQuery, setSearchQuery] = useState(qParam);
   const [isSearching, setIsSearching] = useState(false);
+  const lastLoadedKeyRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (qParam) setSearchQuery(qParam);
+  }, [qParam]);
 
   // Read hash on mount
   useEffect(() => {
@@ -381,14 +414,14 @@ export default function StargazerPage() {
     window.location.hash = tab;
   }, []);
 
-  const fetchData = useCallback(async (customLat?: number, customLon?: number) => {
+  const fetchData = useCallback(async (customLat?: number, customLon?: number, options?: { usedFallback?: boolean }) => {
     try {
       setIsLoading(true);
       setError(null);
 
       let latitude: number;
       let longitude: number;
-      let usedFallback = false;
+      let usedFallback = options?.usedFallback ?? false;
 
       if (customLat != null && customLon != null) {
         latitude = customLat;
@@ -433,6 +466,38 @@ export default function StargazerPage() {
     }
   }, []);
 
+  const resolveAndLoad = useCallback(async () => {
+    const urlLat = parseCoord(latParam);
+    const urlLon = parseCoord(lonParam);
+    const loadKey = `${urlLat ?? ''},${urlLon ?? ''},${qParam},${locationInput},${currentLocation}`;
+
+    if (lastLoadedKeyRef.current === loadKey) return;
+    lastLoadedKeyRef.current = loadKey;
+
+    if (qParam) {
+      setSearchQuery(qParam);
+    } else {
+      const contextLabel = (locationInput || currentLocation)?.trim();
+      if (contextLabel) setSearchQuery(contextLabel);
+    }
+
+    if (urlLat != null && urlLon != null) {
+      await fetchData(urlLat, urlLon);
+      return;
+    }
+
+    const contextLabel = (locationInput || currentLocation)?.trim();
+    if (contextLabel) {
+      const coords = await geocodeLabel(contextLabel);
+      if (coords) {
+        await fetchData(coords.lat, coords.lon);
+        return;
+      }
+    }
+
+    await fetchData();
+  }, [latParam, lonParam, qParam, locationInput, currentLocation, fetchData]);
+
   const handleLocationSearch = useCallback(async (e: React.FormEvent) => {
     e.preventDefault();
     if (!searchQuery.trim()) return;
@@ -461,9 +526,9 @@ export default function StargazerPage() {
 
   useEffect(() => {
     startTransition(() => {
-      fetchData();
+      void resolveAndLoad();
     });
-  }, [fetchData]);
+  }, [resolveAndLoad]);
 
   return (
     <PageWrapper>
@@ -503,7 +568,8 @@ export default function StargazerPage() {
             type="text"
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            aria-label="Search location"
+            aria-label="Stargazer location search"
+            data-testid="stargazer-location-search"
             placeholder="Search location (city, state)"
             className="flex-1 px-3 py-2 text-sm font-mono bg-black/20 border border-subtle rounded focus:outline-none focus:border-primary"
           />

--- a/app/warnings/page.tsx
+++ b/app/warnings/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+import { Suspense } from 'react'
 import PageWrapper from '@/components/page-wrapper'
 import WarningsClient from './warnings-client'
 
@@ -14,7 +15,15 @@ export const metadata: Metadata = {
 export default function WarningsPage() {
   return (
     <PageWrapper>
-      <WarningsClient />
+      <Suspense
+        fallback={
+          <div className="max-w-7xl mx-auto px-4 py-8 text-center font-mono text-muted-foreground animate-pulse">
+            Loading warnings…
+          </div>
+        }
+      >
+        <WarningsClient />
+      </Suspense>
     </PageWrapper>
   )
 }

--- a/app/warnings/warnings-client.tsx
+++ b/app/warnings/warnings-client.tsx
@@ -70,6 +70,8 @@ export default function WarningsClient() {
   const searchParams = useSearchParams()
   const alertFromUrl = searchParams.get('alert')
   const detailRef = useRef<HTMLDivElement | null>(null)
+  const initialAlertAppliedRef = useRef(false)
+  const initialScrollAppliedRef = useRef(false)
   const [alerts, setAlerts] = useState<NWSAlertDetail[]>([])
   const [wis, setWis] = useState<WISScore | null>(null)
   const [geoJson, setGeoJson] = useState<AlertsFeatureCollection | null>(null)
@@ -218,15 +220,19 @@ export default function WarningsClient() {
   )
 
   useEffect(() => {
-    if (!alertFromUrl || alerts.length === 0) return
+    if (!alertFromUrl || alerts.length === 0 || initialAlertAppliedRef.current) return
     const matchedId = findAlertByQueryParam(alerts, alertFromUrl)
-    if (matchedId) setSelectedId(matchedId)
+    if (matchedId) {
+      setSelectedId(matchedId)
+      initialAlertAppliedRef.current = true
+    }
   }, [alertFromUrl, alerts])
 
   useEffect(() => {
-    if (!selected || !alertFromUrl) return
+    if (!selected || !initialAlertAppliedRef.current || initialScrollAppliedRef.current) return
+    initialScrollAppliedRef.current = true
     detailRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })
-  }, [selected, alertFromUrl])
+  }, [selected])
 
   function requestBrowserLocation() {
     if (!navigator.geolocation) return

--- a/app/warnings/warnings-client.tsx
+++ b/app/warnings/warnings-client.tsx
@@ -1,11 +1,13 @@
 'use client'
 
-import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import Link from 'next/link'
+import { useSearchParams } from 'next/navigation'
 import { ShareButtons } from '@/components/share-buttons'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { cn } from '@/lib/utils'
+import { findAlertByQueryParam } from '@/lib/home/hub-links'
 import type { NWSAlertDetail, WISScore } from '@/lib/services/nws-alerts-service'
 import type { SpcReport } from '@/lib/services/spc-storm-reports-service'
 import SPCDay1RiskStrip from '@/components/warnings/spc-day1-strip'
@@ -65,6 +67,9 @@ type CommunityReport = {
 }
 
 export default function WarningsClient() {
+  const searchParams = useSearchParams()
+  const alertFromUrl = searchParams.get('alert')
+  const detailRef = useRef<HTMLDivElement | null>(null)
   const [alerts, setAlerts] = useState<NWSAlertDetail[]>([])
   const [wis, setWis] = useState<WISScore | null>(null)
   const [geoJson, setGeoJson] = useState<AlertsFeatureCollection | null>(null)
@@ -211,6 +216,17 @@ export default function WarningsClient() {
     () => alerts.find((a) => a.id === selectedId) ?? null,
     [alerts, selectedId]
   )
+
+  useEffect(() => {
+    if (!alertFromUrl || alerts.length === 0) return
+    const matchedId = findAlertByQueryParam(alerts, alertFromUrl)
+    if (matchedId) setSelectedId(matchedId)
+  }, [alertFromUrl, alerts])
+
+  useEffect(() => {
+    if (!selected || !alertFromUrl) return
+    detailRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+  }, [selected, alertFromUrl])
 
   function requestBrowserLocation() {
     if (!navigator.geolocation) return
@@ -447,7 +463,11 @@ export default function WarningsClient() {
       </div>
 
       {selected && (
-        <div className="rounded-lg border border-border bg-card/60 p-4 space-y-3 font-mono text-sm">
+        <div
+          ref={detailRef}
+          id="warnings-alert-detail"
+          className="rounded-lg border border-border bg-card/60 p-4 space-y-3 font-mono text-sm scroll-mt-24"
+        >
           <div className="flex flex-wrap justify-between gap-2">
             <h3 className="font-bold text-lg">{selected.event}</h3>
             <span className="text-xs text-muted-foreground">{selected.severity} · {selected.urgency}</span>

--- a/app/weather/[city]/client.tsx
+++ b/app/weather/[city]/client.tsx
@@ -11,7 +11,7 @@
  */
 
 
-import type { JSX } from 'react'
+import type { JSX, ReactNode } from 'react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { fetchWeatherData } from '@/lib/weather'
@@ -24,6 +24,14 @@ import { Loader2 } from 'lucide-react'
 import { ResponsiveContainer } from '@/components/responsive-container'
 import { useLocationContext } from '@/components/location-context'
 import { WeatherDisplay } from '@/components/weather-display'
+import { locationInputToSlug } from '@/lib/city-slug'
+import { useHubLocation } from '@/hooks/use-hub-location'
+import dynamic from 'next/dynamic'
+
+const HomeHub = dynamic(() => import('@/components/home/home-hub'), {
+  ssr: false,
+  loading: () => <div className="mt-4 h-16 animate-pulse rounded-md bg-gray-800/30" aria-hidden />,
+})
 
 interface CityWeatherClientProps {
   city: {
@@ -39,11 +47,10 @@ interface CityWeatherClientProps {
     }
   }
   citySlug: string
-  /** Kept for API compatibility with `page.tsx`. No longer used in rendering. */
-  isPredefinedCity?: boolean
+  climateGuide?: ReactNode
 }
 
-export default function CityWeatherClient({ city, citySlug }: CityWeatherClientProps): JSX.Element {
+export default function CityWeatherClient({ city, citySlug, climateGuide }: CityWeatherClientProps): JSX.Element {
   const router = useRouter()
   const { theme } = useTheme()
   const { preferences } = useAuth()
@@ -62,6 +69,7 @@ export default function CityWeatherClient({ city, citySlug }: CityWeatherClientP
   const weatherRequestRef = useRef(0)
   const weatherLatitude = weather?.coordinates?.lat
   const weatherLongitude = weather?.coordinates?.lon
+  const hubLocation = useHubLocation(weather)
 
   // Fetch 24h precipitation data when weather loads
   useEffect(() => {
@@ -92,14 +100,8 @@ export default function CityWeatherClient({ city, citySlug }: CityWeatherClientP
     return () => controller.abort()
   }, [weatherLatitude, weatherLongitude])
 
-  // Helper: normalize "San Ramon, CA" -> "san-ramon-ca"
-  const toSlug = (input: string) =>
-    input
-      .trim()
-      .toLowerCase()
-      .replace(/,/g, '')
-      .replace(/\s+/g, '-')
-      .replace(/[^a-z0-9-]/g, '')
+  // Helper: normalize search input to /weather/[city] slug
+  const toSlug = locationInputToSlug
 
   // Load weather data for the specific city
   const loadCityWeather = useCallback(async () => {
@@ -143,18 +145,20 @@ export default function CityWeatherClient({ city, citySlug }: CityWeatherClientP
     setCurrentLocation(city.searchTerm)
   }, [city.searchTerm, citySlug, clearLocationState, setCurrentLocation, setLocationInput])
 
-  // Existing effect: load weather for this page's city (runs after reset above)
   useEffect(() => {
     setShouldClearOnRouteChange(false)
-
-    // Load city-specific weather data first (city pages should show city data, not user location)
-    loadCityWeather()
-
-    // Cleanup: enable route change clearing when leaving city pages
+    void loadCityWeather()
     return () => {
       setShouldClearOnRouteChange(true)
     }
   }, [loadCityWeather, setShouldClearOnRouteChange])
+
+  useEffect(() => {
+    if (!weather || loading) return
+    const anchor = document.getElementById('live-weather')
+    if (!anchor) return
+    anchor.scrollIntoView({ behavior: 'smooth', block: 'start' })
+  }, [citySlug, weather?.location, loading])
 
   // REPLACE handleSearch to navigate instead of only setting local weather
   const handleSearch = async (locationInput: string) => {
@@ -209,7 +213,7 @@ export default function CityWeatherClient({ city, citySlug }: CityWeatherClientP
       weatherUnit={weather?.unit}
     >
       <div className="min-h-screen bg-gradient-to-b from-[hsl(var(--background))] to-[hsl(var(--card))]">
-        <ResponsiveContainer maxWidth="xl" padding="md">
+        <ResponsiveContainer maxWidth="2xl" padding="md">
 
           {/* Weather Search Component */}
           <WeatherSearch
@@ -222,6 +226,8 @@ export default function CityWeatherClient({ city, citySlug }: CityWeatherClientP
             isDisabled={false}
             hideLocationButton={true}
           />
+
+          <HomeHub userLocation={hubLocation} />
 
           {/* Loading State */}
           {loading && (
@@ -240,22 +246,19 @@ export default function CityWeatherClient({ city, citySlug }: CityWeatherClientP
 
           {/* Weather Display - Unified with homepage */}
           {weather && !loading && !error && (
-            <WeatherDisplay
-              weather={weather}
-              theme={theme || 'nord'}
-              selectedDay={selectedDay}
-              onDayClick={(index) => setSelectedDay(selectedDay === index ? null : index)}
-              precipitation={precipitation}
-              showRadar={true}
-            />
+            <div id="live-weather" className="scroll-mt-24">
+              <WeatherDisplay
+                weather={weather}
+                theme={theme || 'nord'}
+                selectedDay={selectedDay}
+                onDayClick={(index) => setSelectedDay(selectedDay === index ? null : index)}
+                precipitation={precipitation}
+                showRadar={true}
+              />
+            </div>
           )}
 
-          {/*
-            Note: SEO content (H1, climate overview, seasonal breakdown, FAQ,
-            nearby cities) is now server-rendered by `page.tsx` so it lands in
-            the initial HTML for Googlebot. This client component is purely
-            for the interactive weather widget.
-          */}
+          {climateGuide ? <div className="mt-8">{climateGuide}</div> : null}
         </ResponsiveContainer>
       </div>
     </PageWrapper>

--- a/app/weather/[city]/page.tsx
+++ b/app/weather/[city]/page.tsx
@@ -1,55 +1,34 @@
 /**
- * 16-Bit Weather Platform - v1.0.0
- *
- * Copyright (C) 2025 16-Bit Weather
- * Licensed under Fair Source License, Version 0.9
- *
- * Use Limitation: 5 users
- * See LICENSE file for full terms
- */
-
-/**
  * City Weather Page - Server Component
  *
- * Ships a full, server-rendered SEO article for every city so Googlebot sees
- * meaningful unique content in the raw HTML (not after JS hydration). Rich
- * content for flagship cities comes from `cityEnrichments`; other cities fall
- * back to the short intro/climate/patterns copy with a consistent structure.
- *
- * Below the article, the interactive <CityWeatherClient> renders the live
- * weather widget and handles user interactions.
+ * Live weather renders first; climate/SEO content follows below the fold.
  */
 
 import { Suspense } from 'react'
-import Link from 'next/link'
 import type { Metadata } from 'next'
 
 import { safeJsonLd } from '@/lib/utils'
 import CityWeatherClient from './client'
+import CityClimateGuide from '@/components/city/city-climate-guide'
 import {
   cityData as cityMetadata,
   getCityEnrichment,
   getNearbyCities,
 } from '@/lib/city-metadata'
+import { slugToDisplayName, slugToSearchTerm } from '@/lib/city-slug'
 
 const BASE_URL = 'https://www.16bitweather.co'
-const MONTH_LABELS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
 
-// Generate static pages for better SEO
 export async function generateStaticParams(): Promise<Array<{ city: string }>> {
   return Object.keys(cityMetadata).map(citySlug => ({ city: citySlug }))
 }
 
-// Generate metadata for each city page
 export async function generateMetadata({ params }: { params: Promise<{ city: string }> }): Promise<Metadata> {
   const { city: citySlug } = await params
   const city = cityMetadata[citySlug]
 
-  // For non-predefined slugs, the page still renders a working client-side
-  // weather search. Emit minimal metadata with noindex so Google doesn't
-  // crawl and index every ad-hoc slug users happen to visit.
   if (!city) {
-    const displayName = formatCityName(citySlug)
+    const displayName = slugToDisplayName(citySlug)
     return {
       title: `${displayName} Weather Forecast | 16 Bit Weather`,
       description: `Live weather conditions and forecast for ${displayName}.`,
@@ -101,17 +80,14 @@ export default async function CityWeatherPage({ params }: PageParams) {
   const { city: citySlug } = await params
   const city = cityMetadata[citySlug]
 
-  // If city doesn't exist in our predefined list, still render the client
-  // component so dynamic searches work — but without rich SEO content, since
-  // those pages are intentionally excluded from the sitemap.
   const cityInfo = city || {
-    name: formatCityName(citySlug),
+    name: slugToDisplayName(citySlug),
     state: '',
-    searchTerm: citySlugToSearchTerm(citySlug),
-    title: `${formatCityName(citySlug)} Weather Forecast - 16 Bit Weather`,
-    description: `Current weather conditions and 7-day forecast for ${formatCityName(citySlug)}.`,
+    searchTerm: slugToSearchTerm(citySlug),
+    title: `${slugToDisplayName(citySlug)} Weather Forecast - 16 Bit Weather`,
+    description: `Current weather conditions and 7-day forecast for ${slugToDisplayName(citySlug)}.`,
     content: {
-      intro: `Weather information for ${formatCityName(citySlug)}.`,
+      intro: `Weather information for ${slugToDisplayName(citySlug)}.`,
       climate: 'Real-time weather data and forecasts available.',
       patterns: 'Check current conditions and extended forecasts.',
     },
@@ -122,7 +98,6 @@ export default async function CityWeatherPage({ params }: PageParams) {
   const nearbyCities = isPredefinedCity ? getNearbyCities(citySlug) : []
   const fullLocation = cityInfo.state ? `${cityInfo.name}, ${cityInfo.state}` : cityInfo.name
 
-  // Structured data: WebPage + Place + BreadcrumbList
   const webPageJsonLd = {
     '@context': 'https://schema.org',
     '@type': 'WebPage',
@@ -152,7 +127,6 @@ export default async function CityWeatherPage({ params }: PageParams) {
     },
   }
 
-  // Structured data: FAQPage (only when we have curated FAQs)
   const faqJsonLd = enrichment?.faqs?.length
     ? {
         '@context': 'https://schema.org',
@@ -165,221 +139,29 @@ export default async function CityWeatherPage({ params }: PageParams) {
       }
     : null
 
+  const climateGuide = isPredefinedCity ? (
+    <CityClimateGuide
+      fullLocation={fullLocation}
+      cityName={cityInfo.name}
+      content={cityInfo.content}
+      enrichment={enrichment}
+      nearbyCities={nearbyCities}
+    />
+  ) : null
+
   return (
     <>
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: safeJsonLd(webPageJsonLd) }}
       />
-      {faqJsonLd && (
+      {faqJsonLd ? (
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: safeJsonLd(faqJsonLd) }}
         />
-      )}
+      ) : null}
 
-      {/*
-        Server-rendered SEO content for predefined cities. This is in the
-        initial HTML response (no JS required) so Googlebot sees real unique
-        content for every city it crawls.
-      */}
-      {isPredefinedCity && (
-        <article className="mx-auto max-w-4xl px-4 pt-8 pb-4 text-weather-text font-mono">
-          {/* Breadcrumbs */}
-          <nav aria-label="Breadcrumb" className="mb-6 text-xs uppercase tracking-wider text-weather-muted">
-            <ol className="flex flex-wrap items-center gap-2">
-              <li>
-                <Link href="/" className="hover:text-weather-primary">Home</Link>
-              </li>
-              <li aria-hidden="true">/</li>
-              <li className="text-weather-primary" aria-current="page">
-                {fullLocation}
-              </li>
-            </ol>
-          </nav>
-
-          {/* Hero / H1 — the single authoritative heading for the page */}
-          <header className="mb-8">
-            <h1 className="text-3xl md:text-4xl font-bold uppercase tracking-tight text-weather-primary mb-3">
-              {`${fullLocation} Weather Forecast & Climate Guide`}
-            </h1>
-            <p className="text-sm md:text-base text-weather-muted leading-relaxed max-w-3xl">
-              {cityInfo.content.intro}
-            </p>
-            {enrichment?.climateType && (
-              <p className="mt-3 text-xs uppercase tracking-widest text-weather-muted">
-                Climate type: <span className="text-weather-primary">{enrichment.climateType}</span>
-              </p>
-            )}
-          </header>
-
-          {/* Climate overview — always available, uses existing thin content as fallback */}
-          <section className="mb-10">
-            <h2 className="text-xl font-bold uppercase tracking-wider text-weather-primary mb-3">
-              {cityInfo.name} Climate Overview
-            </h2>
-            <p className="text-sm leading-relaxed mb-3">{cityInfo.content.climate}</p>
-            <p className="text-sm leading-relaxed">{cityInfo.content.patterns}</p>
-          </section>
-
-          {/* Seasonal breakdown — only for enriched cities */}
-          {enrichment?.seasons && (
-            <section className="mb-10">
-              <h2 className="text-xl font-bold uppercase tracking-wider text-weather-primary mb-4">
-                {cityInfo.name} Weather by Season
-              </h2>
-              <div className="grid gap-4 sm:grid-cols-2">
-                {(['spring', 'summer', 'fall', 'winter'] as const).map(season => (
-                  <div
-                    key={season}
-                    className="rounded-lg border-2 border-weather-border bg-weather-bg-elev p-4"
-                  >
-                    <h3 className="text-sm font-bold uppercase tracking-wider text-weather-primary mb-2">
-                      {season}
-                    </h3>
-                    <p className="text-xs leading-relaxed">{enrichment.seasons[season]}</p>
-                  </div>
-                ))}
-              </div>
-            </section>
-          )}
-
-          {/* Monthly averages table — high-value structured data.
-              Guard on exact length === MONTH_LABELS.length so an off-by-one
-              in future data can never silently misalign columns. */}
-          {enrichment?.monthlyHighs?.length === MONTH_LABELS.length &&
-            enrichment?.monthlyLows?.length === MONTH_LABELS.length && (
-            <section className="mb-10">
-              <h2 className="text-xl font-bold uppercase tracking-wider text-weather-primary mb-4">
-                {cityInfo.name} Average Monthly Temperatures
-              </h2>
-              <div className="overflow-x-auto rounded-lg border-2 border-weather-border">
-                <table className="w-full text-xs">
-                  <caption className="sr-only">
-                    Average monthly high and low temperatures for {fullLocation} in °F
-                  </caption>
-                  <thead className="bg-weather-bg-elev">
-                    <tr>
-                      <th scope="col" className="px-2 py-2 text-left uppercase tracking-wider">Month</th>
-                      {MONTH_LABELS.map(month => (
-                        <th key={month} scope="col" className="px-2 py-2 text-center uppercase tracking-wider">
-                          {month}
-                        </th>
-                      ))}
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <tr className="border-t-2 border-weather-border">
-                      <th scope="row" className="px-2 py-2 text-left font-bold uppercase text-weather-primary">
-                        High °F
-                      </th>
-                      {enrichment.monthlyHighs.map((temp, i) => (
-                        <td key={i} className="px-2 py-2 text-center">{temp}°</td>
-                      ))}
-                    </tr>
-                    <tr className="border-t border-weather-border">
-                      <th scope="row" className="px-2 py-2 text-left font-bold uppercase text-weather-muted">
-                        Low °F
-                      </th>
-                      {enrichment.monthlyLows.map((temp, i) => (
-                        <td key={i} className="px-2 py-2 text-center">{temp}°</td>
-                      ))}
-                    </tr>
-                  </tbody>
-                </table>
-              </div>
-            </section>
-          )}
-
-          {/* Best time to visit + severe weather risks */}
-          {enrichment?.bestTimeToVisit && (
-            <section className="mb-10 grid gap-4 md:grid-cols-2">
-              <div className="rounded-lg border-2 border-weather-border bg-weather-bg-elev p-4">
-                <h2 className="text-sm font-bold uppercase tracking-wider text-weather-primary mb-2">
-                  Best Time to Visit {cityInfo.name}
-                </h2>
-                <p className="text-xs leading-relaxed">{enrichment.bestTimeToVisit}</p>
-              </div>
-              {enrichment.severeRisks?.length > 0 && (
-                <div className="rounded-lg border-2 border-weather-border bg-weather-bg-elev p-4">
-                  <h2 className="text-sm font-bold uppercase tracking-wider text-weather-primary mb-2">
-                    Severe Weather Risks
-                  </h2>
-                  <ul className="flex flex-wrap gap-2">
-                    {enrichment.severeRisks.map(risk => (
-                      <li
-                        key={risk}
-                        className="text-[10px] uppercase tracking-wider border border-weather-border rounded px-2 py-1"
-                      >
-                        {risk}
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              )}
-            </section>
-          )}
-
-          {/* Unique local facts */}
-          {enrichment?.uniqueFacts && enrichment.uniqueFacts.length > 0 && (
-            <section className="mb-10">
-              <h2 className="text-xl font-bold uppercase tracking-wider text-weather-primary mb-3">
-                Weather Facts About {cityInfo.name}
-              </h2>
-              <ul className="space-y-2 text-sm leading-relaxed">
-                {enrichment.uniqueFacts.map((fact, i) => (
-                  <li key={i} className="flex gap-2">
-                    <span className="text-weather-primary">&gt;</span>
-                    <span>{fact}</span>
-                  </li>
-                ))}
-              </ul>
-            </section>
-          )}
-
-          {/* FAQ section — also powers FAQPage JSON-LD above */}
-          {enrichment?.faqs && enrichment.faqs.length > 0 && (
-            <section className="mb-10">
-              <h2 className="text-xl font-bold uppercase tracking-wider text-weather-primary mb-4">
-                {cityInfo.name} Weather FAQ
-              </h2>
-              <div className="space-y-4">
-                {enrichment.faqs.map((faq, i) => (
-                  <div
-                    key={i}
-                    className="rounded-lg border-2 border-weather-border bg-weather-bg-elev p-4"
-                  >
-                    <h3 className="text-sm font-bold text-weather-primary mb-2">{faq.question}</h3>
-                    <p className="text-xs leading-relaxed">{faq.answer}</p>
-                  </div>
-                ))}
-              </div>
-            </section>
-          )}
-
-          {/* Nearby cities — internal linking for crawl graph */}
-          {nearbyCities.length > 0 && (
-            <section className="mb-10">
-              <h2 className="text-xl font-bold uppercase tracking-wider text-weather-primary mb-4">
-                Explore Nearby City Weather
-              </h2>
-              <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-                {nearbyCities.map(neighbor => (
-                  <Link
-                    key={neighbor.slug}
-                    href={`/weather/${neighbor.slug}`}
-                    className="block rounded-lg border-2 border-weather-border bg-weather-bg-elev p-3 text-xs uppercase tracking-wider transition-colors hover:border-weather-primary hover:text-weather-primary"
-                  >
-                    {neighbor.name}, {neighbor.state}
-                  </Link>
-                ))}
-              </div>
-            </section>
-          )}
-        </article>
-      )}
-
-      {/* Interactive weather widget — client component */}
       <Suspense
         fallback={
           <div className="min-h-[400px] bg-gradient-to-b from-gray-900 to-black">
@@ -389,31 +171,14 @@ export default async function CityWeatherPage({ params }: PageParams) {
           </div>
         }
       >
-        <CityWeatherClient city={cityInfo} citySlug={citySlug} isPredefinedCity={isPredefinedCity} />
+        <CityWeatherClient
+          city={cityInfo}
+          citySlug={citySlug}
+          climateGuide={climateGuide}
+        />
       </Suspense>
     </>
   )
 }
 
-// Utility functions
-function formatCityName(slug: string): string {
-  return slug
-    .split('-')
-    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(' ')
-}
-
-function citySlugToSearchTerm(slug: string): string {
-  const parts = slug.split('-')
-  if (parts.length > 1) {
-    const state = parts[parts.length - 1].toUpperCase()
-    const cityParts = parts.slice(0, -1)
-    const cityName = cityParts.map(word => word.charAt(0).toUpperCase() + word.slice(1)).join(' ')
-    return `${cityName}, ${state}`
-  }
-  return formatCityName(slug)
-}
-
-// ISR: revalidate every 10 minutes so weather data stays fresh but SEO
-// content is served from the cache for fast TTFB.
 export const revalidate = 600

--- a/components/city/city-climate-guide.tsx
+++ b/components/city/city-climate-guide.tsx
@@ -1,0 +1,237 @@
+import Link from 'next/link';
+import type { CitySeoEnrichment } from '@/lib/city-metadata';
+
+const MONTH_LABELS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+export interface CityClimateGuideProps {
+  fullLocation: string;
+  cityName: string;
+  content: {
+    intro: string;
+    climate: string;
+    patterns: string;
+  };
+  enrichment: CitySeoEnrichment | null;
+  nearbyCities: Array<{ slug: string; name: string; state: string }>;
+}
+
+/**
+ * Optional climate / SEO reading for curated city pages.
+ * Collapsed by default — live forecast stays primary for every visitor.
+ */
+export default function CityClimateGuide({
+  fullLocation,
+  cityName,
+  content,
+  enrichment,
+  nearbyCities,
+}: CityClimateGuideProps) {
+  return (
+    <details
+      id="city-climate-guide"
+      className="mx-auto max-w-4xl border-t border-weather-border/40 pt-6 font-mono text-weather-text group"
+    >
+      <summary className="cursor-pointer list-none px-2 py-3 rounded-md border border-weather-border/60 bg-weather-bg-elev/50 hover:border-weather-primary/50 transition-colors [&::-webkit-details-marker]:hidden">
+        <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+          <span className="text-sm font-bold uppercase tracking-wider text-weather-primary">
+            Climate guide &amp; monthly averages — {fullLocation}
+          </span>
+          <span className="text-[10px] uppercase tracking-widest text-weather-muted">
+            Optional reading · tap to expand
+          </span>
+        </div>
+      </summary>
+
+      <article className="px-2 pt-8 pb-8">
+        <nav aria-label="Breadcrumb" className="mb-6 text-xs uppercase tracking-wider text-weather-muted">
+          <ol className="flex flex-wrap items-center gap-2">
+            <li>
+              <Link href="/" className="hover:text-weather-primary">
+                Home
+              </Link>
+            </li>
+            <li aria-hidden="true">/</li>
+            <li className="text-weather-primary" aria-current="page">
+              {fullLocation}
+            </li>
+          </ol>
+        </nav>
+
+        <header className="mb-8">
+          <h2 className="text-2xl md:text-3xl font-bold uppercase tracking-tight text-weather-primary mb-3">
+            {`${fullLocation} Climate Guide`}
+          </h2>
+          <p className="text-sm md:text-base text-weather-muted leading-relaxed max-w-3xl">
+            {content.intro}
+          </p>
+          {enrichment?.climateType ? (
+            <p className="mt-3 text-xs uppercase tracking-widest text-weather-muted">
+              Climate type: <span className="text-weather-primary">{enrichment.climateType}</span>
+            </p>
+          ) : null}
+        </header>
+
+        <section className="mb-10">
+          <h3 className="text-xl font-bold uppercase tracking-wider text-weather-primary mb-3">
+            {cityName} Climate Overview
+          </h3>
+          <p className="text-sm leading-relaxed mb-3">{content.climate}</p>
+          <p className="text-sm leading-relaxed">{content.patterns}</p>
+        </section>
+
+        {enrichment?.seasons ? (
+          <section className="mb-10">
+            <h3 className="text-xl font-bold uppercase tracking-wider text-weather-primary mb-4">
+              {cityName} Weather by Season
+            </h3>
+            <div className="grid gap-4 sm:grid-cols-2">
+              {(['spring', 'summer', 'fall', 'winter'] as const).map((season) => (
+                <div
+                  key={season}
+                  className="rounded-lg border-2 border-weather-border bg-weather-bg-elev p-4"
+                >
+                  <h4 className="text-sm font-bold uppercase tracking-wider text-weather-primary mb-2">
+                    {season}
+                  </h4>
+                  <p className="text-xs leading-relaxed">{enrichment.seasons[season]}</p>
+                </div>
+              ))}
+            </div>
+          </section>
+        ) : null}
+
+        {enrichment?.monthlyHighs?.length === MONTH_LABELS.length &&
+        enrichment?.monthlyLows?.length === MONTH_LABELS.length ? (
+          <section className="mb-10">
+            <h3 className="text-xl font-bold uppercase tracking-wider text-weather-primary mb-4">
+              {cityName} Average Monthly Temperatures
+            </h3>
+            <div className="overflow-x-auto rounded-lg border-2 border-weather-border">
+              <table className="w-full text-xs">
+                <caption className="sr-only">
+                  Average monthly high and low temperatures for {fullLocation} in °F
+                </caption>
+                <thead className="bg-weather-bg-elev">
+                  <tr>
+                    <th scope="col" className="px-2 py-2 text-left uppercase tracking-wider">
+                      Month
+                    </th>
+                    {MONTH_LABELS.map((month) => (
+                      <th key={month} scope="col" className="px-2 py-2 text-center uppercase tracking-wider">
+                        {month}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr className="border-t-2 border-weather-border">
+                    <th scope="row" className="px-2 py-2 text-left font-bold uppercase text-weather-primary">
+                      High °F
+                    </th>
+                    {enrichment.monthlyHighs.map((temp, i) => (
+                      <td key={i} className="px-2 py-2 text-center">
+                        {temp}°
+                      </td>
+                    ))}
+                  </tr>
+                  <tr className="border-t border-weather-border">
+                    <th scope="row" className="px-2 py-2 text-left font-bold uppercase text-weather-muted">
+                      Low °F
+                    </th>
+                    {enrichment.monthlyLows.map((temp, i) => (
+                      <td key={i} className="px-2 py-2 text-center">
+                        {temp}°
+                      </td>
+                    ))}
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </section>
+        ) : null}
+
+        {enrichment?.bestTimeToVisit ? (
+          <section className="mb-10 grid gap-4 md:grid-cols-2">
+            <div className="rounded-lg border-2 border-weather-border bg-weather-bg-elev p-4">
+              <h3 className="text-sm font-bold uppercase tracking-wider text-weather-primary mb-2">
+                Best Time to Visit {cityName}
+              </h3>
+              <p className="text-xs leading-relaxed">{enrichment.bestTimeToVisit}</p>
+            </div>
+            {enrichment.severeRisks?.length ? (
+              <div className="rounded-lg border-2 border-weather-border bg-weather-bg-elev p-4">
+                <h3 className="text-sm font-bold uppercase tracking-wider text-weather-primary mb-2">
+                  Severe Weather Risks
+                </h3>
+                <ul className="flex flex-wrap gap-2">
+                  {enrichment.severeRisks.map((risk) => (
+                    <li
+                      key={risk}
+                      className="text-[10px] uppercase tracking-wider border border-weather-border rounded px-2 py-1"
+                    >
+                      {risk}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ) : null}
+          </section>
+        ) : null}
+
+        {enrichment?.uniqueFacts && enrichment.uniqueFacts.length > 0 ? (
+          <section className="mb-10">
+            <h3 className="text-xl font-bold uppercase tracking-wider text-weather-primary mb-3">
+              Weather Facts About {cityName}
+            </h3>
+            <ul className="space-y-2 text-sm leading-relaxed">
+              {enrichment.uniqueFacts.map((fact, i) => (
+                <li key={i} className="flex gap-2">
+                  <span className="text-weather-primary">&gt;</span>
+                  <span>{fact}</span>
+                </li>
+              ))}
+            </ul>
+          </section>
+        ) : null}
+
+        {enrichment?.faqs && enrichment.faqs.length > 0 ? (
+          <section className="mb-10">
+            <h3 className="text-xl font-bold uppercase tracking-wider text-weather-primary mb-4">
+              {cityName} Weather FAQ
+            </h3>
+            <div className="space-y-4">
+              {enrichment.faqs.map((faq, i) => (
+                <div
+                  key={i}
+                  className="rounded-lg border-2 border-weather-border bg-weather-bg-elev p-4"
+                >
+                  <h4 className="text-sm font-bold text-weather-primary mb-2">{faq.question}</h4>
+                  <p className="text-xs leading-relaxed">{faq.answer}</p>
+                </div>
+              ))}
+            </div>
+          </section>
+        ) : null}
+
+        {nearbyCities.length > 0 ? (
+          <section className="mb-4">
+            <h3 className="text-xl font-bold uppercase tracking-wider text-weather-primary mb-4">
+              Explore Nearby City Weather
+            </h3>
+            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+              {nearbyCities.map((neighbor) => (
+                <Link
+                  key={neighbor.slug}
+                  href={`/weather/${neighbor.slug}`}
+                  className="block rounded-lg border-2 border-weather-border bg-weather-bg-elev p-3 text-xs uppercase tracking-wider transition-colors hover:border-weather-primary hover:text-weather-primary"
+                >
+                  {neighbor.name}, {neighbor.state}
+                </Link>
+              ))}
+            </div>
+          </section>
+        ) : null}
+      </article>
+    </details>
+  );
+}

--- a/components/forecast.tsx
+++ b/components/forecast.tsx
@@ -90,12 +90,13 @@ function ForecastCard({ day, index, onDayClick, isSelected }: {
 
   return (
     <Card
+      data-precip-tier={precip.tier}
       className={cn(
-        "forecast-day-card cursor-pointer transition-all duration-200 hover:-translate-y-0.5 card-interactive",
+        "forecast-day-card relative overflow-hidden cursor-pointer transition-all duration-200 hover:-translate-y-0.5 card-interactive",
         "flex flex-col justify-between min-h-[120px] sm:min-h-[140px] lg:min-h-[160px]",
-        "backdrop-blur-sm bg-card/70 border border-[var(--border-invisible)] shadow-[0_10px_28px_-14px_rgba(0,0,0,0.55)]",
+        "backdrop-blur-sm border border-[var(--border-invisible)] shadow-[0_10px_28px_-14px_rgba(0,0,0,0.55)]",
         "hover:border-[var(--border-subtle)] hover:shadow-[0_14px_36px_-14px_rgba(0,0,0,0.55)]",
-        !isSelected && precip.borderClass,
+        precip.tier === 'none' ? "bg-card/70" : precip.cardClass,
         isSelected && "ring-2 ring-primary ring-offset-2 ring-offset-background shadow-[0_0_22px_rgba(var(--theme-accent-rgb),0.32)]"
       )}
       onClick={handleClick}
@@ -105,6 +106,12 @@ function ForecastCard({ day, index, onDayClick, isSelected }: {
       aria-label={`Forecast for ${day.day}: High ${Math.round(day.highTemp)}${tempUnit}, Low ${Math.round(day.lowTemp)}${tempUnit}, ${day.description}`}
       aria-pressed={isSelected}
     >
+      {precip.tier !== 'none' ? (
+        <div
+          className={cn("absolute inset-x-0 top-0 rounded-t-lg pointer-events-none", precip.stripClass)}
+          aria-hidden
+        />
+      ) : null}
       <CardContent className="p-2 sm:p-3 flex flex-col items-center justify-between h-full">
         {/* Day - Mobile responsive */}
         <div className="text-xs sm:text-sm font-bold text-primary mb-1 uppercase tracking-wider glow text-center">
@@ -136,8 +143,14 @@ function ForecastCard({ day, index, onDayClick, isSelected }: {
 
         {/* Precipitation chance */}
         {(day.details?.precipitationChance ?? 0) > 0 && (
-          <div className={cn("text-xs font-medium tabular-nums mt-1", precip.chipClass)}>
-            <span aria-label="Precipitation chance">&#x1F4A7;</span> {day.details?.precipitationChance}%
+          <div
+            className={cn(
+              "mt-1 inline-flex items-center gap-0.5 rounded-full px-1.5 py-0.5 text-[10px] sm:text-xs font-medium tabular-nums",
+              precip.chipClass,
+            )}
+          >
+            <span aria-hidden>&#x1F4A7;</span>
+            <span>{day.details?.precipitationChance}%</span>
           </div>
         )}
 

--- a/components/home/home-hub-card.tsx
+++ b/components/home/home-hub-card.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import Link from 'next/link';
+import { cn } from '@/lib/utils';
+import { isExternalHubHref } from '@/lib/home/hub-links';
+
+export interface HomeHubCardProps {
+  title: string;
+  value: string;
+  detail?: string;
+  href: string;
+  accentColor?: string;
+  loading?: boolean;
+  className?: string;
+}
+
+export default function HomeHubCard({
+  title,
+  value,
+  detail,
+  href,
+  accentColor = 'var(--primary)',
+  loading = false,
+  className,
+}: HomeHubCardProps) {
+  const classNames = cn(
+    'group block shrink-0 rounded-md border border-border/80 bg-card/50 px-2.5 py-2 font-mono',
+    'w-[9.25rem] sm:w-[10rem]',
+    'transition-colors hover:border-primary/50 hover:bg-card/80 focus-visible:outline-2',
+    'focus-visible:outline-primary focus-visible:outline-offset-2',
+    className,
+  );
+
+  const content = (
+    <>
+      <div className="mb-1 flex items-center gap-1.5">
+        <span
+          className="inline-block h-1.5 w-1.5 shrink-0 rounded-sm border border-border/60"
+          style={{ backgroundColor: accentColor }}
+          aria-hidden
+        />
+        <p className="truncate text-[9px] uppercase tracking-wider text-muted-foreground">{title}</p>
+      </div>
+      {loading ? (
+        <div className="space-y-1 animate-pulse" aria-hidden>
+          <div className="h-3 w-4/5 rounded bg-muted/40" />
+          <div className="h-2.5 w-full rounded bg-muted/30" />
+        </div>
+      ) : (
+        <>
+          <p className="text-xs font-bold leading-tight text-foreground group-hover:text-primary line-clamp-2">
+            {value}
+          </p>
+          {detail ? (
+            <p className="mt-0.5 text-[10px] leading-snug text-muted-foreground line-clamp-1">{detail}</p>
+          ) : null}
+        </>
+      )}
+    </>
+  );
+
+  if (isExternalHubHref(href)) {
+    return (
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        data-testid="home-hub-card"
+        className={classNames}
+      >
+        {content}
+      </a>
+    );
+  }
+
+  return (
+    <Link href={href} data-testid="home-hub-card" className={classNames}>
+      {content}
+    </Link>
+  );
+}

--- a/components/home/home-hub.tsx
+++ b/components/home/home-hub.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+import { useTheme } from '@/components/theme-provider';
+import { getComponentStyles, type ThemeType } from '@/lib/theme-utils';
+import { getCategoryConfig } from '@/components/news/CategoryBadge';
+import HomeHubCard from '@/components/home/home-hub-card';
+import { stargazerCardDetail } from '@/lib/home/hub-location';
+import {
+  shouldShowHubAlerts,
+  shouldShowHubHeadline,
+  shouldShowSpcOutlook,
+  shouldShowStargazerCard,
+} from '@/lib/home/hub-utils';
+import type { HubUserLocation } from '@/lib/home/hub-utils';
+import {
+  getAlertsCardValue,
+  getHeadlineCardValue,
+  getStargazerCardValue,
+  SEVERITY_ACCENT,
+  useHomeHubData,
+} from '@/hooks/use-home-hub-data';
+import { getHubAlertsHref, getHubHeadlineHref, getHubStargazerHref } from '@/lib/home/hub-links';
+
+export interface HomeHubProps {
+  userLocation?: HubUserLocation | null;
+  className?: string;
+}
+
+function stargazerAccent(score: number | null): string {
+  if (score == null) return '#64748b';
+  if (score >= 80) return '#34d399';
+  if (score >= 60) return '#4ade80';
+  if (score >= 40) return '#facc15';
+  if (score >= 20) return '#fb923c';
+  return '#f87171';
+}
+
+export default function HomeHub({ userLocation, className }: HomeHubProps) {
+  const { theme } = useTheme();
+  const themeClasses = getComponentStyles((theme || 'nord') as ThemeType, 'weather');
+  const data = useHomeHubData(userLocation);
+
+  if (!userLocation) return null;
+
+  const showAlerts = shouldShowHubAlerts(data.alerts);
+  const showSpc = shouldShowSpcOutlook(data.spc.riskCode, data.spc.loading, data.spc.inRegion);
+  const showHeadline = shouldShowHubHeadline(data.headline);
+  const showStargazer = shouldShowStargazerCard(data.stargazer);
+  const hasVisibleCard = showAlerts || showSpc || showHeadline || showStargazer;
+
+  if (data.loading && !hasVisibleCard) {
+    return (
+      <section
+        data-testid="home-hub"
+        aria-label="Alerts for your area"
+        className={cn('mt-4 mb-4', className)}
+      >
+        <div className="mb-2">
+          <h2 className={cn('text-sm font-bold font-mono', themeClasses.headerText)}>
+            FOR YOUR AREA
+          </h2>
+        </div>
+        <div className="flex gap-2 overflow-x-auto pb-0.5">
+          <div className="h-16 min-w-[140px] animate-pulse rounded-md bg-gray-800/40" aria-hidden />
+          <div className="h-16 min-w-[140px] animate-pulse rounded-md bg-gray-800/40" aria-hidden />
+        </div>
+      </section>
+    );
+  }
+
+  if (!data.loading && !hasVisibleCard) {
+    return null;
+  }
+
+  const headlineCategory = data.headline.category
+    ? getCategoryConfig(data.headline.category)
+    : null;
+
+  const alertsAccent =
+    data.alerts.severity != null
+      ? (SEVERITY_ACCENT[data.alerts.severity] ?? '#64748b')
+      : '#64748b';
+
+  return (
+    <section
+      data-testid="home-hub"
+      aria-label="Alerts for your area"
+      className={cn('mt-4 mb-4', className)}
+    >
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <h2
+          className={cn(
+            'text-sm font-bold font-mono flex items-center gap-1.5',
+            themeClasses.headerText,
+          )}
+        >
+          <span
+            className="inline-block h-2 w-2 rounded-full bg-red-500 animate-pulse news-live-dot"
+            aria-hidden
+          />
+          FOR YOUR AREA
+        </h2>
+        {data.headline.lastUpdatedLabel ? (
+          <p className={cn('text-[10px] font-mono opacity-60', themeClasses.text)}>
+            {data.headline.lastUpdatedLabel}
+          </p>
+        ) : null}
+      </div>
+
+      <div className="flex gap-2 overflow-x-auto pb-0.5 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+        {showAlerts ? (
+          <HomeHubCard
+            title="Alerts near you"
+            value={getAlertsCardValue(data.alerts)}
+            detail={truncateAlertDetail(data.alerts.headline)}
+            href={getHubAlertsHref(data.alerts.topAlertId)}
+            accentColor={alertsAccent}
+          />
+        ) : null}
+
+        {showSpc ? (
+          <HomeHubCard
+            title="Storms near you"
+            value={`${data.spc.label ?? 'Elevated'} risk today`}
+            detail="Severe weather outlook"
+            href="/severe"
+            accentColor={data.spc.fill}
+          />
+        ) : null}
+
+        {showHeadline ? (
+          <HomeHubCard
+            title={headlineCategory ? headlineCategory.label : 'Breaking'}
+            value={getHeadlineCardValue(data.headline)}
+            href={getHubHeadlineHref(data.headline)}
+            accentColor="var(--primary)"
+          />
+        ) : null}
+
+        {showStargazer ? (
+          <HomeHubCard
+            title="Tonight's sky"
+            value={getStargazerCardValue(data.stargazer)}
+            detail={stargazerCardDetail(data.stargazer)}
+            href={getHubStargazerHref(userLocation)}
+            accentColor={stargazerAccent(data.stargazer.score)}
+            loading={data.stargazer.loading}
+          />
+        ) : null}
+      </div>
+    </section>
+  );
+}
+
+function truncateAlertDetail(headline: string): string {
+  if (headline.length <= 40) return headline;
+  return `${headline.slice(0, 40).trim()}…`;
+}

--- a/components/warnings/spc-day1-strip.tsx
+++ b/components/warnings/spc-day1-strip.tsx
@@ -1,56 +1,10 @@
 'use client'
 
-import React, { useEffect, useState, useCallback } from 'react'
 import { cn } from '@/lib/utils'
-import {
-  RISK_LABELS,
-  RISK_ORDER,
-  OUTLOOK_TYPE_LABELS,
-  type SPCOutlookGeoJSON,
-} from '@/lib/services/spc-outlook-service'
-
-type OutlookApi = SPCOutlookGeoJSON & { noRiskLabel?: string | null }
+import { useSPCDay1Summary } from '@/hooks/use-spc-day1-summary'
 
 export default function SPCDay1RiskStrip() {
-  const [label, setLabel] = useState<string | null>(null)
-  const [fill, setFill] = useState<string>('#64748b')
-  const [issue, setIssue] = useState<string | null>(null)
-  const [loading, setLoading] = useState(true)
-
-  const load = useCallback(async () => {
-    setLoading(true)
-    try {
-      const res = await fetch('/api/weather/spc-outlook?day=1&type=cat')
-      if (!res.ok) throw new Error('outlook')
-      const data = (await res.json()) as OutlookApi
-      const risks = (data.features ?? [])
-        .map((f) => f.properties)
-        .filter((p) => p.LABEL in RISK_ORDER)
-        .sort((a, b) => RISK_ORDER[a.LABEL] - RISK_ORDER[b.LABEL])
-      const highest = risks.at(-1)
-      if (highest) {
-        setLabel(RISK_LABELS[highest.LABEL] ?? highest.LABEL2 ?? highest.LABEL)
-        setFill((highest.fill as string) || '#f97316')
-        setIssue((highest.ISSUE as string) || (highest.VALID as string) || null)
-      } else {
-        setLabel(data.noRiskLabel ?? `No ${OUTLOOK_TYPE_LABELS.cat} risk in current outlook`)
-        setFill('#22c55e')
-        setIssue(null)
-      }
-    } catch {
-      setLabel('SPC outlook unavailable')
-      setFill('#64748b')
-      setIssue(null)
-    } finally {
-      setLoading(false)
-    }
-  }, [])
-
-  useEffect(() => {
-    load()
-    const t = setInterval(load, 10 * 60 * 1000)
-    return () => clearInterval(t)
-  }, [load])
+  const { label, fill, issue, loading } = useSPCDay1Summary()
 
   return (
     <div

--- a/hooks/use-home-hub-data.ts
+++ b/hooks/use-home-hub-data.ts
@@ -1,0 +1,293 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import type { NWSAlertDetail } from '@/lib/services/nws-alerts-service';
+import type { RSSItem } from '@/lib/services/rss/rssAggregator';
+import type { StargazerScore } from '@/lib/stargazer/types';
+import {
+  formatUpdatedAgo,
+  pickHappeningNowHeadline,
+  summarizeAlerts,
+  truncateText,
+  type HubUserLocation,
+} from '@/lib/home/hub-utils';
+import { isSpcOutlookRegion } from '@/lib/home/hub-location';
+
+export interface HomeHubCoordinates {
+  lat: number;
+  lon: number;
+}
+
+export interface LocalSpcOutlook {
+  label: string | null;
+  fill: string;
+  riskCode: string | null;
+  loading: boolean;
+  inRegion: boolean;
+}
+
+export interface HomeHubData {
+  spc: LocalSpcOutlook;
+  alerts: {
+    loading: boolean;
+    count: number | null;
+    headline: string;
+    severity: NWSAlertDetail['severity'] | null;
+    topAlertId: string | null;
+    needsLocation: boolean;
+  };
+  stargazer: {
+    loading: boolean;
+    score: number | null;
+    label: string | null;
+    summary: string | null;
+    needsLocation: boolean;
+  };
+  headline: {
+    loading: boolean;
+    title: string | null;
+    category: RSSItem['category'] | null;
+    description: string | null;
+    priority: RSSItem['priority'] | null;
+    url: string | null;
+    id: string | null;
+    lastUpdated: Date | null;
+    lastUpdatedLabel: string | null;
+  };
+  loading: boolean;
+}
+
+const SEVERITY_ACCENT: Record<string, string> = {
+  Extreme: '#ef4444',
+  Severe: '#f97316',
+  Moderate: '#eab308',
+  Minor: '#3b82f6',
+};
+
+function hydrateNewsItems(items: RSSItem[]): RSSItem[] {
+  return items.map((item) => ({
+    ...item,
+    timestamp: new Date(item.timestamp),
+  }));
+}
+
+export function useHomeHubData(userLocation?: HubUserLocation | null): HomeHubData {
+  const [alertsLoading, setAlertsLoading] = useState(false);
+  const [alertSummary, setAlertSummary] = useState<ReturnType<typeof summarizeAlerts>>({
+    count: 0,
+    headline: 'No active alerts nearby',
+    severity: null,
+    topAlertId: null,
+  });
+
+  const [spcLoading, setSpcLoading] = useState(false);
+  const [localSpc, setLocalSpc] = useState<Omit<LocalSpcOutlook, 'loading' | 'inRegion'>>({
+    label: null,
+    fill: '#64748b',
+    riskCode: null,
+  });
+
+  const [stargazerLoading, setStargazerLoading] = useState(false);
+  const [stargazerScore, setStargazerScore] = useState<StargazerScore | null>(null);
+
+  const [headlineLoading, setHeadlineLoading] = useState(false);
+  const [headlineItem, setHeadlineItem] = useState<RSSItem | null>(null);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+
+  const loadLocationData = useCallback(
+    async (user: HubUserLocation, signal?: AbortSignal) => {
+      setAlertsLoading(true);
+      setStargazerLoading(true);
+      setHeadlineLoading(true);
+      if (isSpcOutlookRegion(user)) setSpcLoading(true);
+
+      const point = `${user.lat},${user.lon}`;
+      const requests: Promise<void>[] = [];
+
+      requests.push(
+        fetch(`/api/weather/alerts?detail=1&point=${encodeURIComponent(point)}`, { signal })
+          .then(async (alertsRes) => {
+            if (signal?.aborted) return;
+            try {
+              if (alertsRes.ok) {
+                const data = (await alertsRes.json()) as { alerts?: NWSAlertDetail[] };
+                setAlertSummary(summarizeAlerts(data.alerts ?? []));
+              } else {
+                setAlertSummary({ count: 0, headline: 'Alerts unavailable', severity: null, topAlertId: null });
+              }
+            } catch {
+              setAlertSummary({ count: 0, headline: 'Alerts unavailable', severity: null, topAlertId: null });
+            } finally {
+              if (!signal?.aborted) setAlertsLoading(false);
+            }
+          }),
+      );
+
+      requests.push(
+        fetch(`/api/stargazer?lat=${user.lat}&lon=${user.lon}`, { signal })
+          .then(async (stargazerRes) => {
+            if (signal?.aborted) return;
+            try {
+              if (stargazerRes.ok) {
+                const data = (await stargazerRes.json()) as { score?: StargazerScore };
+                setStargazerScore(data.score ?? null);
+              } else {
+                setStargazerScore(null);
+              }
+            } catch {
+              setStargazerScore(null);
+            } finally {
+              if (!signal?.aborted) setStargazerLoading(false);
+            }
+          }),
+      );
+
+      requests.push(
+        fetch('/api/news/rss?maxItems=30&maxAge=72', { signal })
+          .then(async (newsRes) => {
+            if (signal?.aborted) return;
+            try {
+              if (!newsRes.ok) throw new Error('news');
+              const data = await newsRes.json();
+              const happeningNow = Array.isArray(data.happeningNow)
+                ? hydrateNewsItems(data.happeningNow)
+                : [];
+              setHeadlineItem(pickHappeningNowHeadline(happeningNow, user));
+              setLastUpdated(data.lastUpdated ? new Date(data.lastUpdated) : new Date());
+            } catch {
+              setHeadlineItem(null);
+              setLastUpdated(null);
+            } finally {
+              if (!signal?.aborted) setHeadlineLoading(false);
+            }
+          }),
+      );
+
+      if (isSpcOutlookRegion(user)) {
+        requests.push(
+          fetch(
+            `/api/weather/spc-outlook?day=1&type=cat&point=${encodeURIComponent(point)}`,
+            { signal },
+          ).then(async (spcRes) => {
+            if (signal?.aborted) return;
+            try {
+              if (spcRes.ok) {
+                const data = (await spcRes.json()) as {
+                  pointRisk?: { riskCode: string; label: string; fill: string } | null;
+                };
+                const risk = data.pointRisk ?? null;
+                setLocalSpc({
+                  label: risk?.label ?? null,
+                  fill: risk?.fill ?? '#64748b',
+                  riskCode: risk?.riskCode ?? null,
+                });
+              } else {
+                setLocalSpc({ label: null, fill: '#64748b', riskCode: null });
+              }
+            } catch {
+              setLocalSpc({ label: null, fill: '#64748b', riskCode: null });
+            } finally {
+              if (!signal?.aborted) setSpcLoading(false);
+            }
+          }),
+        );
+      } else {
+        setLocalSpc({ label: null, fill: '#64748b', riskCode: null });
+        setSpcLoading(false);
+      }
+
+      await Promise.all(requests);
+    },
+    [],
+  );
+
+  useEffect(() => {
+    if (!userLocation) {
+      setAlertSummary({
+        count: 0,
+        headline: 'Press START or search for local alerts',
+        severity: null,
+        topAlertId: null,
+      });
+      setStargazerScore(null);
+      setHeadlineItem(null);
+      setLastUpdated(null);
+      setLocalSpc({ label: null, fill: '#64748b', riskCode: null });
+      setAlertsLoading(false);
+      setStargazerLoading(false);
+      setHeadlineLoading(false);
+      setSpcLoading(false);
+      return;
+    }
+
+    const controller = new AbortController();
+    void loadLocationData(userLocation, controller.signal);
+    const timer = setInterval(
+      () => void loadLocationData(userLocation, controller.signal),
+      10 * 60 * 1000,
+    );
+    return () => {
+      controller.abort();
+      clearInterval(timer);
+    };
+  }, [userLocation?.lat, userLocation?.lon, userLocation?.locationLabel, loadLocationData]);
+
+  const needsLocation = !userLocation;
+  const inRegion = userLocation ? isSpcOutlookRegion(userLocation) : false;
+  const loading =
+    !needsLocation &&
+    (alertsLoading || stargazerLoading || headlineLoading || (inRegion && spcLoading));
+
+  return {
+    loading,
+    spc: {
+      ...localSpc,
+      loading: inRegion && spcLoading,
+      inRegion,
+    },
+    alerts: {
+      loading: alertsLoading,
+      count: needsLocation ? null : alertSummary.count,
+      headline: alertSummary.headline,
+      severity: alertSummary.severity,
+      topAlertId: needsLocation ? null : alertSummary.topAlertId,
+      needsLocation,
+    },
+    stargazer: {
+      loading: stargazerLoading,
+      score: stargazerScore?.overall ?? null,
+      label: stargazerScore?.label ?? null,
+      summary: stargazerScore?.summary ?? null,
+      needsLocation,
+    },
+    headline: {
+      loading: headlineLoading,
+      title: headlineItem?.title ?? null,
+      category: headlineItem?.category ?? null,
+      description: headlineItem?.description ?? null,
+      priority: headlineItem?.priority ?? null,
+      url: headlineItem?.url ?? null,
+      id: headlineItem?.id ?? null,
+      lastUpdated,
+      lastUpdatedLabel: lastUpdated ? formatUpdatedAgo(lastUpdated) : null,
+    },
+  };
+}
+
+export function getAlertsCardValue(data: HomeHubData['alerts']): string {
+  if (data.count === 0) return 'All clear';
+  return `${data.count} near you`;
+}
+
+export function getStargazerCardValue(data: HomeHubData['stargazer']): string {
+  if (data.score == null) return 'Unavailable';
+  return `${Math.round(data.score)} · ${data.label ?? 'Tonight'}`;
+}
+
+export function getHeadlineCardValue(data: HomeHubData['headline']): string {
+  if (!data.title) return '';
+  return truncateText(data.title, 48);
+}
+
+export { SEVERITY_ACCENT, truncateText };
+export type { HubUserLocation } from '@/lib/home/hub-utils';

--- a/hooks/use-hub-location.ts
+++ b/hooks/use-hub-location.ts
@@ -1,0 +1,70 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import type { WeatherData } from '@/lib/types';
+import type { HubUserLocation } from '@/lib/home/hub-utils';
+
+const geocodeCache = new Map<string, { lat: number; lon: number }>();
+
+async function geocodeLabel(label: string): Promise<{ lat: number; lon: number } | null> {
+  const key = label.toLowerCase().trim();
+  const cached = geocodeCache.get(key);
+  if (cached) return cached;
+
+  try {
+    const res = await fetch(`/api/weather/geocoding?q=${encodeURIComponent(label)}&limit=1`);
+    if (!res.ok) return null;
+    const data = (await res.json()) as Array<{ lat?: number; lon?: number }> | { lat?: number; lon?: number };
+    const first = Array.isArray(data) ? data[0] : data;
+    if (first?.lat == null || first?.lon == null) return null;
+    const coords = { lat: first.lat, lon: first.lon };
+    geocodeCache.set(key, coords);
+    return coords;
+  } catch {
+    return null;
+  }
+}
+
+/** Resolve lat/lon for the home hub even when weather cache stripped coordinates. */
+export function useHubLocation(weather: WeatherData | null): HubUserLocation | null {
+  const [resolved, setResolved] = useState<HubUserLocation | null>(null);
+
+  useEffect(() => {
+    if (!weather?.location) {
+      setResolved(null);
+      return;
+    }
+
+    const lat = weather.coordinates?.lat;
+    const lon = weather.coordinates?.lon;
+    if (lat != null && lon != null) {
+      setResolved({
+        lat,
+        lon,
+        locationLabel: weather.location,
+        country: weather.country ?? '',
+      });
+      return;
+    }
+
+    let cancelled = false;
+    void geocodeLabel(weather.location).then((coords) => {
+      if (cancelled || !coords) {
+        if (!cancelled) setResolved(null);
+        return;
+      }
+      setResolved({
+        lat: coords.lat,
+        lon: coords.lon,
+        locationLabel: weather.location,
+        country: weather.country ?? '',
+      });
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [weather?.location, weather?.country, weather?.coordinates?.lat, weather?.coordinates?.lon]);
+
+  return resolved;
+}

--- a/hooks/use-spc-day1-summary.ts
+++ b/hooks/use-spc-day1-summary.ts
@@ -1,0 +1,68 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import {
+  OUTLOOK_TYPE_LABELS,
+  RISK_LABELS,
+  RISK_ORDER,
+  type SPCOutlookGeoJSON,
+} from '@/lib/services/spc-outlook-service';
+
+type OutlookApi = SPCOutlookGeoJSON & { noRiskLabel?: string | null };
+
+export interface SPCDay1Summary {
+  label: string | null;
+  fill: string;
+  issue: string | null;
+  riskCode: string | null;
+  loading: boolean;
+  refresh: () => Promise<void>;
+}
+
+export function useSPCDay1Summary(): SPCDay1Summary {
+  const [label, setLabel] = useState<string | null>(null);
+  const [fill, setFill] = useState('#64748b');
+  const [issue, setIssue] = useState<string | null>(null);
+  const [riskCode, setRiskCode] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch('/api/weather/spc-outlook?day=1&type=cat');
+      if (!res.ok) throw new Error('outlook');
+      const data = (await res.json()) as OutlookApi;
+      const risks = (data.features ?? [])
+        .map((f) => f.properties)
+        .filter((p) => p.LABEL in RISK_ORDER)
+        .sort((a, b) => RISK_ORDER[a.LABEL] - RISK_ORDER[b.LABEL]);
+      const highest = risks.at(-1);
+      if (highest) {
+        setRiskCode(highest.LABEL);
+        setLabel(RISK_LABELS[highest.LABEL] ?? highest.LABEL2 ?? highest.LABEL);
+        setFill((highest.fill as string) || '#f97316');
+        setIssue((highest.ISSUE as string) || (highest.VALID as string) || null);
+      } else {
+        setRiskCode(null);
+        setLabel(data.noRiskLabel ?? `No ${OUTLOOK_TYPE_LABELS.cat} risk in current outlook`);
+        setFill('#22c55e');
+        setIssue(null);
+      }
+    } catch {
+      setRiskCode(null);
+      setLabel('SPC outlook unavailable');
+      setFill('#64748b');
+      setIssue(null);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+    const timer = setInterval(() => void refresh(), 10 * 60 * 1000);
+    return () => clearInterval(timer);
+  }, [refresh]);
+
+  return { label, fill, issue, riskCode, loading, refresh };
+}

--- a/hooks/useWeatherController.ts
+++ b/hooks/useWeatherController.ts
@@ -69,8 +69,27 @@ export function useWeatherController() {
             const locationKey = `${userCacheService.getLocationKey(location)}_${unitSystemForKey}`
             const cachedWeather = userCacheService.getCachedWeatherData(locationKey)
 
+            const hasCoords =
+                typeof location.latitude === 'number' &&
+                Number.isFinite(location.latitude) &&
+                typeof location.longitude === 'number' &&
+                Number.isFinite(location.longitude)
+
             if (cachedWeather?.forecast && cachedWeather.forecast.length > 0) {
-                setWeather(cachedWeather)
+                const cachedHasCoords =
+                    cachedWeather.coordinates?.lat != null &&
+                    cachedWeather.coordinates?.lon != null
+                const weatherWithCoords =
+                    cachedHasCoords || !hasCoords
+                        ? cachedWeather
+                        : {
+                              ...cachedWeather,
+                              coordinates: {
+                                  lat: location.latitude,
+                                  lon: location.longitude,
+                              },
+                          }
+                setWeather(weatherWithCoords)
                 setLocationInput(location.displayName)
                 setCurrentLocation(location.displayName)
                 setHasSearched(true)
@@ -83,12 +102,6 @@ export function useWeatherController() {
 
             // Guard: some call sites can pass a "location" without coordinates
             // (e.g. privacy-stripped cached lastLocation). Avoid "undefined,undefined".
-            const hasCoords =
-                typeof (location as any).latitude === 'number' &&
-                Number.isFinite((location as any).latitude) &&
-                typeof (location as any).longitude === 'number' &&
-                Number.isFinite((location as any).longitude)
-
             if (!hasCoords) {
                 const fallbackQuery = location.displayName?.trim()
                 if (!fallbackQuery) {

--- a/lib/city-slug.ts
+++ b/lib/city-slug.ts
@@ -1,3 +1,5 @@
+import { US_STATE_CODES } from '@/lib/home/hub-location';
+
 /** Normalize "San Ramon, CA" → "san-ramon-ca" for /weather/[city] routes. */
 export function locationInputToSlug(input: string): string {
   return input
@@ -20,10 +22,12 @@ export function slugToDisplayName(slug: string): string {
 export function slugToSearchTerm(slug: string): string {
   const parts = slug.split('-')
   if (parts.length > 1) {
-    const state = parts[parts.length - 1].toUpperCase()
-    const cityParts = parts.slice(0, -1)
-    const cityName = cityParts.map((word) => word.charAt(0).toUpperCase() + word.slice(1)).join(' ')
-    return `${cityName}, ${state}`
+    const maybeState = parts[parts.length - 1].toUpperCase()
+    if (maybeState.length === 2 && US_STATE_CODES.has(maybeState)) {
+      const cityParts = parts.slice(0, -1)
+      const cityName = cityParts.map((word) => word.charAt(0).toUpperCase() + word.slice(1)).join(' ')
+      return `${cityName}, ${maybeState}`
+    }
   }
   return slugToDisplayName(slug)
 }

--- a/lib/city-slug.ts
+++ b/lib/city-slug.ts
@@ -1,0 +1,29 @@
+/** Normalize "San Ramon, CA" → "san-ramon-ca" for /weather/[city] routes. */
+export function locationInputToSlug(input: string): string {
+  return input
+    .trim()
+    .toLowerCase()
+    .replace(/,/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/[^a-z0-9-]/g, '')
+}
+
+/** Best-effort display name from a slug when the city is not in our catalog. */
+export function slugToDisplayName(slug: string): string {
+  return slug
+    .split('-')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ')
+}
+
+/** Best-effort Open-Meteo search string from a slug. */
+export function slugToSearchTerm(slug: string): string {
+  const parts = slug.split('-')
+  if (parts.length > 1) {
+    const state = parts[parts.length - 1].toUpperCase()
+    const cityParts = parts.slice(0, -1)
+    const cityName = cityParts.map((word) => word.charAt(0).toUpperCase() + word.slice(1)).join(' ')
+    return `${cityName}, ${state}`
+  }
+  return slugToDisplayName(slug)
+}

--- a/lib/geo/point-in-polygon.ts
+++ b/lib/geo/point-in-polygon.ts
@@ -1,0 +1,56 @@
+/** GeoJSON positions are [longitude, latitude]. */
+export type LonLat = [number, number];
+
+function pointInRing(point: LonLat, ring: LonLat[]): boolean {
+  const [x, y] = point;
+  let inside = false;
+
+  for (let i = 0, j = ring.length - 1; i < ring.length; j = i++) {
+    const [xi, yi] = ring[i];
+    const [xj, yj] = ring[j];
+    const intersects = yi > y !== yj > y && x < ((xj - xi) * (y - yi)) / (yj - yi) + xi;
+    if (intersects) inside = !inside;
+  }
+
+  return inside;
+}
+
+function ringFromGeoJson(raw: number[][]): LonLat[] {
+  return raw.map(([lon, lat]) => [lon, lat] as LonLat);
+}
+
+function pointInPolygonCoords(point: LonLat, polygon: number[][][]): boolean {
+  if (polygon.length === 0) return false;
+  const outer = ringFromGeoJson(polygon[0]);
+  if (!pointInRing(point, outer)) return false;
+  for (let holeIndex = 1; holeIndex < polygon.length; holeIndex++) {
+    if (pointInRing(point, ringFromGeoJson(polygon[holeIndex]))) return false;
+  }
+  return true;
+}
+
+export function pointInGeoJsonGeometry(
+  point: LonLat,
+  geometry: {
+    type: string;
+    coordinates?: unknown;
+    geometries?: Array<{ type: string; coordinates?: unknown }>;
+  },
+): boolean {
+  if (geometry.type === 'Polygon') {
+    return pointInPolygonCoords(point, geometry.coordinates as number[][][]);
+  }
+  if (geometry.type === 'MultiPolygon') {
+    const polys = geometry.coordinates as number[][][][];
+    return polys.some((poly) => pointInPolygonCoords(point, poly));
+  }
+  if (geometry.type === 'GeometryCollection' && geometry.geometries) {
+    return geometry.geometries.some((g) => pointInGeoJsonGeometry(point, g));
+  }
+  return false;
+}
+
+/** Rough CONUS bounds — SPC day-1 outlook applies here. */
+export function isInConus(lat: number, lon: number): boolean {
+  return lat >= 24 && lat <= 50 && lon >= -125 && lon <= -66;
+}

--- a/lib/geo/spc-point-risk.ts
+++ b/lib/geo/spc-point-risk.ts
@@ -1,0 +1,40 @@
+import { pointInGeoJsonGeometry } from '@/lib/geo/point-in-polygon';
+import {
+  RISK_LABELS,
+  RISK_ORDER,
+  type SPCOutlookGeoJSON,
+} from '@/lib/services/spc-outlook-service';
+
+export interface PointSpcRisk {
+  riskCode: string;
+  label: string;
+  fill: string;
+}
+
+export function getHighestSpcRiskAtPoint(
+  geojson: SPCOutlookGeoJSON,
+  lat: number,
+  lon: number,
+): PointSpcRisk | null {
+  const point: [number, number] = [lon, lat];
+  let best: (PointSpcRisk & { order: number }) | null = null;
+
+  for (const feature of geojson.features) {
+    const code = feature.properties.LABEL;
+    if (!(code in RISK_ORDER)) continue;
+    if (!pointInGeoJsonGeometry(point, feature.geometry as Parameters<typeof pointInGeoJsonGeometry>[1])) continue;
+
+    const order = RISK_ORDER[code];
+    if (best && order <= best.order) continue;
+
+    best = {
+      riskCode: code,
+      label: RISK_LABELS[code] ?? feature.properties.LABEL2 ?? code,
+      fill: (feature.properties.fill as string) || '#f97316',
+      order,
+    };
+  }
+
+  if (!best) return null;
+  return { riskCode: best.riskCode, label: best.label, fill: best.fill };
+}

--- a/lib/home/hub-links.ts
+++ b/lib/home/hub-links.ts
@@ -1,0 +1,56 @@
+import { safeExternalUrl } from '@/lib/safe-url';
+import type { FeedCategory } from '@/lib/services/rss/feedSources';
+import type { HubUserLocation } from '@/lib/home/hub-utils';
+
+export function getHubStargazerHref(location: HubUserLocation | null | undefined): string {
+  if (!location) return '/stargazer';
+  const params = new URLSearchParams({
+    lat: String(location.lat),
+    lon: String(location.lon),
+  });
+  const label = location.locationLabel?.trim();
+  if (label) params.set('q', label);
+  return `/stargazer?${params.toString()}`;
+}
+
+export function getHubAlertsHref(topAlertId: string | null | undefined): string {
+  if (!topAlertId) return '/warnings';
+  return `/warnings?alert=${encodeURIComponent(topAlertId)}`;
+}
+
+export function getHubHeadlineHref(headline: {
+  url: string | null | undefined;
+  category: FeedCategory | null | undefined;
+}): string {
+  const safe = headline.url ? safeExternalUrl(headline.url) : null;
+  if (safe) return safe;
+  if (headline.category === 'severe') return '/warnings';
+  return '/news';
+}
+
+export function isExternalHubHref(href: string): boolean {
+  return href.startsWith('http://') || href.startsWith('https://');
+}
+
+/** Match an NWS alert id from a warnings URL query param. */
+export function findAlertByQueryParam(
+  alerts: Array<{ id: string }>,
+  alertParam: string | null | undefined,
+): string | null {
+  if (!alertParam || alerts.length === 0) return null;
+  const decoded = (() => {
+    try {
+      return decodeURIComponent(alertParam);
+    } catch {
+      return alertParam;
+    }
+  })();
+
+  const exact = alerts.find((a) => a.id === decoded || a.id === alertParam);
+  if (exact) return exact.id;
+
+  const suffix = alerts.find(
+    (a) => a.id.endsWith(decoded) || decoded.endsWith(a.id) || a.id.includes(decoded),
+  );
+  return suffix?.id ?? null;
+}

--- a/lib/home/hub-location.ts
+++ b/lib/home/hub-location.ts
@@ -1,0 +1,124 @@
+import type { RSSItem } from '@/lib/services/rss/rssAggregator';
+import { isActiveTropicalHeadline, isDiscoveryHeadline } from '@/lib/news/tropical-headlines';
+import { isInConus } from '@/lib/geo/point-in-polygon';
+
+export interface HubUserLocation {
+  lat: number;
+  lon: number;
+  locationLabel: string;
+  country: string;
+}
+
+const US_STATE_CODES = new Set([
+  'AL', 'AK', 'AZ', 'AR', 'CA', 'CO', 'CT', 'DE', 'FL', 'GA',
+  'HI', 'ID', 'IL', 'IN', 'IA', 'KS', 'KY', 'LA', 'ME', 'MD',
+  'MA', 'MI', 'MN', 'MS', 'MO', 'MT', 'NE', 'NV', 'NH', 'NJ',
+  'NM', 'NY', 'NC', 'ND', 'OH', 'OK', 'OR', 'PA', 'RI', 'SC',
+  'SD', 'TN', 'TX', 'UT', 'VT', 'VA', 'WA', 'WV', 'WI', 'WY',
+  'DC', 'PR', 'VI', 'GU', 'AS', 'MP',
+]);
+
+export function parseUsStateCode(locationLabel: string): string | null {
+  const match = locationLabel.match(/,\s*([A-Z]{2})\b/);
+  const code = match?.[1];
+  return code && US_STATE_CODES.has(code) ? code : null;
+}
+
+export function parseCityName(locationLabel: string): string | null {
+  const city = locationLabel.split(',')[0]?.trim();
+  return city && city.length > 2 ? city : null;
+}
+
+function haystack(item: Pick<RSSItem, 'title' | 'description' | 'location'>): string {
+  return `${item.title} ${item.description ?? ''} ${item.location ?? ''}`.toLowerCase();
+}
+
+export function isGeographicallyRelatedToUser(
+  text: string,
+  user: HubUserLocation,
+): boolean {
+  const state = parseUsStateCode(user.locationLabel);
+  if (state) {
+    const stateRe = new RegExp(`\\b${state}\\b`, 'i');
+    if (stateRe.test(text)) return true;
+  }
+
+  const city = parseCityName(user.locationLabel);
+  if (city && city.length > 3) {
+    const cityRe = new RegExp(`\\b${escapeRegExp(city)}\\b`, 'i');
+    if (cityRe.test(text)) return true;
+  }
+
+  const country = user.country.trim().toLowerCase();
+  if (country === 'us' || country === 'usa' || country === 'united states') {
+    if (/\b(united states|u\.s\.|usa)\b/i.test(text)) return true;
+  } else if (country.length >= 4) {
+    const countryRe = new RegExp(`\\b${escapeRegExp(country)}\\b`, 'i');
+    if (countryRe.test(text)) return true;
+  }
+
+  return false;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export function isHeadlineRelevantToUser(item: RSSItem, user: HubUserLocation): boolean {
+  if (!isDiscoveryHeadline(item)) return false;
+
+  const text = haystack(item);
+
+  switch (item.category) {
+    case 'earthquakes': {
+      const magnitude = item.magnitude ?? 0;
+      if (magnitude >= 6) return true;
+      if (magnitude >= 5) return isGeographicallyRelatedToUser(text, user);
+      return false;
+    }
+    case 'severe':
+      return isGeographicallyRelatedToUser(text, user);
+    case 'hurricanes':
+      return (
+        isActiveTropicalHeadline(item) && isGeographicallyRelatedToUser(text, user)
+      );
+    case 'volcanoes':
+      return item.priority === 'high' && isGeographicallyRelatedToUser(text, user);
+    case 'space':
+      return item.priority === 'high';
+    default:
+      return false;
+  }
+}
+
+export function pickHeadlineForUser(
+  happeningNow: RSSItem[],
+  user: HubUserLocation,
+): RSSItem | null {
+  return happeningNow.find((item) => isHeadlineRelevantToUser(item, user)) ?? null;
+}
+
+/** Stargazer chip: show whenever we have a score for the user's area. */
+export function shouldShowStargazerCard(stargazer: {
+  score: number | null;
+  needsLocation: boolean;
+  loading: boolean;
+}): boolean {
+  if (stargazer.needsLocation || stargazer.loading || stargazer.score == null) return false;
+  return true;
+}
+
+export function isSpcOutlookRegion(user: HubUserLocation): boolean {
+  return isInConus(user.lat, user.lon);
+}
+
+export function stargazerCardDetail(stargazer: {
+  score: number | null;
+  label: string | null;
+  summary: string | null;
+}): string | undefined {
+  if (stargazer.score == null) return undefined;
+  if (stargazer.score >= 65) return stargazer.label ?? 'Good viewing tonight';
+  if (stargazer.score <= 35) return stargazer.summary ?? stargazer.label ?? 'Poor tonight';
+  return stargazer.summary ?? stargazer.label ?? 'Fair conditions tonight';
+}

--- a/lib/home/hub-location.ts
+++ b/lib/home/hub-location.ts
@@ -9,7 +9,7 @@ export interface HubUserLocation {
   country: string;
 }
 
-const US_STATE_CODES = new Set([
+export const US_STATE_CODES = new Set([
   'AL', 'AK', 'AZ', 'AR', 'CA', 'CO', 'CT', 'DE', 'FL', 'GA',
   'HI', 'ID', 'IL', 'IN', 'IA', 'KS', 'KY', 'LA', 'ME', 'MD',
   'MA', 'MI', 'MN', 'MS', 'MO', 'MT', 'NE', 'NV', 'NH', 'NJ',
@@ -17,6 +17,9 @@ const US_STATE_CODES = new Set([
   'SD', 'TN', 'TX', 'UT', 'VT', 'VA', 'WA', 'WV', 'WI', 'WY',
   'DC', 'PR', 'VI', 'GU', 'AS', 'MP',
 ]);
+
+/** State abbreviations that collide with common English words when matched with \\b. */
+const AMBIGUOUS_STATE_CODES = new Set(['OR', 'IN', 'ME', 'OK', 'HI', 'AS']);
 
 export function parseUsStateCode(locationLabel: string): string | null {
   const match = locationLabel.match(/,\s*([A-Z]{2})\b/);
@@ -39,8 +42,13 @@ export function isGeographicallyRelatedToUser(
 ): boolean {
   const state = parseUsStateCode(user.locationLabel);
   if (state) {
-    const stateRe = new RegExp(`\\b${state}\\b`, 'i');
-    if (stateRe.test(text)) return true;
+    const stateLower = state.toLowerCase();
+    const commaStateRe = new RegExp(`,\\s*${stateLower}(?:\\s|,|$)`);
+    if (commaStateRe.test(text)) return true;
+    if (!AMBIGUOUS_STATE_CODES.has(state)) {
+      const tokenStateRe = new RegExp(`(?:^|\\s)${stateLower}(?:\\s|,|$)`);
+      if (tokenStateRe.test(text)) return true;
+    }
   }
 
   const city = parseCityName(user.locationLabel);

--- a/lib/home/hub-utils.ts
+++ b/lib/home/hub-utils.ts
@@ -1,0 +1,98 @@
+import type { FeedCategory } from '@/lib/services/rss/feedSources';
+import type { NWSAlertDetail } from '@/lib/services/nws-alerts-service';
+import type { RSSItem } from '@/lib/services/rss/rssAggregator';
+import {
+  pickHeadlineForUser,
+  shouldShowStargazerCard,
+  type HubUserLocation,
+} from '@/lib/home/hub-location';
+
+const SEVERITY_ORDER: Record<string, number> = {
+  Extreme: 0,
+  Severe: 1,
+  Moderate: 2,
+  Minor: 3,
+};
+
+/** SPC categorical risk levels worth surfacing on the home hub (Slight or higher). */
+export const ELEVATED_SPC_RISK_CODES = new Set(['SLGT', 'ENH', 'MDT', 'HIGH']);
+
+export function formatUpdatedAgo(date: Date): string {
+  const diffMins = Math.floor((Date.now() - date.getTime()) / 60000);
+  if (diffMins < 1) return 'just now';
+  if (diffMins < 60) return `${diffMins}m ago`;
+  const diffHours = Math.floor(diffMins / 60);
+  if (diffHours < 24) return `${diffHours}h ago`;
+  return `${Math.floor(diffHours / 24)}d ago`;
+}
+
+export function pickHappeningNowHeadline(
+  happeningNow: RSSItem[],
+  user: HubUserLocation,
+): RSSItem | null {
+  return pickHeadlineForUser(happeningNow, user);
+}
+
+export function shouldShowHubAlerts(
+  alerts: { count: number | null; needsLocation: boolean; loading: boolean },
+): boolean {
+  if (alerts.needsLocation || alerts.loading) return false;
+  return (alerts.count ?? 0) > 0;
+}
+
+export function shouldShowSpcOutlook(
+  riskCode: string | null,
+  loading: boolean,
+  inRegion: boolean,
+): boolean {
+  if (!inRegion || loading || !riskCode) return false;
+  return ELEVATED_SPC_RISK_CODES.has(riskCode);
+}
+
+export function shouldShowHubHeadline(headline: {
+  title: string | null;
+  loading: boolean;
+}): boolean {
+  if (headline.loading || !headline.title) return false;
+  return true;
+}
+
+export { shouldShowStargazerCard };
+
+export function summarizeAlerts(alerts: NWSAlertDetail[]): {
+  count: number;
+  headline: string;
+  severity: NWSAlertDetail['severity'] | null;
+  topAlertId: string | null;
+} {
+  if (alerts.length === 0) {
+    return { count: 0, headline: 'No active alerts nearby', severity: null, topAlertId: null };
+  }
+
+  const sorted = [...alerts].sort((a, b) => {
+    const sa = SEVERITY_ORDER[a.severity] ?? 99;
+    const sb = SEVERITY_ORDER[b.severity] ?? 99;
+    return sa - sb;
+  });
+
+  const top = sorted[0];
+  const headline =
+    top.headline?.trim() ||
+    top.event?.trim() ||
+    `${alerts.length} active alert${alerts.length === 1 ? '' : 's'}`;
+
+  return {
+    count: alerts.length,
+    headline,
+    severity: top.severity,
+    topAlertId: top.id || null,
+  };
+}
+
+export function truncateText(text: string, maxLength: number): string {
+  const trimmed = text.trim();
+  if (trimmed.length <= maxLength) return trimmed;
+  return `${trimmed.slice(0, maxLength).trim()}…`;
+}
+
+export type { HubUserLocation };

--- a/lib/news/rails.ts
+++ b/lib/news/rails.ts
@@ -49,7 +49,10 @@ export function selectFeaturedItem(
   );
   if (highPriority.length > 0) return highPriority[0];
 
-  return pool[0] ?? items[0] ?? null;
+  const actionablePool = pool.filter(
+    (item) => item.category !== 'hurricanes' || isActiveTropicalHeadline(item),
+  );
+  return actionablePool[0] ?? items[0] ?? null;
 }
 
 export function excludeRailIds(items: RSSItem[], rails: RSSItem[]): RSSItem[] {

--- a/lib/news/rails.ts
+++ b/lib/news/rails.ts
@@ -1,5 +1,6 @@
 import type { FeedCategory } from '@/lib/services/rss/feedSources';
 import type { RSSItem } from '@/lib/services/rss/rssAggregator';
+import { isActiveTropicalHeadline, isDiscoveryHeadline } from '@/lib/news/tropical-headlines';
 
 export const HAPPENING_NOW_WINDOW_MS = 6 * 60 * 60 * 1000;
 export const HAPPENING_NOW_MAX = 8;
@@ -27,7 +28,8 @@ export function selectHappeningNow(items: RSSItem[], now = Date.now()): RSSItem[
       (item) =>
         item.priority === 'high' &&
         item.timestamp.getTime() > 0 &&
-        item.timestamp.getTime() >= cutoff,
+        item.timestamp.getTime() >= cutoff &&
+        isDiscoveryHeadline(item),
     )
     .slice(0, HAPPENING_NOW_MAX);
 }
@@ -42,7 +44,9 @@ export function selectFeaturedItem(
   const includeTropical = isHurricaneSeason(now);
   const pool = includeTropical ? items : items.filter((item) => item.category !== 'hurricanes');
 
-  const highPriority = pool.filter((item) => item.priority === 'high');
+  const highPriority = pool.filter(
+    (item) => item.priority === 'high' && isActiveTropicalHeadline(item),
+  );
   if (highPriority.length > 0) return highPriority[0];
 
   return pool[0] ?? items[0] ?? null;

--- a/lib/news/tropical-headlines.ts
+++ b/lib/news/tropical-headlines.ts
@@ -1,0 +1,44 @@
+import type { RSSItem } from '@/lib/services/rss/rssAggregator';
+
+/** Routine NHC posts when the basin is quiet — not actionable on discovery surfaces. */
+const TROPICAL_CALM_PATTERNS = [
+  /no tropical cyclones/i,
+  /there are no tropical/i,
+  /no (active )?(tropical cyclones|hurricanes)/i,
+  /tropical weather outlook/i,
+  /two-day graphical tropical weather outlook/i,
+  /five-day graphical tropical weather outlook/i,
+  /\bgtwo\b/i,
+];
+
+/** Active tropical hazards worth surfacing (warnings, watches, named systems). */
+const TROPICAL_ACTIVE_PATTERNS = [
+  /(hurricane|tropical storm|typhoon) (warning|watch|advisory)/i,
+  /storm surge (warning|watch)/i,
+  /potential tropical cyclone/i,
+  /(hurricane|tropical storm|typhoon) [A-Z][a-z]{2,}/i,
+  /post-tropical cyclone.*(warning|watch|advisory)/i,
+  /special (tropical|hurricane) weather outlook/i,
+  /extreme wind warning/i,
+];
+
+function tropicalText(item: Pick<RSSItem, 'title' | 'description'>): string {
+  return `${item.title} ${item.description ?? ''}`.trim();
+}
+
+/** True when a hurricanes-category item reflects an active tropical warning or named system. */
+export function isActiveTropicalHeadline(item: Pick<RSSItem, 'title' | 'description' | 'category'>): boolean {
+  if (item.category !== 'hurricanes') return true;
+
+  const text = tropicalText(item);
+  if (TROPICAL_CALM_PATTERNS.some((pattern) => pattern.test(text))) {
+    return false;
+  }
+  return TROPICAL_ACTIVE_PATTERNS.some((pattern) => pattern.test(text));
+}
+
+/** High-priority headlines suitable for home hub / happening-now discovery. */
+export function isDiscoveryHeadline(item: RSSItem): boolean {
+  if (item.priority !== 'high') return false;
+  return isActiveTropicalHeadline(item);
+}

--- a/lib/news/tropical-headlines.ts
+++ b/lib/news/tropical-headlines.ts
@@ -31,10 +31,13 @@ export function isActiveTropicalHeadline(item: Pick<RSSItem, 'title' | 'descript
   if (item.category !== 'hurricanes') return true;
 
   const text = tropicalText(item);
+  if (TROPICAL_ACTIVE_PATTERNS.some((pattern) => pattern.test(text))) {
+    return true;
+  }
   if (TROPICAL_CALM_PATTERNS.some((pattern) => pattern.test(text))) {
     return false;
   }
-  return TROPICAL_ACTIVE_PATTERNS.some((pattern) => pattern.test(text));
+  return false;
 }
 
 /** High-priority headlines suitable for home hub / happening-now discovery. */

--- a/lib/weather/precip-utils.ts
+++ b/lib/weather/precip-utils.ts
@@ -1,16 +1,19 @@
 /**
- * Precipitation severity helper for forecast cards.
+ * Precipitation severity helper for 7-day forecast tiles.
  *
- * Drives an optional left-edge accent + chip color on 7-day forecast tiles
- * so the scanline answer to "which day will it rain?" pops visually.
- * Mirrors the getAQIColor/getPollenColor shape in lib/air-quality-utils.ts.
+ * Uses a symmetric top strip + faint wash (same pattern as AQI panels on
+ * daybreak) so wet days stand out without a lopsided left border.
  */
 
 export type PrecipTier = 'none' | 'light' | 'moderate' | 'heavy'
 
 export interface PrecipSeverity {
   tier: PrecipTier
-  borderClass: string
+  /** Subtle card background wash */
+  cardClass: string
+  /** Top edge strip inside the card */
+  stripClass: string
+  /** Precip % pill */
   chipClass: string
 }
 
@@ -18,26 +21,33 @@ export function getPrecipSeverity(prob: number | null | undefined): PrecipSeveri
   const p = typeof prob === 'number' ? prob : 0
 
   if (p < 20) {
-    return { tier: 'none', borderClass: '', chipClass: 'text-sky-400/80' }
+    return {
+      tier: 'none',
+      cardClass: '',
+      stripClass: '',
+      chipClass: 'bg-muted/40 text-muted-foreground',
+    }
   }
   if (p < 40) {
     return {
       tier: 'light',
-      borderClass: 'border-l-[3px] border-l-sky-400/40',
-      chipClass: 'text-sky-300',
+      cardClass: 'bg-sky-500/[0.04] dark:bg-sky-400/[0.06]',
+      stripClass: 'h-px bg-gradient-to-r from-transparent via-sky-400/45 to-transparent',
+      chipClass: 'bg-sky-500/10 text-sky-700 dark:text-sky-300',
     }
   }
   if (p < 70) {
     return {
       tier: 'moderate',
-      borderClass: 'border-l-[3px] border-l-sky-400/70 shadow-[inset_3px_0_0_rgba(56,189,248,0.25)]',
-      chipClass: 'text-sky-200 font-semibold',
+      cardClass: 'bg-sky-500/[0.07] dark:bg-sky-400/[0.09]',
+      stripClass: 'h-0.5 bg-gradient-to-r from-sky-500/30 via-sky-400/65 to-sky-500/30',
+      chipClass: 'bg-sky-500/15 text-sky-800 dark:text-sky-200 font-medium',
     }
   }
   return {
     tier: 'heavy',
-    borderClass:
-      'border-l-[3px] border-l-sky-300 shadow-[inset_3px_0_0_rgba(125,211,252,0.45),0_0_18px_rgba(56,189,248,0.18)]',
-    chipClass: 'text-sky-100 font-bold',
+    cardClass: 'bg-sky-600/[0.10] dark:bg-sky-400/[0.12]',
+    stripClass: 'h-1 bg-gradient-to-r from-sky-600/50 via-sky-400/85 to-sky-600/50',
+    chipClass: 'bg-sky-500/20 text-sky-900 dark:text-sky-100 font-semibold',
   }
 }

--- a/lib/weather/precip-utils.ts
+++ b/lib/weather/precip-utils.ts
@@ -18,7 +18,8 @@ export interface PrecipSeverity {
 }
 
 export function getPrecipSeverity(prob: number | null | undefined): PrecipSeverity {
-  const p = typeof prob === 'number' ? prob : 0
+  const raw = typeof prob === 'number' && Number.isFinite(prob) ? prob : 0;
+  const p = Math.max(0, raw);
 
   if (p < 20) {
     return {

--- a/tests/e2e/stargazer.spec.ts
+++ b/tests/e2e/stargazer.spec.ts
@@ -37,9 +37,7 @@ test.beforeEach(async ({ page }) => {
 
 test('renders the Stargazer Command Center shell', async ({ page }) => {
   await expect(page).toHaveTitle(/Stargazer/i);
-  await expect(
-    page.getByRole('heading', { name: /STARGAZER COMMAND CENTER/i }).first()
-  ).toBeVisible({ timeout: 30000 });
+  await expect(page.getByTestId('stargazer-page-title')).toBeVisible({ timeout: 30000 });
 });
 
 test('exposes the location search form', async ({ page }) => {

--- a/tests/e2e/stargazer.spec.ts
+++ b/tests/e2e/stargazer.spec.ts
@@ -43,8 +43,15 @@ test('renders the Stargazer Command Center shell', async ({ page }) => {
 });
 
 test('exposes the location search form', async ({ page }) => {
-  // The search form renders unconditionally (above the loading/data gates),
-  // so it is a stable shell assertion independent of the forecast payload.
-  await expect(page.getByLabel(/Search location/i)).toBeVisible({ timeout: 30000 });
+  await expect(page.getByTestId('stargazer-location-search')).toBeVisible({ timeout: 30000 });
   await expect(page.getByRole('button', { name: /^Go$/i })).toBeVisible();
+});
+
+test('prefills location from hub query params', async ({ page }) => {
+  await page.goto('/stargazer?lat=33.5779&lon=-101.8552&q=Lubbock%2C%20TX', {
+    waitUntil: 'domcontentloaded',
+  });
+  await expect(page.getByTestId('stargazer-location-search')).toHaveValue('Lubbock, TX', {
+    timeout: 30000,
+  });
 });

--- a/tests/e2e/weather-app.spec.ts
+++ b/tests/e2e/weather-app.spec.ts
@@ -53,6 +53,13 @@ test('displays main weather search component', async ({ page }) => {
   await expect(page.getByTestId('location-search-input').first()).toBeVisible({ timeout: 30000 });
 });
 
+test('displays home hub discovery cards', async ({ page }) => {
+  const hub = page.getByTestId('home-hub');
+  await expect(hub).toBeVisible({ timeout: 30000 });
+  await expect(hub.getByRole('heading', { name: /FOR YOUR AREA/i })).toBeVisible();
+  await expect(hub.getByTestId('home-hub-card').first()).toBeVisible();
+});
+
 test('can search for weather by city name', async ({ page }) => {
   await expect(page.getByTestId('temperature-value')).toBeVisible({ timeout: 15000 });
 });

--- a/tests/fixtures/utils.ts
+++ b/tests/fixtures/utils.ts
@@ -805,47 +805,134 @@ export async function stubRadarApis(page: Page): Promise<void> {
     body: transparentPng,
   }));
 
-  await page.route('**/api/weather/alerts**', (route) => route.fulfill({
+  await page.route('**/api/weather/alerts**', (route) => {
+    const url = new URL(route.request().url());
+    if (url.searchParams.get('detail') === '1') {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          alerts: [{
+            id: 'alert-1',
+            event: 'Severe Thunderstorm Warning',
+            severity: 'Severe',
+            headline: 'Severe Thunderstorm Warning for test area',
+            areaDesc: 'Test County',
+            urgency: 'Immediate',
+            expires: new Date(Date.now() + 3600000).toISOString(),
+            sent: new Date().toISOString(),
+            effective: new Date().toISOString(),
+            ends: new Date(Date.now() + 3600000).toISOString(),
+            description: 'Take shelter.',
+            instruction: 'Move indoors.',
+            certainty: 'Likely',
+            response: 'Shelter',
+            sender: 'NWS',
+            geometry: null,
+          }],
+          wis: {
+            score: 45,
+            level: 'orange',
+            label: 'Elevated',
+            activeWarnings: 1,
+            activeWatches: 0,
+            activeAdvisories: 0,
+            totalAlerts: 1,
+            nwsWarnings: 1,
+            nwsWatches: 0,
+            nwsAdvisories: 0,
+          },
+          total: 1,
+        }),
+      });
+    }
+
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        type: 'FeatureCollection',
+        features: [{
+          type: 'Feature',
+          geometry: {
+            type: 'Polygon',
+            coordinates: [[[-74.2, 40.6], [-73.8, 40.6], [-73.8, 40.9], [-74.2, 40.9], [-74.2, 40.6]]],
+          },
+          properties: {
+            id: 'alert-1',
+            event: 'Severe Thunderstorm Warning',
+            severity: 'Severe',
+            headline: 'Severe Thunderstorm Warning for test area',
+            areaDesc: 'Test County',
+            instruction: 'Move indoors.',
+          },
+        }],
+      }),
+    });
+  });
+
+  await page.route('**/api/weather/spc-outlook**', (route) => {
+    const url = new URL(route.request().url());
+    const hasPoint = url.searchParams.has('point');
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        type: 'FeatureCollection',
+        features: [{
+          type: 'Feature',
+          geometry: {
+            type: 'Polygon',
+            coordinates: [[[-75, 40], [-73, 40], [-73, 42], [-75, 42], [-75, 40]]],
+          },
+          properties: {
+            LABEL: 'SLGT',
+            LABEL2: 'Slight Risk',
+            fill: '#FFE066',
+            stroke: '#facc15',
+          },
+        }],
+        pointRisk: hasPoint
+          ? { riskCode: 'SLGT', label: 'Slight', fill: '#FFE066' }
+          : null,
+      }),
+    });
+  });
+
+  await page.route(/\/api\/news\/rss/, (route) => route.fulfill({
     status: 200,
     contentType: 'application/json',
     body: JSON.stringify({
-      type: 'FeatureCollection',
-      features: [{
-        type: 'Feature',
-        geometry: {
-          type: 'Polygon',
-          coordinates: [[[-74.2, 40.6], [-73.8, 40.6], [-73.8, 40.9], [-74.2, 40.9], [-74.2, 40.6]]],
-        },
-        properties: {
-          id: 'alert-1',
-          event: 'Severe Thunderstorm Warning',
-          severity: 'Severe',
-          headline: 'Severe Thunderstorm Warning for test area',
-          areaDesc: 'Test County',
-          instruction: 'Move indoors.',
-        },
+      status: 'ok',
+      items: [],
+      happeningNow: [{
+        id: 'hub-headline-1',
+        title: 'M6.2 earthquake strikes test region',
+        description: 'Test headline for home hub',
+        url: 'https://earthquake.usgs.gov/',
+        source: 'USGS',
+        category: 'earthquakes',
+        priority: 'high',
+        timestamp: new Date().toISOString(),
       }],
+      featured: null,
+      stats: { byCategory: {}, errors: [], enabledSources: [] },
+      lastUpdated: new Date().toISOString(),
+      categories: {},
     }),
   }));
 
-  await page.route('**/api/weather/spc-outlook**', (route) => route.fulfill({
+  await page.route(/\/api\/stargazer/, (route) => route.fulfill({
     status: 200,
     contentType: 'application/json',
     body: JSON.stringify({
-      type: 'FeatureCollection',
-      features: [{
-        type: 'Feature',
-        geometry: {
-          type: 'Polygon',
-          coordinates: [[[-75, 40], [-73, 40], [-73, 42], [-75, 42], [-75, 40]]],
-        },
-        properties: {
-          LABEL: 'SLGT',
-          LABEL2: 'Slight Risk',
-          fill: '#FFE066',
-          stroke: '#facc15',
-        },
-      }],
+      score: {
+        overall: 72,
+        label: 'Good',
+        color: '#4ade80',
+        summary: 'Partly cloudy with fair seeing tonight',
+        subScores: { cloud: 70, moon: 80, seeing: 65, transparency: 75, ground: 70 },
+      },
     }),
   }));
 


### PR DESCRIPTION
## Summary
- Adds a location-aware **FOR YOUR AREA** home hub with compact cards for nearby alerts, SPC storm risk, breaking headlines, and tonight's sky (shown only when actionable).
- Unifies city forecast pages: live weather first, home search routes to `/weather/[city]`, optional collapsed climate guide for curated cities, and hub on city pages too.
- Deep-links hub cards to the right destinations: warnings alert detail, headline source URLs, and stargazer with lat/lon/city query params.
- Polishes 7-day forecast wet-day styling (symmetric top strip + wash instead of left border).

## Test plan
- [x] `npm run typecheck`
- [x] Unit tests: home-hub, hub-links, hub-location, city-slug, precip-utils, tropical-headlines, geo-spc-point, news-rails
- [x] Playwright: `tests/e2e/weather-app.spec.ts`, `tests/e2e/stargazer.spec.ts`
- [ ] Manual: search Lubbock from home, confirm hub cards and Tonight's sky carry location
- [ ] Manual: click hub alert/headline cards and confirm deep links land on correct alert/article


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Home Hub” section with discovery cards for nearby alerts, headlines, SPC outlook, and stargazer info.
  * Added a collapsible city climate guide with seasonal details, weather facts, FAQs, and nearby-city links.
  * Improved weather and warning pages with loading states, smoother navigation, and direct links to selected alerts.
  * Added point-based SPC risk lookup and richer precipitation styling on forecast cards.

* **Bug Fixes**
  * Improved city search and location handling so searches and prefilled locations work more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->