### PR TITLE
feat(seo): AI discoverability — robots, llms.txt, homepage JSON-LD

### DIFF
--- a/__tests__/robots-seo.test.ts
+++ b/__tests__/robots-seo.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Tests for robots.txt AI crawler policy (search/browse vs training bots).
+ */
+
+import fs from 'fs'
+import path from 'path'
+
+const ROBOTS_PATH = path.join(process.cwd(), 'public', 'robots.txt')
+
+function readRobots(): string {
+  return fs.readFileSync(ROBOTS_PATH, 'utf-8')
+}
+
+/** Returns rule lines for a specific User-agent block (until the next User-agent or EOF). */
+function getAgentBlock(content: string, agent: string): string {
+  const lines = content.split('\n')
+  const start = lines.findIndex((line) => line.trim() === `User-agent: ${agent}`)
+  if (start === -1) return ''
+
+  const block: string[] = []
+  for (let i = start + 1; i < lines.length; i++) {
+    const line = lines[i]
+    if (line.startsWith('User-agent:')) break
+    block.push(line)
+  }
+  return block.join('\n')
+}
+
+function blockAllowsRoot(block: string): boolean {
+  return /Allow:\s*\//.test(block)
+}
+
+function blockDisallowsAll(block: string): boolean {
+  return /Disallow:\s*\/\s*$/.test(block.trim()) || /Disallow:\s*\/\r?$/m.test(block)
+}
+
+describe('robots.txt AI crawler policy', () => {
+  let content: string
+
+  beforeAll(() => {
+    content = readRobots()
+  })
+
+  it('allows AI search and browse bots on public content', () => {
+    const searchBots = ['OAI-SearchBot', 'ChatGPT-User', 'PerplexityBot', 'ClaudeBot']
+    for (const agent of searchBots) {
+      const block = getAgentBlock(content, agent)
+      expect(block).not.toBe('')
+      expect(blockAllowsRoot(block)).toBe(true)
+      expect(blockDisallowsAll(block)).toBe(false)
+    }
+  })
+
+  it('blocks AI training crawlers site-wide', () => {
+    const trainingBots = ['GPTBot', 'CCBot', 'anthropic-ai', 'Claude-Web']
+    for (const agent of trainingBots) {
+      const block = getAgentBlock(content, agent)
+      expect(block).not.toBe('')
+      expect(blockDisallowsAll(block)).toBe(true)
+    }
+  })
+
+  it('keeps sensitive routes disallowed for AI search bots', () => {
+    const searchBots = ['OAI-SearchBot', 'ChatGPT-User', 'PerplexityBot', 'ClaudeBot']
+    const sensitivePaths = ['/api/', '/auth/', '/dashboard', '/profile']
+    for (const agent of searchBots) {
+      const block = getAgentBlock(content, agent)
+      for (const route of sensitivePaths) {
+        expect(block).toContain(`Disallow: ${route}`)
+      }
+    }
+  })
+
+  it('documents llms.txt discoverability file at site root', () => {
+    const llmsPath = path.join(process.cwd(), 'public', 'llms.txt')
+    expect(fs.existsSync(llmsPath)).toBe(true)
+    const llms = fs.readFileSync(llmsPath, 'utf-8')
+    expect(llms).toContain('16 Bit Weather')
+    expect(llms).toContain('https://www.16bitweather.co')
+  })
+
+  it('does not allow removed stale routes in the default crawler block', () => {
+    const defaultBlock = getAgentBlock(content, '*')
+    expect(defaultBlock).not.toContain('Allow: /situation')
+    expect(defaultBlock).not.toContain('Allow: /map')
+    expect(defaultBlock).not.toContain('Allow: /hourly')
+  })
+})

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -52,35 +52,61 @@ export const metadata: Metadata = {
   },
 }
 
