### PR TITLE
fix(auth): auth UX, dashboard settings, and signup admin alerts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,8 +66,18 @@ NEXT_PUBLIC_BASE_URL=http://localhost:3000
 # NASA_API_KEY=your_nasa_api_key_here
 
 # =============================================================================
-# Sentry Error Tracking (optional)
+# Registration admin notifications (server-side only, optional)
 # =============================================================================
+# Fired when Supabase Database Webhook POSTs to /api/webhooks/new-user on profiles INSERT.
+# See planning/supabase-registration-webhook-setup.md for dashboard setup steps.
+#
+# SUPABASE_WEBHOOK_SECRET=your_random_secret_here
+# ADMIN_NOTIFICATION_EMAIL=you@example.com
+# RESEND_API_KEY=re_xxxxxxxx
+# RESEND_FROM_EMAIL=16 Bit Weather <noreply@16bitweather.co>
+# SLACK_WEBHOOK_URL=https://hooks.slack.com/services/...
+# DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/...
+
 # NEXT_PUBLIC_SENTRY_DSN=your_sentry_dsn_here
 
 # =============================================================================

--- a/__tests__/auth-form.test.tsx
+++ b/__tests__/auth-form.test.tsx
@@ -84,7 +84,7 @@ describe('AuthForm', () => {
       target: { value: 'bad@example.com' },
     })
     fireEvent.change(screen.getByPlaceholderText(/enter your password/i), {
-      target: { value: 'wrong' },
+      target: { value: 'wrong12' },
     })
     fireEvent.click(screen.getByRole('button', { name: /^sign in$/i }))
 

--- a/__tests__/auth-form.test.tsx
+++ b/__tests__/auth-form.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * Unit tests for AuthForm signup success vs error alerts
+ */
+
+import React from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+
+const mockPush = jest.fn()
+const mockRefresh = jest.fn()
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush, refresh: mockRefresh }),
+}))
+
+jest.mock('@/components/theme-provider', () => ({
+  useTheme: () => ({ theme: 'nord' }),
+}))
+
+jest.mock('@/lib/theme-utils', () => ({
+  getComponentStyles: () => ({
+    background: 'bg-test',
+    text: 'text-test',
+    mutedText: 'text-muted',
+    borderColor: 'border-test',
+    accentBg: 'bg-accent',
+    accentText: 'text-accent',
+  }),
+}))
+
+const mockSignUp = jest.fn()
+const mockSignIn = jest.fn()
+const mockSignInWithProvider = jest.fn()
+
+jest.mock('@/lib/supabase/auth', () => ({
+  signUp: (...args: unknown[]) => mockSignUp(...args),
+  signIn: (...args: unknown[]) => mockSignIn(...args),
+  signInWithProvider: (...args: unknown[]) => mockSignInWithProvider(...args),
+}))
+
+import AuthForm from '@/components/auth/auth-form'
+
+describe('AuthForm', () => {
+  beforeEach(() => {
+    mockPush.mockReset()
+    mockRefresh.mockReset()
+    mockSignUp.mockReset()
+    mockSignIn.mockReset()
+    mockSignInWithProvider.mockReset()
+  })
+
+  it('shows a success alert after signup without using the destructive error alert', async () => {
+    mockSignUp.mockResolvedValue({ user: { id: 'user-1' }, error: null })
+
+    render(<AuthForm mode="signup" />)
+
+    fireEvent.change(screen.getByPlaceholderText(/enter your email/i), {
+      target: { value: 'new@example.com' },
+    })
+    fireEvent.change(screen.getByPlaceholderText(/enter your password/i), {
+      target: { value: 'secret123' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /^sign up$/i }))
+
+    await waitFor(() => {
+      expect(mockSignUp).toHaveBeenCalled()
+    })
+
+    expect(screen.getByTestId('auth-success-alert')).toBeInTheDocument()
+    expect(screen.queryByTestId('auth-error-alert')).not.toBeInTheDocument()
+    expect(screen.getByTestId('auth-success-alert')).toHaveTextContent(/check your email/i)
+  })
+
+  it('shows a destructive alert for sign-in errors', async () => {
+    mockSignIn.mockResolvedValue({
+      user: null,
+      error: { message: 'Invalid login credentials' },
+    })
+
+    render(<AuthForm mode="signin" initialError="OAuth failed" />)
+
+    expect(screen.getByTestId('auth-error-alert')).toHaveTextContent(/oauth failed/i)
+
+    fireEvent.change(screen.getByPlaceholderText(/enter your email/i), {
+      target: { value: 'bad@example.com' },
+    })
+    fireEvent.change(screen.getByPlaceholderText(/enter your password/i), {
+      target: { value: 'wrong' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /^sign in$/i }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('auth-error-alert')).toHaveTextContent(/invalid login credentials/i)
+    })
+  })
+})

--- a/__tests__/middleware-auth-redirects.test.ts
+++ b/__tests__/middleware-auth-redirects.test.ts
@@ -1,0 +1,16 @@
+import { resolveAuthenticatedAuthRouteRedirect } from '@/lib/auth/middleware-redirects'
+
+describe('auth middleware redirect helpers', () => {
+  it('defaults authenticated auth-route visitors to dashboard', () => {
+    expect(resolveAuthenticatedAuthRouteRedirect(null)).toBe('/dashboard')
+  })
+
+  it('honors a validated next param', () => {
+    expect(resolveAuthenticatedAuthRouteRedirect('/profile')).toBe('/profile')
+  })
+
+  it('blocks open redirects', () => {
+    expect(resolveAuthenticatedAuthRouteRedirect('//evil.com')).toBe('/dashboard')
+    expect(resolveAuthenticatedAuthRouteRedirect('https://evil.com')).toBe('/dashboard')
+  })
+})

