### PR TITLE
fix(seo): crawlable city links and glossary indexing signals

### DIFF
--- a/__tests__/featured-city-links.test.ts
+++ b/__tests__/featured-city-links.test.ts
@@ -1,0 +1,16 @@
+import { FEATURED_CITY_SLUGS, getFeaturedCities } from '@/lib/featured-city-links'
+
+describe('featured city links', () => {
+  it('includes GSC-demand cities with metadata', () => {
+    const slugs = getFeaturedCities().map((c) => c.slug)
+    expect(slugs).toEqual([...FEATURED_CITY_SLUGS])
+    expect(slugs).toContain('boston-ma')
+    expect(slugs).toContain('denver-co')
+    expect(slugs).toContain('atlanta-ga')
+  })
+
+  it('provides human-readable labels for footer links', () => {
+    const boston = getFeaturedCities().find((c) => c.slug === 'boston-ma')
+    expect(boston?.label).toBe('Boston, MA')
+  })
+})

--- a/__tests__/seo-indexing-fixes.test.ts
+++ b/__tests__/seo-indexing-fixes.test.ts
@@ -28,10 +28,29 @@ describe('SEO Indexing Fixes', () => {
     const content = fs.readFileSync(wrapperPath, 'utf-8')
 
     expect(content).toContain('<footer')
-    const requiredLinks = ['/radar', '/severe', '/aviation', '/education', '/blog', '/news', '/about']
+    const requiredLinks = ['/radar', '/severe', '/aviation', '/education', '/education/glossary', '/blog', '/news', '/about']
     for (const link of requiredLinks) {
       expect(content).toContain(`href="${link}"`)
     }
+    expect(content).toContain('/education/glossary')
+    expect(content).toContain('getFeaturedCities')
+    expect(content).toContain('/weather/${city.slug}')
+  })
+
+  it('homepage should server-render featured city links for crawlers', () => {
+    const pagePath = path.join(process.cwd(), 'app', 'page.tsx')
+    const content = fs.readFileSync(pagePath, 'utf-8')
+
+    expect(content).toContain('FeaturedCityLinks')
+    expect(content).toContain('Weather by city')
+  })
+
+  it('glossary layout should include breadcrumb and featured city links', () => {
+    const layoutPath = path.join(process.cwd(), 'app', 'education', 'glossary', 'layout.tsx')
+    const content = fs.readFileSync(layoutPath, 'utf-8')
+
+    expect(content).toContain('BreadcrumbList')
+    expect(content).toContain('FeaturedCityLinks')
   })
 
   it('sitemap should not include /ai route', async () => {

--- a/app/education/glossary/layout.tsx
+++ b/app/education/glossary/layout.tsx
@@ -4,6 +4,9 @@
 
 import type { Metadata } from 'next'
 import { safeJsonLd } from '@/lib/utils'
+import FeaturedCityLinks from '@/components/featured-city-links'
+
+const GLOSSARY_URL = 'https://www.16bitweather.co/education/glossary'
 
 export const metadata: Metadata = {
   title: 'Weather Glossary - Metric Definitions | 16 Bit Weather',
@@ -15,7 +18,7 @@ export const metadata: Metadata = {
     title: 'Weather Glossary - 16 Bit Weather',
     description:
       'In-depth definitions of every weather metric. UV Index, humidity, pressure, wind, and more explained with practical tips.',
-    url: 'https://www.16bitweather.co/education/glossary',
+    url: GLOSSARY_URL,
     siteName: '16 Bit Weather',
     images: [
       {
@@ -35,27 +38,56 @@ export const metadata: Metadata = {
     images: ['/api/og?title=Weather+Glossary&subtitle=Metric+Definitions'],
   },
   alternates: {
-    canonical: 'https://www.16bitweather.co/education/glossary',
+    canonical: GLOSSARY_URL,
   },
 }
 
 const glossarySchema = {
   '@context': 'https://schema.org',
-  '@type': 'DefinedTermSet',
-  name: 'Weather Metric Glossary',
-  description: 'Comprehensive definitions of weather measurements and metrics',
-  url: 'https://www.16bitweather.co/education/glossary',
-  hasDefinedTerm: [
-    { '@type': 'DefinedTerm', name: 'UV Index', description: 'Measures ultraviolet radiation strength from the sun' },
-    { '@type': 'DefinedTerm', name: 'Humidity', description: 'Amount of water vapor present in the air' },
-    { '@type': 'DefinedTerm', name: 'Barometric Pressure', description: 'Weight of the atmosphere pressing down on Earth' },
-    { '@type': 'DefinedTerm', name: 'Wind', description: 'Movement of air from high to low pressure areas' },
-    { '@type': 'DefinedTerm', name: 'Visibility', description: 'Maximum distance objects can be clearly seen' },
-    { '@type': 'DefinedTerm', name: 'Feels Like', description: 'Apparent temperature accounting for wind and humidity' },
-    { '@type': 'DefinedTerm', name: 'Precipitation', description: 'Total rainfall and snowfall measurement' },
-    { '@type': 'DefinedTerm', name: 'Pollen Count', description: 'Concentration of airborne pollen grains' },
-    { '@type': 'DefinedTerm', name: 'Sun Times', description: 'Sunrise and sunset times for a location' },
-    { '@type': 'DefinedTerm', name: 'Moon Phase', description: 'Current shape of the moon illuminated portion' },
+  '@graph': [
+    {
+      '@type': 'BreadcrumbList',
+      itemListElement: [
+        {
+          '@type': 'ListItem',
+          position: 1,
+          name: 'Education',
+          item: 'https://www.16bitweather.co/education',
+        },
+        {
+          '@type': 'ListItem',
+          position: 2,
+          name: 'Weather Glossary',
+          item: GLOSSARY_URL,
+        },
+      ],
+    },
+    {
+      '@type': 'DefinedTermSet',
+      name: 'Weather Metric Glossary',
+      description: 'Comprehensive definitions of weather measurements and metrics',
+      url: GLOSSARY_URL,
+      hasDefinedTerm: [
+        { '@type': 'DefinedTerm', name: 'UV Index', description: 'Measures ultraviolet radiation strength from the sun' },
+        { '@type': 'DefinedTerm', name: 'Humidity', description: 'Amount of water vapor present in the air' },
+        { '@type': 'DefinedTerm', name: 'Barometric Pressure', description: 'Weight of the atmosphere pressing down on Earth' },
+        { '@type': 'DefinedTerm', name: 'Wind', description: 'Movement of air from high to low pressure areas' },
+        { '@type': 'DefinedTerm', name: 'Visibility', description: 'Maximum distance objects can be clearly seen' },
+        { '@type': 'DefinedTerm', name: 'Feels Like', description: 'Apparent temperature accounting for wind and humidity' },
+        { '@type': 'DefinedTerm', name: 'Precipitation', description: 'Total rainfall and snowfall measurement' },
+        { '@type': 'DefinedTerm', name: 'Pollen Count', description: 'Concentration of airborne pollen grains' },
+        { '@type': 'DefinedTerm', name: 'Sun Times', description: 'Sunrise and sunset times for a location' },
+        { '@type': 'DefinedTerm', name: 'Moon Phase', description: 'Current shape of the moon illuminated portion' },
+      ],
+    },
+    {
+      '@type': 'WebPage',
+      name: 'Weather Glossary - Metric Definitions',
+      url: GLOSSARY_URL,
+      description: 'In-depth definitions of weather metrics with practical tips',
+      isPartOf: { '@id': 'https://www.16bitweather.co/#website' },
+      about: { '@type': 'DefinedTermSet', url: GLOSSARY_URL },
+    },
   ],
 }
 
@@ -71,6 +103,10 @@ export default function EducationGlossaryLayout({
         dangerouslySetInnerHTML={{ __html: safeJsonLd(glossarySchema) }}
       />
       {children}
+      <FeaturedCityLinks
+        title="See metrics in context — city forecasts"
+        limit={8}
+      />
     </>
   )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,6 +13,7 @@ import { Suspense } from 'react'
 import dynamic from 'next/dynamic'
 import { safeJsonLd } from '@/lib/utils'
 import { WeatherCardsSkeleton } from '@/components/home-shell'
+import FeaturedCityLinks from '@/components/featured-city-links'
 
 // PERFORMANCE: Use next/dynamic for proper SSR streaming with fallback
 // This enables the server-rendered shell to display immediately as LCP
@@ -171,6 +172,8 @@ export default function HomePage() {
       <Suspense fallback={<HomePageShell />}>
         <HomeClient />
       </Suspense>
+      {/* Crawlable city links — server-rendered (RandomCityLinks is client-only / ssr:false) */}
+      <FeaturedCityLinks title="Weather by city" />
     </>
   )
 }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -34,6 +34,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       { url: `${baseUrl}/weather-systems`, lastModified: new Date(), changeFrequency: 'weekly', priority: 0.8 },
       { url: `${baseUrl}/fun-facts`, lastModified: new Date(), changeFrequency: 'weekly', priority: 0.7 },
       { url: `${baseUrl}/education/glossary`, lastModified: new Date(), changeFrequency: 'monthly' as const, priority: 0.7 },
+      { url: `${baseUrl}/llms.txt`, lastModified: new Date(), changeFrequency: 'monthly' as const, priority: 0.5 },
     ]
   
     // Dynamic city pages

--- a/components/featured-city-links.tsx
+++ b/components/featured-city-links.tsx
@@ -1,0 +1,68 @@
+import Link from 'next/link'
+import { getFeaturedCities } from '@/lib/featured-city-links'
+
+type FeaturedCityLinksProps = {
+  variant?: 'section' | 'footer'
+  title?: string
+  limit?: number
+}
+
+export default function FeaturedCityLinks({
+  variant = 'section',
+  title = 'Popular city forecasts',
+  limit,
+}: FeaturedCityLinksProps) {
+  const items = limit ? getFeaturedCities().slice(0, limit) : getFeaturedCities()
+
+  if (variant === 'footer') {
+    return (
+      <nav aria-label="Popular city weather forecasts" className="flex flex-col gap-1.5">
+        {items.map((city) => (
+          <Link
+            key={city.slug}
+            href={`/weather/${city.slug}`}
+            className="text-muted-foreground hover:text-foreground transition-colors"
+          >
+            {city.label}
+          </Link>
+        ))}
+      </nav>
+    )
+  }
+
+  return (
+    <section
+      aria-labelledby="featured-city-forecasts"
+      className="border-t border-border/40 bg-black/20 py-10"
+    >
+      <div className="max-w-6xl mx-auto px-4">
+        <h2
+          id="featured-city-forecasts"
+          className="text-center text-sm font-bold uppercase tracking-widest font-mono text-primary mb-2"
+        >
+          {title}
+        </h2>
+        <p className="text-center text-xs font-mono text-muted-foreground mb-6 max-w-2xl mx-auto">
+          Live forecasts, climate guides, and monthly averages for major US cities.
+        </p>
+        <nav
+          aria-label="Featured city weather pages"
+          className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-2 max-w-5xl mx-auto"
+        >
+          {items.map((city) => (
+            <Link
+              key={city.slug}
+              href={`/weather/${city.slug}`}
+              className="block px-3 py-2 text-xs sm:text-sm font-mono text-center rounded border border-border/50 text-muted-foreground hover:text-foreground hover:border-primary/50 hover:bg-primary/5 transition-colors"
+            >
+              {city.name}
+              {city.state ? (
+                <span className="block text-[10px] opacity-70">{city.state}</span>
+              ) : null}
+            </Link>
+          ))}
+        </nav>
+      </div>
+    </section>
+  )
+}

--- a/components/page-wrapper.tsx
+++ b/components/page-wrapper.tsx
@@ -17,6 +17,7 @@
 
 import Navigation from "./navigation"
 import Link from "next/link"
+import { getFeaturedCities } from "@/lib/featured-city-links"
 
 interface PageWrapperProps {
   children: React.ReactNode
@@ -35,6 +36,8 @@ interface PageWrapperProps {
  * based on the data-theme attribute set by ThemeProvider.
  */
 export default function PageWrapper({ children, weatherLocation, weatherTemperature, weatherUnit }: PageWrapperProps) {
+  const featuredCities = getFeaturedCities().slice(0, 10)
+
   return (
     <div className="min-h-screen bg-background text-foreground relative">
       <Navigation
@@ -47,7 +50,7 @@ export default function PageWrapper({ children, weatherLocation, weatherTemperat
       </main>
       <footer className="border-t border-border/40 bg-black/30 mt-16">
         <div className="max-w-7xl mx-auto px-4 py-10">
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-8 text-sm font-mono">
+          <div className="grid grid-cols-2 md:grid-cols-5 gap-8 text-sm font-mono">
             <div>
               <h3 className="text-xs font-bold uppercase tracking-widest text-muted-foreground mb-3">Weather</h3>
               <nav className="flex flex-col gap-1.5">
@@ -59,6 +62,20 @@ export default function PageWrapper({ children, weatherLocation, weatherTemperat
                 <Link href="/tropical" className="text-muted-foreground hover:text-foreground transition-colors">Tropical</Link>
                 <Link href="/winter" className="text-muted-foreground hover:text-foreground transition-colors">Winter</Link>
                 <Link href="/earth-sciences" className="text-muted-foreground hover:text-foreground transition-colors">Earth Sciences</Link>
+              </nav>
+            </div>
+            <div>
+              <h3 className="text-xs font-bold uppercase tracking-widest text-muted-foreground mb-3">Cities</h3>
+              <nav aria-label="Popular city weather forecasts" className="flex flex-col gap-1.5">
+                {featuredCities.map((city) => (
+                  <Link
+                    key={city.slug}
+                    href={`/weather/${city.slug}`}
+                    className="text-muted-foreground hover:text-foreground transition-colors"
+                  >
+                    {city.label}
+                  </Link>
+                ))}
               </nav>
             </div>
             <div>
@@ -75,6 +92,7 @@ export default function PageWrapper({ children, weatherLocation, weatherTemperat
               <h3 className="text-xs font-bold uppercase tracking-widest text-muted-foreground mb-3">Learn</h3>
               <nav className="flex flex-col gap-1.5">
                 <Link href="/education" className="text-muted-foreground hover:text-foreground transition-colors">Education</Link>
+                <Link href="/education/glossary" className="text-muted-foreground hover:text-foreground transition-colors">Weather Glossary</Link>
                 <Link href="/blog" className="text-muted-foreground hover:text-foreground transition-colors">Blog</Link>
                 <Link href="/news" className="text-muted-foreground hover:text-foreground transition-colors">News</Link>
                 <Link href="/cloud-types" className="text-muted-foreground hover:text-foreground transition-colors">Cloud Types</Link>

--- a/lib/featured-city-links.ts
+++ b/lib/featured-city-links.ts
@@ -1,0 +1,31 @@
+import { cityData } from '@/lib/city-metadata'
+
+/** Stable slugs for crawlable internal links — aligned with GSC query demand. */
+export const FEATURED_CITY_SLUGS = [
+  'boston-ma',
+  'atlanta-ga',
+  'denver-co',
+  'pittsburgh-pa',
+  'new-york-ny',
+  'chicago-il',
+  'los-angeles-ca',
+  'houston-tx',
+  'phoenix-az',
+  'philadelphia-pa',
+  'seattle-wa',
+  'miami-fl',
+] as const
+
+export type FeaturedCitySlug = (typeof FEATURED_CITY_SLUGS)[number]
+
+export function getFeaturedCities() {
+  return FEATURED_CITY_SLUGS.map((slug) => {
+    const city = cityData[slug]
+    return {
+      slug,
+      name: city?.name ?? slug,
+      state: city?.state ?? '',
+      label: city ? `${city.name}, ${city.state}` : slug,
+    }
+  })
+}


### PR DESCRIPTION
## Summary

- Add stable server-rendered featured city links on the homepage (fixes client-only `RandomCityLinks` with `ssr: false` that crawlers often miss).
- Add a **Cities** footer column plus **Weather Glossary** link on every page using `PageWrapper`.
- Strengthen glossary SEO with `BreadcrumbList` + `WebPage` JSON-LD and a featured-city cross-link section in the glossary layout.
- Add `/llms.txt` to the sitemap for faster discovery.

Targets GSC issues: city pages **Discovered — not indexed** and glossary **Crawled — not indexed**.

## Test plan

- [x] `npm test -- seo-indexing featured-city-links sitemap-seo`
- [x] `npm run typecheck`
- [ ] CI e2e-preview
- [ ] After merge: re-run GSC post-deploy checklist and request indexing for glossary + top city URLs


Made with [Cursor](https://cursor.com)