-// JSON-LD structured data for the homepage
+const SITE_URL = 'https://www.16bitweather.co'
+
+// JSON-LD structured data for the homepage (Organization + WebSite + WebApplication)
 const jsonLd = {
   '@context': 'https://schema.org',
-  '@type': 'WebApplication',
-  name: '16 Bit Weather',
-  description: 'Real-time weather forecasts with authentic 16-bit terminal aesthetics',
-  url: 'https://www.16bitweather.co',
-  applicationCategory: 'WeatherApplication',
-  operatingSystem: 'Web',
-  offers: {
-    '@type': 'Offer',
-    price: '0',
-    priceCurrency: 'USD',
-  },
-  author: {
-    '@type': 'Organization',
-    name: '16 Bit Weather',
-    url: 'https://www.16bitweather.co',
-  },
-  featureList: [
-    'Real-time weather data',
-    '7-day weather forecast',
-    'North America weather radar',
-    'Air quality index',
-    'Pollen count',
-    'UV index',
-    'Hourly forecast',
-    'Multiple retro themes',
-    'City weather search',
+  '@graph': [
+    {
+      '@type': 'Organization',
+      '@id': `${SITE_URL}/#organization`,
+      name: '16 Bit Weather',
+      url: SITE_URL,
+      logo: `${SITE_URL}/favicon.svg`,
+    },
+    {
+      '@type': 'WebSite',
+      '@id': `${SITE_URL}/#website`,
+      url: SITE_URL,
+      name: '16 Bit Weather',
+      description: 'Real-time weather forecasts with authentic 16-bit terminal aesthetics',
+      publisher: { '@id': `${SITE_URL}/#organization` },
+      potentialAction: {
+        '@type': 'SearchAction',
+        target: {
+          '@type': 'EntryPoint',
+          urlTemplate: `${SITE_URL}/weather/{search_term_string}`,
+        },
+        'query-input': 'required name=search_term_string',
+      },
+    },
+    {
+      '@type': 'WebApplication',
+      '@id': `${SITE_URL}/#webapp`,
+      name: '16 Bit Weather',
+      description: 'Real-time weather forecasts with authentic 16-bit terminal aesthetics',
+      url: SITE_URL,
+      applicationCategory: 'WeatherApplication',
+      operatingSystem: 'Web',
+      offers: {
+        '@type': 'Offer',
+        price: '0',
+        priceCurrency: 'USD',
+      },
+      author: { '@id': `${SITE_URL}/#organization` },
+      featureList: [
+        'Real-time weather data',
+        '7-day weather forecast',
+        'North America weather radar',
+        'Air quality index',
+        'Pollen count',
+        'UV index',
+        'Hourly forecast',
+        'Multiple retro themes',
+        'City weather search',
+      ],
+    },
   ],
 }
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,56 @@
+# 16 Bit Weather
+
+> Real-time weather forecasts, hazard tracking, and meteorology education with a retro 16-bit terminal aesthetic. Live at https://www.16bitweather.co
+
+16 Bit Weather combines Open-Meteo forecasts, NOAA/NWS warnings, SPC outlooks, radar, space weather, stargazing conditions, and educational content for weather enthusiasts and the general public.
+
+## Canonical source
+
+- Website: https://www.16bitweather.co
+- Sitemap: https://www.16bitweather.co/sitemap.xml
+
+## Best pages to cite
+
+- Home / city search: https://www.16bitweather.co
+- City forecasts and climate guides: https://www.16bitweather.co/weather/{city-slug} (e.g. /weather/denver-co, /weather/new-york-ny)
+- Active NWS warnings command center: https://www.16bitweather.co/warnings
+- Severe weather (SPC outlooks + NWS alerts): https://www.16bitweather.co/severe
+- Earth and space hazard news: https://www.16bitweather.co/news
+- Weather education hub: https://www.16bitweather.co/education
+- Weather metric glossary: https://www.16bitweather.co/education/glossary
+- Live radar: https://www.16bitweather.co/radar
+- Stargazer / tonight's sky forecast: https://www.16bitweather.co/stargazer
+- Space weather: https://www.16bitweather.co/space-weather
+- Blog (weekly weather dispatches): https://www.16bitweather.co/blog
+- About: https://www.16bitweather.co/about
+
+## Topics we cover well
+
+- Current conditions and 7-day forecasts for US and global cities
+- NWS active warnings with map polygons and alert deep links
+- SPC convective outlook context
+- Hurricane/tropical NHC outlooks
+- Aviation weather tools (METAR, turbulence — educational, not for operational flight planning)
+- Stargazing scores (seeing, transparency, moon phase) by location
+- Cloud types, weather systems, and glossary definitions
+
+## Do not cite or index
+
+- User dashboards: /dashboard
+- User profiles: /profile
+- Auth flows: /auth/*
+- API endpoints: /api/*
+- Internal/dev utilities: /test-sentry, /radar-diagnostic, /gfs-model/*
+
+## Data sources (for attribution)
+
+- Forecasts: Open-Meteo
+- US warnings and alerts: NOAA National Weather Service (api.weather.gov)
+- SPC outlooks: NOAA Storm Prediction Center
+- Radar tiles: RainViewer (see site attribution)
+- News/hazards: USGS, NASA, NOAA RSS feeds
+
+## Contact
+
+- Site: https://www.16bitweather.co/about
+- Issues: https://github.com/deephouse23/Weather-application-/issues

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,8 @@
 # 16 Bit Weather - robots.txt
-# Updated: April 2026
+# Updated: June 2026
+#
+# Policy: allow search/browse AI crawlers on public content; block training
+# crawlers and keep API, auth, and user-private routes out of all crawlers.
 
 User-agent: *
 Allow: /
@@ -13,45 +16,65 @@ Allow: /tropical
 Allow: /winter
 Allow: /radar
 Allow: /space-weather
-Allow: /situation
+Allow: /stargazer
+Allow: /warnings
 Allow: /travel
 Allow: /extremes
-Allow: /hourly
 Allow: /about
 Allow: /cloud-types
 Allow: /weather-systems
 Allow: /fun-facts
-Allow: /map
 
-# API and internal routes
 Disallow: /api/
 Disallow: /_next/
 Disallow: /admin/
-
-# Dev/utility pages (noindex)
+Disallow: /auth/
 Disallow: /test-sentry
 Disallow: /radar-diagnostic
 Disallow: /gfs-model/
-
-# Private user pages
 Disallow: /dashboard
 Disallow: /profile
 
-# Sitemap
 Sitemap: https://www.16bitweather.co/sitemap.xml
 
-# Social media crawlers
+# Social preview crawlers
 User-agent: facebookexternalhit
 Allow: /
 
 User-agent: Twitterbot
 Allow: /
 
-# Block AI training bots
-User-agent: GPTBot
-Disallow: /
+# AI search and browse (ChatGPT search, user link previews, Perplexity, Claude)
+User-agent: OAI-SearchBot
+Allow: /
+Disallow: /api/
+Disallow: /auth/
+Disallow: /dashboard
+Disallow: /profile
 
 User-agent: ChatGPT-User
+Allow: /
+Disallow: /api/
+Disallow: /auth/
+Disallow: /dashboard
+Disallow: /profile
+
+User-agent: PerplexityBot
+Allow: /
+Disallow: /api/
+Disallow: /auth/
+Disallow: /dashboard
+Disallow: /profile
+
+User-agent: ClaudeBot
+Allow: /
+Disallow: /api/
+Disallow: /auth/
+Disallow: /dashboard
+Disallow: /profile
+
+# AI training crawlers (opt out of model training datasets)
+User-agent: GPTBot
 Disallow: /
 
 User-agent: CCBot


### PR DESCRIPTION
## Summary

- Allow AI search/browse crawlers (OAI-SearchBot, ChatGPT-User, PerplexityBot, ClaudeBot) on public pages while keeping training bots blocked and sensitive routes disallowed; remove stale Allow entries for `/situation`, `/map`, and `/hourly`.
- Add root `llms.txt` guide for LLM crawlers with canonical URLs, topic coverage, data sources, and no-cite routes.
- Expand homepage structured data to an `@graph` with Organization, WebSite + SearchAction, and WebApplication entities.
- Add `__tests__/robots-seo.test.ts` to pin search-vs-training bot policy and llms.txt presence.

## Test plan

- [x] `npm test -- robots-seo seo-indexing`
- [x] `npm run typecheck`
- [ ] CI e2e-preview + Lighthouse
- [ ] After merge/deploy: re-run GSC post-deploy checklist (`llms.txt`, updated `robots.txt`, sitemap resubmit)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support pages and discoverability guidance for AI and search engines.
  * Expanded site metadata so the homepage is better represented in search results.
  * Published an `llms.txt` file with recommended citation pages and site information.

* **Bug Fixes**
  * Updated crawler rules to keep private areas and APIs out of search access.
  * Refined bot guidance so public content remains accessible while training crawlers stay blocked.

* **Tests**
  * Added automated checks to verify crawler rules and `llms.txt` content stay consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->