--- a/__tests__/new-user-webhook.test.ts
+++ b/__tests__/new-user-webhook.test.ts
@@ -79,7 +79,11 @@ describe('new-user webhook', () => {
   })
 
   afterAll(() => {
-    process.env.SUPABASE_WEBHOOK_SECRET = originalSecret
+    if (originalSecret === undefined) {
+      delete process.env.SUPABASE_WEBHOOK_SECRET
+    } else {
+      process.env.SUPABASE_WEBHOOK_SECRET = originalSecret
+    }
   })
 
   describe('verifyWebhookSecret', () => {
@@ -98,16 +102,34 @@ describe('new-user webhook', () => {
     it('parses a profiles INSERT record', () => {
       const parsed = parseProfileInsertPayload(VALID_PAYLOAD)
       expect(parsed).toEqual({
-        userId: VALID_PAYLOAD.record.id,
-        email: VALID_PAYLOAD.record.email,
-        username: 'newuser',
-        fullName: 'New User',
-        createdAt: VALID_PAYLOAD.record.created_at,
+        status: 'ok',
+        registration: {
+          userId: VALID_PAYLOAD.record.id,
+          email: VALID_PAYLOAD.record.email,
+          username: 'newuser',
+          fullName: 'New User',
+          createdAt: VALID_PAYLOAD.record.created_at,
+        },
       })
     })
 
-    it('ignores non-INSERT events', () => {
-      expect(parseProfileInsertPayload({ ...VALID_PAYLOAD, type: 'UPDATE' })).toBeNull()
+    it('skips non-INSERT events', () => {
+      expect(parseProfileInsertPayload({ ...VALID_PAYLOAD, type: 'UPDATE' })).toEqual({
+        status: 'skip',
+      })
+    })
+
+    it('rejects profiles INSERT missing required fields', () => {
+      expect(
+        parseProfileInsertPayload({
+          ...VALID_PAYLOAD,
+          record: { ...VALID_PAYLOAD.record, email: '' },
+        }),
+      ).toEqual({
+        status: 'invalid',
+        message:
+          'profiles INSERT payload missing required record.id, record.email, or record.created_at',
+      })
     })
   })
 
@@ -143,6 +165,20 @@ describe('new-user webhook', () => {
       expect(response.status).toBe(200)
       const json = await response.json()
       expect(json.skipped).toBe(true)
+      expect(mockNotify).not.toHaveBeenCalled()
+    })
+
+    it('returns 400 for malformed profiles INSERT payloads', async () => {
+      const response = await POST(
+        makeRequest({
+          secret: 'test-webhook-secret',
+          body: {
+            ...VALID_PAYLOAD,
+            record: { id: VALID_PAYLOAD.record.id },
+          },
+        }),
+      )
+      expect(response.status).toBe(400)
       expect(mockNotify).not.toHaveBeenCalled()
     })
   })

--- a/__tests__/new-user-webhook.test.ts
+++ b/__tests__/new-user-webhook.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Unit tests for new-user registration webhook
+ */
+
+jest.mock('next/server', () => ({
+  NextRequest: class MockNextRequest {
+    url: string
+    headers: Headers
+    private bodyText: string
+
+    constructor(url: string, init?: { method?: string; headers?: Headers; body?: string }) {
+      this.url = url
+      this.headers = init?.headers ?? new Headers()
+      this.bodyText = init?.body ?? ''
+    }
+
+    async json() {
+      return JSON.parse(this.bodyText)
+    }
+  },
+  NextResponse: {
+    json: (body: unknown, init?: { status?: number }) => ({
+      status: init?.status ?? 200,
+      json: async () => body,
+    }),
+  },
+}))
+
+jest.mock('@/lib/services/admin-notify-service', () => ({
+  notifyNewRegistration: jest.fn().mockResolvedValue({
+    email: { sent: true },
+    slack: { sent: true },
+    discord: { sent: false, reason: 'DISCORD_WEBHOOK_URL not configured' },
+  }),
+}))
+
+import { NextRequest } from 'next/server'
+import {
+  parseProfileInsertPayload,
+  verifyWebhookSecret,
+  POST,
+} from '@/app/api/webhooks/new-user/route'
+import { notifyNewRegistration } from '@/lib/services/admin-notify-service'
+
+const mockNotify = notifyNewRegistration as jest.MockedFunction<typeof notifyNewRegistration>
+
+const VALID_PAYLOAD = {
+  type: 'INSERT',
+  table: 'profiles',
+  schema: 'public',
+  record: {
+    id: '11111111-1111-1111-1111-111111111111',
+    email: 'newuser@example.com',
+    username: 'newuser',
+    full_name: 'New User',
+    created_at: '2026-06-25T12:00:00.000Z',
+  },
+}
+
+function makeRequest(options: { secret?: string; body?: unknown }): NextRequest {
+  const headers = new Headers({ 'Content-Type': 'application/json' })
+  if (options.secret !== undefined) {
+    headers.set('x-webhook-secret', options.secret)
+  }
+
+  return new NextRequest('http://localhost:3000/api/webhooks/new-user', {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(options.body ?? VALID_PAYLOAD),
+  })
+}
+
+describe('new-user webhook', () => {
+  const originalSecret = process.env.SUPABASE_WEBHOOK_SECRET
+
+  beforeEach(() => {
+    process.env.SUPABASE_WEBHOOK_SECRET = 'test-webhook-secret'
+    mockNotify.mockClear()
+  })
+
+  afterAll(() => {
+    process.env.SUPABASE_WEBHOOK_SECRET = originalSecret
+  })
+
+  describe('verifyWebhookSecret', () => {
+    it('accepts matching secrets', () => {
+      const request = makeRequest({ secret: 'test-webhook-secret' })
+      expect(verifyWebhookSecret(request, 'test-webhook-secret')).toBe(true)
+    })
+
+    it('rejects wrong secrets', () => {
+      const request = makeRequest({ secret: 'wrong-secret' })
+      expect(verifyWebhookSecret(request, 'test-webhook-secret')).toBe(false)
+    })
+  })
+
+  describe('parseProfileInsertPayload', () => {
+    it('parses a profiles INSERT record', () => {
+      const parsed = parseProfileInsertPayload(VALID_PAYLOAD)
+      expect(parsed).toEqual({
+        userId: VALID_PAYLOAD.record.id,
+        email: VALID_PAYLOAD.record.email,
+        username: 'newuser',
+        fullName: 'New User',
+        createdAt: VALID_PAYLOAD.record.created_at,
+      })
+    })
+
+    it('ignores non-INSERT events', () => {
+      expect(parseProfileInsertPayload({ ...VALID_PAYLOAD, type: 'UPDATE' })).toBeNull()
+    })
+  })
+
+  describe('POST', () => {
+    it('returns 401 when webhook secret is invalid', async () => {
+      const response = await POST(makeRequest({ secret: 'bad-secret' }))
+      expect(response.status).toBe(401)
+      expect(mockNotify).not.toHaveBeenCalled()
+    })
+
+    it('notifies on valid profiles INSERT payload', async () => {
+      const response = await POST(makeRequest({ secret: 'test-webhook-secret' }))
+      expect(response.status).toBe(200)
+
+      const json = await response.json()
+      expect(json.ok).toBe(true)
+      expect(json.userId).toBe(VALID_PAYLOAD.record.id)
+      expect(mockNotify).toHaveBeenCalledWith(
+        expect.objectContaining({
+          email: 'newuser@example.com',
+          username: 'newuser',
+        }),
+      )
+    })
+
+    it('skips non-profile INSERT events without error', async () => {
+      const response = await POST(
+        makeRequest({
+          secret: 'test-webhook-secret',
+          body: { ...VALID_PAYLOAD, table: 'user_preferences' },
+        }),
+      )
+      expect(response.status).toBe(200)
+      const json = await response.json()
+      expect(json.skipped).toBe(true)
+      expect(mockNotify).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/app/api/webhooks/new-user/route.ts
+++ b/app/api/webhooks/new-user/route.ts
@@ -1,0 +1,98 @@
+import { timingSafeEqual } from 'node:crypto'
+import type { NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
+import { notifyNewRegistration } from '@/lib/services/admin-notify-service'
+
+export const dynamic = 'force-dynamic'
+export const runtime = 'nodejs'
+
+const WEBHOOK_SECRET_HEADER = 'x-webhook-secret'
+
+export interface SupabaseProfileWebhookPayload {
+  type: string
+  table: string
+  schema: string
+  record: {
+    id: string
+    email: string
+    username?: string | null
+    full_name?: string | null
+    created_at: string
+  } | null
+}
+
+export function verifyWebhookSecret(request: NextRequest, expectedSecret: string): boolean {
+  const provided = request.headers.get(WEBHOOK_SECRET_HEADER) ?? ''
+  const a = Buffer.from(provided)
+  const b = Buffer.from(expectedSecret)
+  if (a.length !== b.length) return false
+  return timingSafeEqual(a, b)
+}
+
+export function parseProfileInsertPayload(body: unknown): NewRegistrationFromWebhook | null {
+  if (body == null || typeof body !== 'object') return null
+
+  const payload = body as SupabaseProfileWebhookPayload
+
+  if (payload.type !== 'INSERT') return null
+  if (payload.table !== 'profiles') return null
+  if (!payload.record?.id || !payload.record.email) return null
+
+  return {
+    userId: payload.record.id,
+    email: payload.record.email,
+    username: payload.record.username ?? null,
+    fullName: payload.record.full_name ?? null,
+    createdAt: payload.record.created_at ?? new Date().toISOString(),
+  }
+}
+
+export interface NewRegistrationFromWebhook {
+  userId: string
+  email: string
+  username: string | null
+  fullName: string | null
+  createdAt: string
+}
+
+export async function POST(request: NextRequest) {
+  const webhookSecret = process.env.SUPABASE_WEBHOOK_SECRET
+  if (!webhookSecret) {
+    console.error('[webhooks/new-user] SUPABASE_WEBHOOK_SECRET not configured')
+    return NextResponse.json({ error: 'Webhook not configured' }, { status: 500 })
+  }
+
+  if (!verifyWebhookSecret(request, webhookSecret)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  const registration = parseProfileInsertPayload(body)
+  if (!registration) {
+    return NextResponse.json({ ok: true, skipped: true, reason: 'Not a profiles INSERT event' })
+  }
+
+  try {
+    const results = await notifyNewRegistration(registration)
+
+    const anySent = results.email.sent || results.slack.sent || results.discord.sent
+    if (!anySent) {
+      console.warn('[webhooks/new-user] No notification channels configured or all failed', results)
+    }
+
+    return NextResponse.json({
+      ok: true,
+      userId: registration.userId,
+      notifications: results,
+    })
+  } catch (error) {
+    console.error('[webhooks/new-user] Notification failed:', error)
+    return NextResponse.json({ error: 'Failed to send notifications' }, { status: 500 })
+  }
+}

--- a/app/api/webhooks/new-user/route.ts
+++ b/app/api/webhooks/new-user/route.ts
@@ -21,6 +21,19 @@ export interface SupabaseProfileWebhookPayload {
   } | null
 }
 
+export interface NewRegistrationFromWebhook {
+  userId: string
+  email: string
+  username: string | null
+  fullName: string | null
+  createdAt: string
+}
+
+export type ProfileWebhookParseResult =
+  | { status: 'skip' }
+  | { status: 'invalid'; message: string }
+  | { status: 'ok'; registration: NewRegistrationFromWebhook }
+
 export function verifyWebhookSecret(request: NextRequest, expectedSecret: string): boolean {
   const provided = request.headers.get(WEBHOOK_SECRET_HEADER) ?? ''
   const a = Buffer.from(provided)
@@ -29,30 +42,35 @@ export function verifyWebhookSecret(request: NextRequest, expectedSecret: string
   return timingSafeEqual(a, b)
 }
 
-export function parseProfileInsertPayload(body: unknown): NewRegistrationFromWebhook | null {
-  if (body == null || typeof body !== 'object') return null
+export function parseProfileInsertPayload(body: unknown): ProfileWebhookParseResult {
+  if (body == null || typeof body !== 'object') {
+    return { status: 'invalid', message: 'Webhook body must be a JSON object' }
+  }
 
   const payload = body as SupabaseProfileWebhookPayload
 
-  if (payload.type !== 'INSERT') return null
-  if (payload.table !== 'profiles') return null
-  if (!payload.record?.id || !payload.record.email) return null
+  if (payload.type !== 'INSERT' || payload.table !== 'profiles') {
+    return { status: 'skip' }
+  }
+
+  const record = payload.record
+  if (!record?.id || !record.email || !record.created_at) {
+    return {
+      status: 'invalid',
+      message: 'profiles INSERT payload missing required record.id, record.email, or record.created_at',
+    }
+  }
 
   return {
-    userId: payload.record.id,
-    email: payload.record.email,
-    username: payload.record.username ?? null,
-    fullName: payload.record.full_name ?? null,
-    createdAt: payload.record.created_at ?? new Date().toISOString(),
+    status: 'ok',
+    registration: {
+      userId: record.id,
+      email: record.email,
+      username: record.username ?? null,
+      fullName: record.full_name ?? null,
+      createdAt: record.created_at,
+    },
   }
-}
-
-export interface NewRegistrationFromWebhook {
-  userId: string
-  email: string
-  username: string | null
-  fullName: string | null
-  createdAt: string
 }
 
 export async function POST(request: NextRequest) {
@@ -73,13 +91,16 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
   }
 
-  const registration = parseProfileInsertPayload(body)
-  if (!registration) {
+  const parsed = parseProfileInsertPayload(body)
+  if (parsed.status === 'skip') {
     return NextResponse.json({ ok: true, skipped: true, reason: 'Not a profiles INSERT event' })
+  }
+  if (parsed.status === 'invalid') {
+    return NextResponse.json({ error: parsed.message }, { status: 400 })
   }
 
   try {
-    const results = await notifyNewRegistration(registration)
+    const results = await notifyNewRegistration(parsed.registration)
 
     const anySent = results.email.sent || results.slack.sent || results.discord.sent
     if (!anySent) {
@@ -88,7 +109,7 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({
       ok: true,
-      userId: registration.userId,
+      userId: parsed.registration.userId,
       notifications: results,
     })
   } catch (error) {

--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -6,6 +6,17 @@ export const metadata: Metadata = {
   description: 'Sign in to access your saved locations and weather preferences.',
 }
 
-export default function LoginPage() {
-  return <AuthForm mode="signin" />
+interface LoginPageProps {
+  searchParams?: Promise<{ error?: string; next?: string }>
+}
+
+export default async function LoginPage({ searchParams }: LoginPageProps) {
+  const params = searchParams ? await searchParams : {}
+  const rawError = params.error
+  const initialError =
+    typeof rawError === 'string' && rawError.length > 0
+      ? decodeURIComponent(rawError.replace(/\+/g, ' '))
+      : undefined
+
+  return <AuthForm mode="signin" initialError={initialError} />
 }

--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -14,9 +14,7 @@ export default async function LoginPage({ searchParams }: LoginPageProps) {
   const params = searchParams ? await searchParams : {}
   const rawError = params.error
   const initialError =
-    typeof rawError === 'string' && rawError.length > 0
-      ? decodeURIComponent(rawError.replace(/\+/g, ' '))
-      : undefined
+    typeof rawError === 'string' && rawError.length > 0 ? rawError : undefined
 
   return <AuthForm mode="signin" initialError={initialError} />
 }

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -82,7 +82,7 @@ function DashboardContent() {
           onAddLocation={() => setIsAddModalOpen(true)}
         />
 
-        {/* Preferences (includes AI personality) */}
+        {/* Preferences (units, default location, auto-location) */}
         <PreferencesPanel locations={locations} />
 
         {/* Theme */}

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -40,11 +40,11 @@ function ProfileContent() {
   }, [])
 
   useEffect(() => {
-    if (profile) {
+    if (profile && !editing) {
       setUsername(profile.username || '')
       setFullName(profile.full_name || '')
     }
-  }, [profile])
+  }, [profile, editing])
 
   const handleSave = async () => {
     if (!user) return
@@ -67,12 +67,12 @@ function ProfileContent() {
         setMessageType('success')
         setMessage('Profile updated successfully.')
       } else {
-        console.error('updateProfile returned null - check database schema and RLS policies')
+        console.error('[profile]', 'updateProfile returned null - check database schema and RLS policies')
         setMessageType('error')
         setMessage('Failed to update profile. Please check your database configuration or try again later.')
       }
     } catch (error) {
-      console.error('Profile update error:', error)
+      console.error('[profile]', error)
       const errorMessage = error instanceof Error ? error.message : 'Unknown error'
       setMessageType('error')
 

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,20 +1,18 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { useRouter } from 'next/navigation'
 import { ProtectedRoute } from '@/lib/auth'
 import { useAuth } from '@/lib/auth'
 import { updateProfile } from '@/lib/supabase/database'
-import { updateUserPreferencesAPI } from '@/lib/services/preferences-service'
 import { useTheme } from '@/components/theme-provider'
 import { getComponentStyles, type ThemeType } from '@/lib/theme-utils'
-import { User, Mail, MapPin, Save, Settings, Loader2 } from 'lucide-react'
+import { User, Mail, Save, Loader2 } from 'lucide-react'
 import Navigation from '@/components/navigation'
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { Switch } from '@/components/ui/switch'
+import Link from 'next/link'
 
 export default function ProfilePage() {
   return (
@@ -25,39 +23,28 @@ export default function ProfilePage() {
 }
 
 function ProfileContent() {
-  const router = useRouter()
-  const { user, profile, preferences, profileLoading, refreshProfile, refreshPreferences } = useAuth()
+  const { user, profile, profileLoading, refreshProfile } = useAuth()
   const { theme } = useTheme()
   const themeClasses = getComponentStyles(theme as ThemeType, 'auth')
 
   const [editing, setEditing] = useState(false)
   const [username, setUsername] = useState('')
   const [fullName, setFullName] = useState('')
-  const [defaultLocation, setDefaultLocation] = useState('')
-  const [autoLocation, setAutoLocation] = useState<boolean>(true)
-  const [temperatureUnit, setTemperatureUnit] = useState<'fahrenheit' | 'celsius'>('fahrenheit')
   const [loading, setLoading] = useState(false)
   const [message, setMessage] = useState('')
   const [messageType, setMessageType] = useState<'success' | 'error'>('success')
   const [mounted, setMounted] = useState(false)
 
-  // Handle mounting to prevent hydration issues
   useEffect(() => {
     setMounted(true)
   }, [])
 
-  // Initialize form values when profile loads
   useEffect(() => {
     if (profile) {
       setUsername(profile.username || '')
       setFullName(profile.full_name || '')
-      setDefaultLocation(profile.default_location || '')
     }
-    if (preferences) {
-      setAutoLocation(preferences.auto_location)
-      setTemperatureUnit(preferences.temperature_unit)
-    }
-  }, [profile, preferences])
+  }, [profile])
 
   const handleSave = async () => {
     if (!user) return
@@ -70,59 +57,25 @@ function ProfileContent() {
       const updates = {
         username: username?.trim() || null,
         full_name: fullName?.trim() || null,
-        default_location: defaultLocation?.trim() || null,
       }
 
       const updatedProfile = await updateProfile(user.id, updates)
 
       if (updatedProfile) {
-        // Refresh profile to verify changes persisted
         await refreshProfile()
-
-        // Save preferences updates (auto-location and units)
-        try {
-          const preferencesResult = await updateUserPreferencesAPI({
-            auto_location: autoLocation,
-            temperature_unit: temperatureUnit
-          })
-
-          if (!preferencesResult) {
-            setMessageType('error')
-            setMessage('Profile saved, but preferences failed to save. Please try updating preferences again.')
-            setLoading(false)
-            return
-          }
-
-          await refreshPreferences()
-        } catch (prefError) {
-          console.error('Error updating preferences:', prefError)
-          setMessageType('error')
-          setMessage('Profile saved, but preferences failed to save. Please try updating preferences again.')
-          setLoading(false)
-          return
-        }
-
         setEditing(false)
         setMessageType('success')
-        setMessage('Profile updated successfully! Redirecting...')
-
-        // Redirect to dashboard after showing success message briefly
-        setTimeout(() => {
-          router.push('/dashboard')
-        }, 1500)
+        setMessage('Profile updated successfully.')
       } else {
-        // updateProfile returned null - database error
         console.error('updateProfile returned null - check database schema and RLS policies')
         setMessageType('error')
         setMessage('Failed to update profile. Please check your database configuration or try again later.')
-        setLoading(false)
       }
     } catch (error) {
       console.error('Profile update error:', error)
       const errorMessage = error instanceof Error ? error.message : 'Unknown error'
       setMessageType('error')
 
-      // Provide user-friendly error messages based on error type
       if (errorMessage.includes('permission') || errorMessage.includes('policy')) {
         setMessage('Permission denied. Please ensure you are logged in and have permission to update your profile.')
       } else if (errorMessage.includes('network') || errorMessage.includes('fetch')) {
@@ -130,11 +83,11 @@ function ProfileContent() {
       } else {
         setMessage(`Unable to save profile: ${errorMessage}. Please try again or contact support if the issue persists.`)
       }
+    } finally {
       setLoading(false)
     }
   }
 
-  // Don't render until mounted to prevent hydration issues
   if (!mounted) {
     return (
       <div className="min-h-screen bg-terminal-bg-primary">
@@ -161,13 +114,16 @@ function ProfileContent() {
                 User Profile
               </CardTitle>
               <CardDescription className={`font-mono mt-2 ${themeClasses.secondary || themeClasses.text}`}>
-                Manage your account settings and preferences
+                Update your display name and username. Weather units and saved locations live on the{' '}
+                <Link href="/dashboard" className={`font-bold hover:underline ${themeClasses.accentText}`}>
+                  dashboard
+                </Link>
+                .
               </CardDescription>
             </div>
           </CardHeader>
 
           <CardContent className="space-y-6">
-            {/* Success/Error Message */}
             {message && (
               <div className={`p-4 border-2 text-sm font-mono rounded-md ${messageType === 'success'
                   ? 'border-green-500 bg-green-950/30 text-green-400'
@@ -177,7 +133,6 @@ function ProfileContent() {
               </div>
             )}
 
-            {/* Profile Loading Indicator */}
             {profileLoading && (
               <div className="flex items-center justify-center p-4 border-2 border-cyan-500/50 bg-cyan-950/20 rounded-md">
                 <Loader2 className="w-4 h-4 animate-spin text-cyan-400 mr-2" />
@@ -185,7 +140,6 @@ function ProfileContent() {
               </div>
             )}
 
-            {/* Email (Read-only) */}
             <div className="space-y-2">
               <Label className={`text-xs font-mono font-bold uppercase ${themeClasses.text}`}>
                 Email Address
@@ -204,7 +158,6 @@ function ProfileContent() {
               </p>
             </div>
 
-            {/* Username */}
             <div className="space-y-2">
               <Label className={`text-xs font-mono font-bold uppercase ${themeClasses.text}`}>
                 Username
@@ -222,7 +175,6 @@ function ProfileContent() {
               </div>
             </div>
 
-            {/* Full Name */}
             <div className="space-y-2">
               <Label className={`text-xs font-mono font-bold uppercase ${themeClasses.text}`}>
                 Full Name
@@ -240,71 +192,6 @@ function ProfileContent() {
               </div>
             </div>
 
-            {/* Default Location */}
-            <div className="space-y-2">
-              <Label className={`text-xs font-mono font-bold uppercase ${themeClasses.text}`}>
-                Default Location
-              </Label>
-              <div className="relative">
-                <MapPin className={`absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 ${themeClasses.mutedText}`} />
-                <Input
-                  type="text"
-                  value={defaultLocation}
-                  onChange={(e) => setDefaultLocation(e.target.value)}
-                  disabled={!editing}
-                  className={`pl-10 font-mono bg-transparent ${themeClasses.borderColor} ${themeClasses.text}`}
-                  placeholder="Enter default location"
-                />
-              </div>
-            </div>
-
-            {/* Location Preferences */}
-            <div className="border-t pt-6 mt-6 space-y-6">
-              <div className="flex items-center space-x-2">
-                <Settings className={`w-5 h-5 ${themeClasses.text}`} />
-                <h3 className={`text-lg font-bold uppercase tracking-wider font-mono ${themeClasses.text}`}>
-                  Preferences
-                </h3>
-              </div>
-
-              {/* Auto-detect Location */}
-              <div className="flex items-center justify-between p-4 border rounded-lg bg-white/5">
-                <div className="space-y-0.5">
-                  <Label className={`text-sm font-mono font-bold uppercase ${themeClasses.text}`}>
-                    Auto-Detect Location
-                  </Label>
-                  <p className={`text-xs font-mono ${themeClasses.mutedText}`}>
-                    Use your current location on startup
-                  </p>
-                </div>
-                <Switch
-                  checked={autoLocation}
-                  onCheckedChange={setAutoLocation}
-                  disabled={!editing}
-                  className={`${autoLocation ? 'bg-green-500' : 'bg-gray-600'}`}
-                />
-              </div>
-
-              {/* Temperature Units */}
-              <div className="space-y-2">
-                <Label className={`text-xs font-mono font-bold uppercase ${themeClasses.text}`}>
-                  Temperature Units
-                </Label>
-                <div className="relative">
-                  <select
-                    value={temperatureUnit}
-                    disabled={!editing}
-                    onChange={(e) => setTemperatureUnit(e.target.value as 'fahrenheit' | 'celsius')}
-                    className={`flex h-10 w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 font-mono ${themeClasses.borderColor} ${themeClasses.text}`}
-                  >
-                    <option value="fahrenheit" className="bg-gray-900">Fahrenheit (°F)</option>
-                    <option value="celsius" className="bg-gray-900">Celsius (°C)</option>
-                  </select>
-                </div>
-              </div>
-            </div>
-
-            {/* Action Buttons */}
             <div className="flex space-x-4 pt-4">
               {!editing ? (
                 <Button
@@ -336,7 +223,6 @@ function ProfileContent() {
                       setEditing(false)
                       setUsername(profile?.username || '')
                       setFullName(profile?.full_name || '')
-                      setDefaultLocation(profile?.default_location || '')
                     }}
                     className={`flex-1 font-mono font-bold uppercase tracking-wider ${themeClasses.borderColor} ${themeClasses.text} hover:bg-white/10`}
                   >

--- a/components/auth/auth-form.tsx
+++ b/components/auth/auth-form.tsx
@@ -17,16 +17,18 @@ import { Alert, AlertDescription } from "@/components/ui/alert"
 
 interface AuthFormProps {
   mode: 'signin' | 'signup'
+  initialError?: string
 }
 
-export default function AuthForm({ mode }: AuthFormProps) {
+export default function AuthForm({ mode, initialError }: AuthFormProps) {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [username, setUsername] = useState('')
   const [fullName, setFullName] = useState('')
   const [showPassword, setShowPassword] = useState(false)
   const [loading, setLoading] = useState(false)
-  const [error, setError] = useState('')
+  const [error, setError] = useState(initialError ?? '')
+  const [success, setSuccess] = useState('')
   const router = useRouter()
   const { theme } = useTheme()
 
@@ -36,6 +38,7 @@ export default function AuthForm({ mode }: AuthFormProps) {
     e.preventDefault()
     setLoading(true)
     setError('')
+    setSuccess('')
 
     try {
       if (mode === 'signin') {
@@ -57,8 +60,7 @@ export default function AuthForm({ mode }: AuthFormProps) {
         if (error) {
           setError(error.message)
         } else {
-          // Show success message for email verification
-          setError('Success! Check your email for a confirmation link.')
+          setSuccess('Check your email for a confirmation link to finish signing up.')
         }
       }
     } catch (err) {
@@ -103,9 +105,17 @@ export default function AuthForm({ mode }: AuthFormProps) {
         </CardHeader>
 
         <CardContent className="space-y-6">
-          {/* Error Message */}
+          {success && (
+            <Alert
+              className="border-2 border-green-500/50 bg-green-950/30 text-green-400 font-mono"
+              data-testid="auth-success-alert"
+            >
+              <AlertDescription>{success}</AlertDescription>
+            </Alert>
+          )}
+
           {error && (
-            <Alert variant="destructive" className="border-2 font-mono">
+            <Alert variant="destructive" className="border-2 font-mono" data-testid="auth-error-alert">
               <AlertDescription>{error}</AlertDescription>
             </Alert>
           )}

--- a/components/auth/auth-form.tsx
+++ b/components/auth/auth-form.tsx
@@ -73,6 +73,8 @@ export default function AuthForm({ mode, initialError }: AuthFormProps) {
   const handleOAuthSignIn = async (provider: 'google' | 'github') => {
     try {
       setLoading(true)
+      setError('')
+      setSuccess('')
       const { error } = await signInWithProvider(provider)
       if (error) {
         setError(error.message)

--- a/components/dashboard/preferences-panel.tsx
+++ b/components/dashboard/preferences-panel.tsx
@@ -1,10 +1,11 @@
 'use client'
 
 import { useEffect, useMemo, useState } from 'react'
-import { Save, Settings, Thermometer, Wind } from 'lucide-react'
+import { Save, Settings, Thermometer, Wind, MapPin, Bell } from 'lucide-react'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Label } from '@/components/ui/label'
+import { Switch } from '@/components/ui/switch'
 import { useTheme } from '@/components/theme-provider'
 import { getComponentStyles, type ThemeType } from '@/lib/theme-utils'
 import { useAuth } from '@/lib/auth'
@@ -34,6 +35,8 @@ export default function PreferencesPanel({ locations }: PreferencesPanelProps) {
   const [temperatureUnit, setTemperatureUnit] = useState<TemperatureUnit>('fahrenheit')
   const [windUnit, setWindUnit] = useState<WindUnit>('mph')
   const [defaultLocation, setDefaultLocation] = useState<string>('')
+  const [autoLocation, setAutoLocation] = useState(false)
+  const [notificationsEnabled, setNotificationsEnabled] = useState(false)
   const [saving, setSaving] = useState(false)
   const [message, setMessage] = useState<string | null>(null)
   const [messageType, setMessageType] = useState<'success' | 'error'>('success')
@@ -43,6 +46,8 @@ export default function PreferencesPanel({ locations }: PreferencesPanelProps) {
     if (preferences) {
       setTemperatureUnit(preferences.temperature_unit)
       setWindUnit(preferences.wind_unit)
+      setAutoLocation(preferences.auto_location)
+      setNotificationsEnabled(preferences.notifications_enabled)
     }
   }, [preferences])
 
@@ -67,9 +72,11 @@ export default function PreferencesPanel({ locations }: PreferencesPanelProps) {
     if (!preferences) return false
     if (temperatureUnit !== preferences.temperature_unit) return true
     if (windUnit !== preferences.wind_unit) return true
+    if (autoLocation !== preferences.auto_location) return true
+    if (notificationsEnabled !== preferences.notifications_enabled) return true
     if ((profile?.default_location ?? '') !== defaultLocation) return true
     return false
-  }, [preferences, profile?.default_location, temperatureUnit, windUnit, defaultLocation])
+  }, [preferences, profile?.default_location, temperatureUnit, windUnit, autoLocation, notificationsEnabled, defaultLocation])
 
   const handleSave = async () => {
     if (!user) return
@@ -80,6 +87,8 @@ export default function PreferencesPanel({ locations }: PreferencesPanelProps) {
       const prefsResult = await updateUserPreferencesAPI({
         temperature_unit: temperatureUnit,
         wind_unit: windUnit,
+        auto_location: autoLocation,
+        notifications_enabled: notificationsEnabled,
       })
 
       if (!prefsResult) {
@@ -126,7 +135,7 @@ export default function PreferencesPanel({ locations }: PreferencesPanelProps) {
           Preferences
         </CardTitle>
         <CardDescription className={`font-mono ${themeClasses.mutedText}`}>
-          Units, default location, and AI personality persist across sessions.
+          Units, default location, and startup behavior persist across sessions.
         </CardDescription>
       </CardHeader>
 
@@ -193,6 +202,43 @@ export default function PreferencesPanel({ locations }: PreferencesPanelProps) {
               </option>
             ))}
           </select>
+        </div>
+
+        {/* Auto-detect Location */}
+        <div className="flex items-center justify-between p-4 border-2 rounded-lg bg-black/20 border-[var(--weather-border)]">
+          <div className="space-y-0.5">
+            <Label className={`flex items-center gap-2 font-mono uppercase tracking-wider ${themeClasses.text}`}>
+              <MapPin className="w-4 h-4" aria-hidden="true" />
+              Auto-Detect Location
+            </Label>
+            <p className={`text-xs font-mono ${themeClasses.mutedText}`}>
+              Use your current location when you open the app
+            </p>
+          </div>
+          <Switch
+            checked={autoLocation}
+            onCheckedChange={setAutoLocation}
+            aria-label="Auto-detect location on startup"
+          />
+        </div>
+
+        {/* Notifications (UI only until Condition Watch ships) */}
+        <div className="flex items-center justify-between p-4 border-2 rounded-lg bg-black/20 border-[var(--weather-border)]">
+          <div className="space-y-0.5">
+            <Label className={`flex items-center gap-2 font-mono uppercase tracking-wider ${themeClasses.text}`}>
+              <Bell className="w-4 h-4" aria-hidden="true" />
+              Weather Notifications
+            </Label>
+            <p className={`text-xs font-mono ${themeClasses.mutedText}`}>
+              Saved for future alert delivery — no emails or push yet
+            </p>
+          </div>
+          <Switch
+            checked={notificationsEnabled}
+            onCheckedChange={setNotificationsEnabled}
+            aria-label="Enable weather notifications"
+            data-testid="notifications-enabled-toggle"
+          />
         </div>
 
         {/* Default Location */}

--- a/components/dashboard/saved-locations-panel.tsx
+++ b/components/dashboard/saved-locations-panel.tsx
@@ -91,8 +91,8 @@ export default function SavedLocationsPanel({
             <p
               className={`text-sm font-mono mb-6 ${themeClasses.text} opacity-75 max-w-sm mx-auto`}
             >
-              Save your favorite weather locations for quick access. Search from the home page
-              and tap the save icon, or add one directly below.
+              Add your first location to unlock quick weather cards and pick a default city.
+              Search from the home page and tap save, or add one directly below.
             </p>
             <div className="flex items-center justify-center gap-3 flex-wrap">
               <Button

--- a/lib/auth/middleware-redirects.ts
+++ b/lib/auth/middleware-redirects.ts
@@ -1,0 +1,8 @@
+import { validateRedirectPath } from '@/lib/utils/redirect-validation'
+
+/**
+ * Where to send an authenticated user who hits /auth/login or /auth/signup.
+ */
+export function resolveAuthenticatedAuthRouteRedirect(nextParam: string | null): string {
+  return validateRedirectPath(nextParam)
+}

--- a/lib/env-validation.ts
+++ b/lib/env-validation.ts
@@ -70,6 +70,30 @@ const envConfig: EnvConfig = {
       name: 'OPENSKY_PASSWORD',
       description: 'OpenSky Network password (optional - paired with OPENSKY_USERNAME).',
     },
+    SUPABASE_WEBHOOK_SECRET: {
+      name: 'SUPABASE_WEBHOOK_SECRET',
+      description: 'Shared secret for Supabase Database Webhook on profiles INSERT (optional - registration admin alerts).',
+    },
+    ADMIN_NOTIFICATION_EMAIL: {
+      name: 'ADMIN_NOTIFICATION_EMAIL',
+      description: 'Inbox for new-user registration admin emails (optional).',
+    },
+    RESEND_API_KEY: {
+      name: 'RESEND_API_KEY',
+      description: 'Resend API key for admin registration emails (optional).',
+    },
+    RESEND_FROM_EMAIL: {
+      name: 'RESEND_FROM_EMAIL',
+      description: 'Verified Resend sender address (optional).',
+    },
+    SLACK_WEBHOOK_URL: {
+      name: 'SLACK_WEBHOOK_URL',
+      description: 'Slack incoming webhook for new signup alerts (optional).',
+    },
+    DISCORD_WEBHOOK_URL: {
+      name: 'DISCORD_WEBHOOK_URL',
+      description: 'Discord webhook for new signup alerts (optional).',
+    },
   },
 };
 

--- a/lib/services/admin-notify-service.ts
+++ b/lib/services/admin-notify-service.ts
@@ -1,0 +1,139 @@
+/**
+ * Admin notification service for new user registrations.
+ * Sends email (Resend) and optional Slack/Discord webhook messages.
+ */
+
+import { Resend } from 'resend'
+
+export interface NewRegistrationPayload {
+  userId: string
+  email: string
+  username: string | null
+  fullName: string | null
+  createdAt: string
+}
+
+const SUPABASE_AUTH_USERS_URL =
+  process.env.NEXT_PUBLIC_SUPABASE_URL != null
+    ? `${process.env.NEXT_PUBLIC_SUPABASE_URL.replace(/\/$/, '')}/project/default/auth/users`
+    : 'https://supabase.com/dashboard/project/_/auth/users'
+
+function buildRegistrationSummary(payload: NewRegistrationPayload): string {
+  const lines = [
+    'New user registered on 16 Bit Weather',
+    '',
+    `Email: ${payload.email}`,
+    `User ID: ${payload.userId}`,
+    `Username: ${payload.username ?? '(none)'}`,
+    `Full name: ${payload.fullName ?? '(none)'}`,
+    `Created: ${payload.createdAt}`,
+    '',
+    `Supabase Auth: ${SUPABASE_AUTH_USERS_URL}`,
+  ]
+  return lines.join('\n')
+}
+
+export async function sendAdminRegistrationEmail(
+  payload: NewRegistrationPayload,
+): Promise<{ sent: boolean; reason?: string }> {
+  const apiKey = process.env.RESEND_API_KEY
+  const fromEmail = process.env.RESEND_FROM_EMAIL
+  const toEmail = process.env.ADMIN_NOTIFICATION_EMAIL
+
+  if (!apiKey || !fromEmail || !toEmail) {
+    return { sent: false, reason: 'Resend or admin email env vars not configured' }
+  }
+
+  const resend = new Resend(apiKey)
+  const body = buildRegistrationSummary(payload)
+
+  const { error } = await resend.emails.send({
+    from: fromEmail,
+    to: toEmail,
+    subject: `[16 Bit Weather] New signup: ${payload.email}`,
+    text: body,
+  })
+
+  if (error) {
+    console.error('[admin-notify] Resend error:', error)
+    return { sent: false, reason: error.message }
+  }
+
+  return { sent: true }
+}
+
+export async function sendSlackRegistrationNotification(
+  payload: NewRegistrationPayload,
+): Promise<{ sent: boolean; reason?: string }> {
+  const webhookUrl = process.env.SLACK_WEBHOOK_URL
+  if (!webhookUrl) {
+    return { sent: false, reason: 'SLACK_WEBHOOK_URL not configured' }
+  }
+
+  const text = [
+    '*New 16 Bit Weather signup*',
+    `Email: ${payload.email}`,
+    `Username: ${payload.username ?? '(none)'}`,
+    `User ID: \`${payload.userId}\``,
+  ].join('\n')
+
+  const response = await fetch(webhookUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ text }),
+  })
+
+  if (!response.ok) {
+    const reason = `Slack webhook returned ${response.status}`
+    console.error('[admin-notify]', reason)
+    return { sent: false, reason }
+  }
+
+  return { sent: true }
+}
+
+export async function sendDiscordRegistrationNotification(
+  payload: NewRegistrationPayload,
+): Promise<{ sent: boolean; reason?: string }> {
+  const webhookUrl = process.env.DISCORD_WEBHOOK_URL
+  if (!webhookUrl) {
+    return { sent: false, reason: 'DISCORD_WEBHOOK_URL not configured' }
+  }
+
+  const content = [
+    '**New 16 Bit Weather signup**',
+    `Email: ${payload.email}`,
+    `Username: ${payload.username ?? '(none)'}`,
+    `User ID: ${payload.userId}`,
+  ].join('\n')
+
+  const response = await fetch(webhookUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ content }),
+  })
+
+  if (!response.ok) {
+    const reason = `Discord webhook returned ${response.status}`
+    console.error('[admin-notify]', reason)
+    return { sent: false, reason }
+  }
+
+  return { sent: true }
+}
+
+export async function notifyNewRegistration(
+  payload: NewRegistrationPayload,
+): Promise<{
+  email: { sent: boolean; reason?: string }
+  slack: { sent: boolean; reason?: string }
+  discord: { sent: boolean; reason?: string }
+}> {
+  const [email, slack, discord] = await Promise.all([
+    sendAdminRegistrationEmail(payload),
+    sendSlackRegistrationNotification(payload),
+    sendDiscordRegistrationNotification(payload),
+  ])
+
+  return { email, slack, discord }
+}

--- a/lib/services/admin-notify-service.ts
+++ b/lib/services/admin-notify-service.ts
@@ -44,22 +44,30 @@ export async function sendAdminRegistrationEmail(
     return { sent: false, reason: 'Resend or admin email env vars not configured' }
   }
 
-  const resend = new Resend(apiKey)
-  const body = buildRegistrationSummary(payload)
+  try {
+    const resend = new Resend(apiKey)
+    const body = buildRegistrationSummary(payload)
 
-  const { error } = await resend.emails.send({
-    from: fromEmail,
-    to: toEmail,
-    subject: `[16 Bit Weather] New signup: ${payload.email}`,
-    text: body,
-  })
+    const { error } = await resend.emails.send({
+      from: fromEmail,
+      to: toEmail,
+      subject: `[16 Bit Weather] New signup: ${payload.email}`,
+      text: body,
+    })
 
-  if (error) {
+    if (error) {
+      console.error('[admin-notify] Resend error:', error)
+      return { sent: false, reason: error.message }
+    }
+
+    return { sent: true }
+  } catch (error) {
     console.error('[admin-notify] Resend error:', error)
-    return { sent: false, reason: error.message }
+    return {
+      sent: false,
+      reason: error instanceof Error ? error.message : 'Resend request failed',
+    }
   }
-
-  return { sent: true }
 }
 
 export async function sendSlackRegistrationNotification(
@@ -77,19 +85,27 @@ export async function sendSlackRegistrationNotification(
     `User ID: \`${payload.userId}\``,
   ].join('\n')
 
-  const response = await fetch(webhookUrl, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ text }),
-  })
+  try {
+    const response = await fetch(webhookUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text }),
+    })
 
-  if (!response.ok) {
-    const reason = `Slack webhook returned ${response.status}`
-    console.error('[admin-notify]', reason)
-    return { sent: false, reason }
+    if (!response.ok) {
+      const reason = `Slack webhook returned ${response.status}`
+      console.error('[admin-notify]', reason)
+      return { sent: false, reason }
+    }
+
+    return { sent: true }
+  } catch (error) {
+    console.error('[admin-notify] Slack error:', error)
+    return {
+      sent: false,
+      reason: error instanceof Error ? error.message : 'Slack request failed',
+    }
   }
-
-  return { sent: true }
 }
 
 export async function sendDiscordRegistrationNotification(
@@ -107,19 +123,41 @@ export async function sendDiscordRegistrationNotification(
     `User ID: ${payload.userId}`,
   ].join('\n')
 
-  const response = await fetch(webhookUrl, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ content }),
-  })
+  try {
+    const response = await fetch(webhookUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content }),
+    })
 
-  if (!response.ok) {
-    const reason = `Discord webhook returned ${response.status}`
-    console.error('[admin-notify]', reason)
-    return { sent: false, reason }
+    if (!response.ok) {
+      const reason = `Discord webhook returned ${response.status}`
+      console.error('[admin-notify]', reason)
+      return { sent: false, reason }
+    }
+
+    return { sent: true }
+  } catch (error) {
+    console.error('[admin-notify] Discord error:', error)
+    return {
+      sent: false,
+      reason: error instanceof Error ? error.message : 'Discord request failed',
+    }
   }
+}
 
-  return { sent: true }
+function settledChannelResult(
+  result: PromiseSettledResult<{ sent: boolean; reason?: string }>,
+  channel: string,
+): { sent: boolean; reason?: string } {
+  if (result.status === 'fulfilled') {
+    return result.value
+  }
+  console.error(`[admin-notify] ${channel} error:`, result.reason)
+  return {
+    sent: false,
+    reason: result.reason instanceof Error ? result.reason.message : `${channel} request failed`,
+  }
 }
 
 export async function notifyNewRegistration(
@@ -129,11 +167,15 @@ export async function notifyNewRegistration(
   slack: { sent: boolean; reason?: string }
   discord: { sent: boolean; reason?: string }
 }> {
-  const [email, slack, discord] = await Promise.all([
+  const [email, slack, discord] = await Promise.allSettled([
     sendAdminRegistrationEmail(payload),
     sendSlackRegistrationNotification(payload),
     sendDiscordRegistrationNotification(payload),
   ])
 
-  return { email, slack, discord }
+  return {
+    email: settledChannelResult(email, 'email'),
+    slack: settledChannelResult(slack, 'slack'),
+    discord: settledChannelResult(discord, 'discord'),
+  }
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,6 +1,8 @@
 import { createServerClient, type CookieOptions } from '@supabase/ssr'
 import { NextResponse, type NextRequest } from 'next/server'
 import { isPlaywrightTestModeRequest } from '@/lib/playwright-test-mode'
+import { validateRedirectPath } from '@/lib/utils/redirect-validation'
+import { resolveAuthenticatedAuthRouteRedirect } from '@/lib/auth/middleware-redirects'
 
 /**
  * Build a Content-Security-Policy for this request.
@@ -50,6 +52,11 @@ export async function middleware(request: NextRequest) {
   })
   response.headers.set('Content-Security-Policy', csp)
 
+  // Legacy URL — redirect before Playwright test-mode bypass so E2E and prod behave the same
+  if (request.nextUrl.pathname.startsWith('/settings')) {
+    return NextResponse.redirect(new URL('/dashboard', request.url))
+  }
+
   // TEST MODE: Skip auth checks during E2E (same rules as API routes — see lib/playwright-test-mode.ts)
 
   if (isPlaywrightTestModeRequest(request)) {
@@ -83,7 +90,8 @@ export async function middleware(request: NextRequest) {
     data: { user },
   } = await supabase.auth.getUser()
 
-  const protectedRoutes = ['/dashboard', '/profile', '/settings', '/saved-locations']
+
+  const protectedRoutes = ['/dashboard', '/profile', '/saved-locations']
   const isProtectedRoute = protectedRoutes.some((route) =>
     request.nextUrl.pathname.startsWith(route)
   )
@@ -100,7 +108,8 @@ export async function middleware(request: NextRequest) {
   )
 
   if (isAuthRoute && user) {
-    return NextResponse.redirect(new URL('/', request.url))
+    const next = resolveAuthenticatedAuthRouteRedirect(request.nextUrl.searchParams.get('next'))
+    return NextResponse.redirect(new URL(next, request.url))
   }
 
   return response

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,7 +1,6 @@
 import { createServerClient, type CookieOptions } from '@supabase/ssr'
 import { NextResponse, type NextRequest } from 'next/server'
 import { isPlaywrightTestModeRequest } from '@/lib/playwright-test-mode'
-import { validateRedirectPath } from '@/lib/utils/redirect-validation'
 import { resolveAuthenticatedAuthRouteRedirect } from '@/lib/auth/middleware-redirects'
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "recharts": "^3.8.1",
         "rehype-sanitize": "^6.0.0",
         "remark-gfm": "^4.0.1",
+        "resend": "^6.16.0",
         "satellite.js": "^7.0.1",
         "tailwind-merge": "^3.6.0",
         "tailwindcss-animate": "^1.0.7",
@@ -6472,6 +6473,12 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -11543,6 +11550,12 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
     },
     "node_modules/fast-xml-builder": {
       "version": "1.2.0",
@@ -18151,6 +18164,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/postal-mime": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.4.tgz",
+      "integrity": "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==",
+      "license": "MIT-0"
+    },
     "node_modules/postcss": {
       "version": "8.5.15",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
@@ -18904,6 +18923,27 @@
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
       "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
       "license": "MIT"
+    },
+    "node_modules/resend": {
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.16.0.tgz",
+      "integrity": "sha512-SaKISwHtxvAxneF84Njgnzg+zdngUu1vOT/paRU1De9QF+zXQR3GnwJHSh+mpJPjUhsGD4WxYi5CfKkXMkDqwg==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.4",
+        "standardwebhooks": "1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
+      }
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -19785,6 +19825,16 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
       }
     },
     "node_modules/statuses": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "recharts": "^3.8.1",
     "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1",
+    "resend": "^6.16.0",
     "satellite.js": "^7.0.1",
     "tailwind-merge": "^3.6.0",
     "tailwindcss-animate": "^1.0.7",

--- a/planning/supabase-pro-upgrade-checklist.md
+++ b/planning/supabase-pro-upgrade-checklist.md
@@ -1,0 +1,44 @@
+# Supabase Pro upgrade checklist
+
+Use this when a Free-tier limit or product requirement makes the $25/mo Pro plan worth it. **Do not upgrade preemptively** at current scale.
+
+## Stay on Free while all of these are true
+
+- Under ~50k monthly active auth users
+- Database under 500 MB
+- Supabase-branded auth emails are acceptable
+- No requirement for daily backups or 7-day auth audit logs
+- Production project receives regular traffic (avoids inactivity pause)
+
+## Upgrade to Pro ($25/mo) when any trigger fires
+
+| Trigger | Why Pro helps |
+|---------|----------------|
+| Branded auth emails | Custom SMTP (`noreply@16bitweather.co`) — not available on Free |
+| Backups / recovery | Daily backups, 7-day retention; Free has none |
+| Auth audit / support | 7-day auth logs vs 1 hour on Free; email support |
+| Database growth | 8 GB vs 500 MB on Free |
+| Staging project always-on | Free dev projects pause after ~1 week idle |
+| Registration alerts are business-critical | Pro adds reliability headroom; webhook itself works on Free |
+
+## After upgrading
+
+1. Leave **Spend Cap ON** (default) until you intentionally want pay-as-you-go overages.
+2. Enable **daily backups** in project settings.
+3. Configure **custom SMTP** for Auth if branded emails were the reason.
+4. Optional: log drain to Sentry for auth failures.
+5. Document the upgrade date and primary trigger in this file or team notes.
+
+## Cost forecast
+
+| Stage | Supabase | Notes |
+|-------|----------|-------|
+| Now (<100 MAU) | $0 Free | Resend free tier for admin signup emails |
+| Growth (1k–10k MAU) | $0 Free or $25 Pro | Upgrade when a trigger above hits |
+| Large (50k+ MAU) | $25 Pro | Auth overage $0.00325/user above 100k on Pro |
+
+## Decision record
+
+- **Keep Supabase** for auth + RLS + user tables — migration cost outweighs benefit today.
+- **Registration notifications** use app-side Resend + Slack/Discord, not a paid Supabase feature.
+- Revisit this checklist quarterly or when launching Condition Watch alert storage.

--- a/planning/supabase-registration-webhook-setup.md
+++ b/planning/supabase-registration-webhook-setup.md
@@ -1,0 +1,46 @@
+# Supabase registration webhook setup
+
+After deploying the `/api/webhooks/new-user` route, configure a Database Webhook in the Supabase Dashboard so you receive email and Slack/Discord alerts when a new profile row is created.
+
+## Prerequisites
+
+Set these environment variables in Vercel (production) and optionally in `.env.local` for testing:
+
+| Variable | Purpose |
+|----------|---------|
+| `SUPABASE_WEBHOOK_SECRET` | Shared secret sent in the `x-webhook-secret` header |
+| `ADMIN_NOTIFICATION_EMAIL` | Your inbox for signup alerts |
+| `RESEND_API_KEY` | Resend API key |
+| `RESEND_FROM_EMAIL` | Verified sender (e.g. `noreply@16bitweather.co`) |
+| `SLACK_WEBHOOK_URL` | Optional Slack incoming webhook |
+| `DISCORD_WEBHOOK_URL` | Optional Discord webhook |
+
+Generate a strong random secret for `SUPABASE_WEBHOOK_SECRET` (e.g. `openssl rand -hex 32`).
+
+## Supabase Dashboard steps
+
+1. Open your **production** Supabase project (not local).
+2. Go to **Database → Webhooks → Create a new hook**.
+3. **Name:** `new-user-registration`
+4. **Table:** `public.profiles`
+5. **Events:** `INSERT` only
+6. **Type:** HTTP Request
+7. **Method:** POST
+8. **URL:** `https://www.16bitweather.co/api/webhooks/new-user`
+9. **HTTP Headers:** add `x-webhook-secret` with the same value as `SUPABASE_WEBHOOK_SECRET` in Vercel.
+10. Save the webhook.
+
+## Why `profiles` and not `auth.users`?
+
+The `handle_new_user()` trigger creates a `profiles` row (and `user_preferences`) after signup. Alerting on `profiles` INSERT means you only get notified when provisioning succeeded — for both email/password and OAuth signups.
+
+## Verification
+
+1. Create a test account on staging or production.
+2. Check Vercel function logs for `[webhooks/new-user]`.
+3. Confirm email/Slack/Discord delivery.
+4. Supabase **Authentication → Users** remains a manual backup view.
+
+## Retries and duplicates
+
+Supabase may retry failed webhook deliveries. Duplicate admin emails on retry are possible; acceptable for low-volume signup alerts. Add an `admin_events` dedupe table later if needed.

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from './fixtures';
-import { setupStableApp, setupMockAuth, isRemotePreviewTarget } from '../fixtures/utils';
+import { setupStableApp, isRemotePreviewTarget } from '../fixtures/utils';
 
 const skipAuthTests = isRemotePreviewTarget();
 
@@ -31,17 +31,12 @@ test.describe('Auth flow', () => {
     // Middleware auth redirect requires a real Supabase session cookie; Playwright test mode
     // bypasses middleware auth checks, so this behavior is covered by manual QA + unit tests.
     test.skip(true, 'Requires real Supabase session; middleware bypassed in Playwright test mode');
-    await setupMockAuth(page);
-    await page.waitForTimeout(200);
     await page.goto('/auth/login', { waitUntil: 'domcontentloaded' });
     await expect(page).toHaveURL(/\/dashboard/, { timeout: 15000 });
   });
 
   test('legacy /settings redirects to dashboard', async ({ page }) => {
-    await setupMockAuth(page);
-    await page.waitForTimeout(200);
     await page.goto('/settings', { waitUntil: 'domcontentloaded' });
-    await page.waitForTimeout(1000);
     await expect(page).toHaveURL(/\/dashboard/, { timeout: 15000 });
   });
 });

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from './fixtures';
+import { setupStableApp, setupMockAuth, isRemotePreviewTarget } from '../fixtures/utils';
+
+const skipAuthTests = isRemotePreviewTarget();
+
+test.describe('Auth flow', () => {
+  test.skip(skipAuthTests, 'Auth mocking not supported against deployed preview URLs');
+
+  test.beforeEach(async ({ page }) => {
+    await setupStableApp(page);
+  });
+
+  test('login page loads and shows sign-in form', async ({ page }) => {
+    await page.goto('/auth/login', { waitUntil: 'domcontentloaded' });
+    await expect(page.getByRole('button', { name: /sign in/i }).first()).toBeVisible({ timeout: 15000 });
+    await expect(page.getByText(/continue with google/i)).toBeVisible();
+  });
+
+  test('signup page loads', async ({ page }) => {
+    await page.goto('/auth/signup', { waitUntil: 'domcontentloaded' });
+    await expect(page.getByRole('button', { name: /sign up/i }).first()).toBeVisible({ timeout: 15000 });
+  });
+
+  test('login page displays OAuth callback errors from query string', async ({ page }) => {
+    await page.goto('/auth/login?error=access_denied', { waitUntil: 'domcontentloaded' });
+    await expect(page.getByTestId('auth-error-alert')).toBeVisible({ timeout: 15000 });
+    await expect(page.getByTestId('auth-error-alert')).toContainText(/access_denied/i);
+  });
+
+  test('logged-in user visiting login redirects to dashboard', async ({ page }) => {
+    // Middleware auth redirect requires a real Supabase session cookie; Playwright test mode
+    // bypasses middleware auth checks, so this behavior is covered by manual QA + unit tests.
+    test.skip(true, 'Requires real Supabase session; middleware bypassed in Playwright test mode');
+    await setupMockAuth(page);
+    await page.waitForTimeout(200);
+    await page.goto('/auth/login', { waitUntil: 'domcontentloaded' });
+    await expect(page).toHaveURL(/\/dashboard/, { timeout: 15000 });
+  });
+
+  test('legacy /settings redirects to dashboard', async ({ page }) => {
+    await setupMockAuth(page);
+    await page.waitForTimeout(200);
+    await page.goto('/settings', { waitUntil: 'domcontentloaded' });
+    await page.waitForTimeout(1000);
+    await expect(page).toHaveURL(/\/dashboard/, { timeout: 15000 });
+  });
+});

--- a/tests/e2e/profile.spec.ts
+++ b/tests/e2e/profile.spec.ts
@@ -9,14 +9,8 @@ test.describe('Profile Settings', () => {
 
   test.beforeEach(async ({ page }) => {
     await setupStableApp(page);
-    
-    // CRITICAL: Set up auth mocking FIRST, before any navigation
     await setupMockAuth(page);
-    
-    // Wait for auth setup to complete
-    await page.waitForTimeout(200);
-    
-    // Mock profile data
+
     await stubSupabaseProfile(page, {
       id: '00000000-0000-0000-0000-000000000000',
       username: 'testuser',
@@ -24,84 +18,68 @@ test.describe('Profile Settings', () => {
       default_location: 'New York, NY',
       email: 'test@example.com'
     });
-    
+
     await stubProfileUpdate(page);
   });
 
   test('can navigate to profile page', async ({ page }) => {
     await navigateToProfile(page);
-    // Wait a bit for auth check to complete
-    await page.waitForTimeout(1000);
-    // Profile page should load (not redirect to login)
-    const url = page.url();
-    expect(url).toMatch(/\/profile/);
+    await expect(page).toHaveURL(/\/profile/);
   });
 
   test('displays current profile information', async ({ page }) => {
     await navigateToProfile(page);
-    await page.waitForTimeout(1000);
-    
-    // Wait for page to load and check for profile content
-    // The page might show loading state initially
-    await expect(page.locator('body')).toContainText(/(profile|settings|testuser|Test User|New York)/i, { timeout: 15000 });
+    await expect(page.locator('body')).toContainText(/(profile|settings|testuser|Test User)/i, { timeout: 15000 });
   });
 
   test('can edit profile fields', async ({ page }) => {
     await navigateToProfile(page);
-    await page.waitForTimeout(2000); // Wait for auth and profile to load
-    
-    // Find and click Edit Profile button
+
     const editButton = page.getByTestId('profile-edit-button');
     await expect(editButton).toBeVisible({ timeout: 10000 });
     await editButton.click();
-    
-    // Wait for edit mode - look for Save Changes button
+
     await expect(page.locator('button').filter({ hasText: /save changes/i })).toBeVisible({ timeout: 5000 });
-    
-    // Fill form fields
+
     await fillProfileForm(page, {
       username: 'updateduser',
       fullName: 'Updated Name',
     });
-    
-    // Verify fields were filled
+
     const usernameInput = page.locator('input[placeholder*="username" i]').first();
-    await expect(usernameInput).toBeVisible({ timeout: 5000 });
     await expect(usernameInput).toHaveValue(/updateduser/i);
   });
 
   test('can save profile changes', async ({ page }) => {
     await navigateToProfile(page);
-    await page.waitForTimeout(2000);
-    
+
     const editButton = page.getByTestId('profile-edit-button');
     await expect(editButton).toBeVisible({ timeout: 10000 });
     await editButton.click();
-    
+
     await expect(page.locator('button').filter({ hasText: /save changes/i })).toBeVisible({ timeout: 5000 });
-    
+
     await fillProfileForm(page, {
       username: 'saveduser'
     });
-    
+
     await saveProfile(page);
-    
+
     await expect(page.locator('body')).toContainText(/success|saved|updated/i, { timeout: 10000 });
   });
 
   test('stays on profile after saving', async ({ page }) => {
     await navigateToProfile(page);
-    await page.waitForTimeout(2000);
-    
+
     const editButton = page.getByTestId('profile-edit-button');
     await expect(editButton).toBeVisible({ timeout: 10000 });
     await editButton.click();
-    
+
     await expect(page.locator('button').filter({ hasText: /save changes/i })).toBeVisible({ timeout: 5000 });
-    
+
     await fillProfileForm(page, { username: 'stayonprofile' });
     await saveProfile(page);
-    
+
     await expect(page.locator('body')).toContainText(/success|saved|updated/i, { timeout: 10000 });
     await expect(page).toHaveURL(/\/profile/, { timeout: 5000 });
   });
@@ -114,7 +92,6 @@ test.describe('Profile Settings', () => {
   // for the test user. Error-handler coverage lives in
   // __tests__/sentry-profile-nil-uuid.test.ts instead.
   test.skip('displays error message on save failure', async ({ page }) => {
-    // Stub a failing Supabase update
     await page.route('**/rest/v1/profiles**', (route) => {
       if (route.request().method() === 'PATCH') {
         return route.fulfill({
@@ -127,19 +104,16 @@ test.describe('Profile Settings', () => {
     });
 
     await navigateToProfile(page);
-    await page.waitForTimeout(2000);
-    
+
     const editButton = page.getByTestId('profile-edit-button');
     await expect(editButton).toBeVisible({ timeout: 10000 });
     await editButton.click();
-    
+
     await expect(page.locator('button').filter({ hasText: /save changes/i })).toBeVisible({ timeout: 5000 });
-    
+
     await fillProfileForm(page, { username: 'failtest' });
     await saveProfile(page);
-    
-    // Verify error message appears
+
     await expect(page.locator('body')).toContainText(/error|failed|try again/i, { timeout: 10000 });
   });
 });
-

--- a/tests/e2e/profile.spec.ts
+++ b/tests/e2e/profile.spec.ts
@@ -62,7 +62,6 @@ test.describe('Profile Settings', () => {
     await fillProfileForm(page, {
       username: 'updateduser',
       fullName: 'Updated Name',
-      defaultLocation: 'Los Angeles, CA'
     });
     
     // Verify fields were filled
@@ -75,44 +74,36 @@ test.describe('Profile Settings', () => {
     await navigateToProfile(page);
     await page.waitForTimeout(2000);
     
-    // Enter edit mode
     const editButton = page.getByTestId('profile-edit-button');
     await expect(editButton).toBeVisible({ timeout: 10000 });
     await editButton.click();
     
-    // Wait for edit mode
     await expect(page.locator('button').filter({ hasText: /save changes/i })).toBeVisible({ timeout: 5000 });
     
-    // Fill form fields
     await fillProfileForm(page, {
       username: 'saveduser'
     });
     
-    // Save
     await saveProfile(page);
     
-    // Verify success message appears
-    await expect(page.locator('body')).toContainText(/success|saved|updated|redirecting/i, { timeout: 10000 });
+    await expect(page.locator('body')).toContainText(/success|saved|updated/i, { timeout: 10000 });
   });
 
-  test('redirects to dashboard after saving', async ({ page }) => {
+  test('stays on profile after saving', async ({ page }) => {
     await navigateToProfile(page);
     await page.waitForTimeout(2000);
     
-    // Enter edit mode
     const editButton = page.getByTestId('profile-edit-button');
     await expect(editButton).toBeVisible({ timeout: 10000 });
     await editButton.click();
     
-    // Wait for edit mode
     await expect(page.locator('button').filter({ hasText: /save changes/i })).toBeVisible({ timeout: 5000 });
     
-    // Fill and save
-    await fillProfileForm(page, { username: 'redirecttest' });
+    await fillProfileForm(page, { username: 'stayonprofile' });
     await saveProfile(page);
     
-    // Wait for redirect (with delay for success message - 1.5s + buffer)
-    await expect(page).toHaveURL('/dashboard', { timeout: 10000 });
+    await expect(page.locator('body')).toContainText(/success|saved|updated/i, { timeout: 10000 });
+    await expect(page).toHaveURL(/\/profile/, { timeout: 5000 });
   });
 
   // Skipped: untestable as written. The mock auth session uses NULL_UUID,


### PR DESCRIPTION
## Summary

- **Auth flow:** Signup shows a green success alert; login reads OAuth/callback `?error=`; logged-in users on `/auth/*` redirect to `/dashboard`; `/settings` redirects to dashboard.
- **Dashboard/profile:** Profile is identity-only (email, username, full name); units, default location, auto-location, and notifications toggle live on the dashboard; profile no longer auto-redirects after save.
- **Registration alerts:** Secured `POST /api/webhooks/new-user` on `profiles` INSERT with Resend email plus optional Slack/Discord webhooks; setup docs in `planning/supabase-registration-webhook-setup.md`.

## Test plan

- [x] Unit: `auth-form`, `new-user-webhook`, `middleware-auth-redirects`, `preferences-panel`
- [x] `npm run typecheck`
- [x] Playwright: `tests/e2e/auth.spec.ts`, `tests/e2e/profile.spec.ts` (9 passed, 2 skipped)
- [ ] CI lint + build + Jest on GitHub Actions
- [ ] E2E + Lighthouse CI workflows on PR

## Post-merge manual steps

1. Set Vercel env vars: `SUPABASE_WEBHOOK_SECRET`, `DISCORD_WEBHOOK_URL` (and optional Resend/Slack vars).
2. Create Supabase Database Webhook on `public.profiles` INSERT → `https://www.16bitweather.co/api/webhooks/new-user` with header `x-webhook-secret`.
3. Confirm Supabase Auth redirect URLs include `/auth/reset-password`.

## Discord setup

Create a webhook in channel `1465900690072404072`, copy the webhook URL into `DISCORD_WEBHOOK_URL` in Vercel, redeploy, then test with a signup.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added admin registration alert notifications for new user signups, delivered via email and optional Slack/Discord.
  * Improved authentication UI with success/error alerts, seeded login errors, and clearer feedback.
  * Updated dashboard preferences to include auto-detect location and weather notifications.
* **Bug Fixes**
  * Improved redirect behavior for authenticated and legacy `/settings` routes to prevent unsafe destinations.
  * Profile editing now stays on the profile page after saving.
* **Documentation**
  * Added webhook-based registration alert setup guidance and a Supabase upgrade checklist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->