### PR TITLE
feat(education): refresh hub, glossary, detail pages, and cloud lab

### DIFF
--- a/__tests__/cloud-altitude-quiz.test.ts
+++ b/__tests__/cloud-altitude-quiz.test.ts
@@ -1,0 +1,18 @@
+import {
+  CLOUD_QUIZ_QUESTIONS,
+  isCorrectCloudLayer,
+} from '@/components/education/cloud-altitude-stack'
+
+describe('cloud altitude quiz', () => {
+  it('validates layer answers for each question', () => {
+    for (const question of CLOUD_QUIZ_QUESTIONS) {
+      expect(isCorrectCloudLayer(question, question.layer)).toBe(true)
+      expect(isCorrectCloudLayer(question, 'high')).toBe(question.layer === 'high')
+    }
+  })
+
+  it('includes four distinct cloud prompts', () => {
+    expect(CLOUD_QUIZ_QUESTIONS).toHaveLength(4)
+    expect(new Set(CLOUD_QUIZ_QUESTIONS.map((q) => q.id)).size).toBe(4)
+  })
+})

--- a/__tests__/education-entries.test.ts
+++ b/__tests__/education-entries.test.ts
@@ -1,0 +1,50 @@
+import {
+  FEATURED_DETAIL_SLUGS,
+  countEncyclopediaEntries,
+  getCloudBySlug,
+  getEducationDetailHref,
+  getPhenomenonBySlug,
+  getWeatherSystemBySlug,
+} from '@/lib/education/entries'
+import { cloudDatabase } from '@/data/cloud-types'
+import { weatherPhenomena } from '@/data/fun-facts'
+import { weatherSystemsDatabase } from '@/data/weather-systems'
+
+describe('education entries', () => {
+  it('counts encyclopedia entries from all databases', () => {
+    const expected =
+      weatherSystemsDatabase.length + cloudDatabase.length + weatherPhenomena.length
+    expect(countEncyclopediaEntries()).toBe(expected)
+  })
+
+  it('resolves featured weather system slugs', () => {
+    expect(getWeatherSystemBySlug('cyclones')?.name).toBe('CYCLONES')
+    expect(getWeatherSystemBySlug('jet-streams')?.name).toBe('JET STREAMS')
+  })
+
+  it('resolves featured cloud slugs', () => {
+    expect(getCloudBySlug('cumulonimbus')?.name).toBe('CUMULONIMBUS')
+    expect(getCloudBySlug('lenticular')?.name).toBe('LENTICULAR')
+  })
+
+  it('resolves featured phenomenon slugs', () => {
+    expect(getPhenomenonBySlug('thundersnow')?.name).toBe('Thundersnow')
+    expect(getPhenomenonBySlug('ball-lightning')?.name).toBe('Ball Lightning')
+  })
+
+  it('builds detail hrefs under /education', () => {
+    expect(getEducationDetailHref('weather-system', 'cyclones')).toBe(
+      '/education/weather-systems/cyclones',
+    )
+    expect(getEducationDetailHref('cloud', 'cirrus')).toBe('/education/cloud-types/cirrus')
+    expect(getEducationDetailHref('phenomenon', 'haboob')).toBe('/education/phenomena/haboob')
+  })
+
+  it('defines exactly 20 featured detail pages', () => {
+    const total =
+      FEATURED_DETAIL_SLUGS['weather-system'].length +
+      FEATURED_DETAIL_SLUGS.cloud.length +
+      FEATURED_DETAIL_SLUGS.phenomenon.length
+    expect(total).toBe(20)
+  })
+})

--- a/__tests__/education-hub-security.test.ts
+++ b/__tests__/education-hub-security.test.ts
@@ -1,0 +1,23 @@
+import { decodeHtmlEntities } from '@/lib/services/rss/html-utils'
+import { validateRedirectPath } from '@/lib/utils/redirect-validation'
+
+describe('education hub security', () => {
+  it('strips HTML from blog display fields before render', () => {
+    const malicious = '<script>alert(1)</script>Storm Report'
+    expect(decodeHtmlEntities(malicious)).toBe('alert(1)Storm Report')
+    expect(decodeHtmlEntities(malicious)).not.toContain('<')
+    expect(decodeHtmlEntities(malicious)).not.toContain('>')
+  })
+
+  it('allows only shipped education detail redirect paths', () => {
+    expect(validateRedirectPath('/education/glossary')).toBe('/education/glossary')
+    expect(validateRedirectPath('/education/weather-systems/cyclones')).toBe(
+      '/education/weather-systems/cyclones',
+    )
+    expect(validateRedirectPath('/education/cloud-types/cirrus')).toBe('/education/cloud-types/cirrus')
+    expect(validateRedirectPath('/education/phenomena/thundersnow')).toBe(
+      '/education/phenomena/thundersnow',
+    )
+    expect(validateRedirectPath('/education/fake/evil')).toBe('/dashboard')
+  })
+})

--- a/__tests__/sitemap-seo.test.ts
+++ b/__tests__/sitemap-seo.test.ts
@@ -86,15 +86,25 @@ describe('Sitemap SEO', () => {
     expect(sitemapPaths.some((p) => p.startsWith('/stargazer/objects/'))).toBe(true)
   })
 
-  it('sitemap should include education detail guide pages', async () => {
+  it('sitemap should include all featured education detail guide pages', async () => {
+    const { FEATURED_DETAIL_SLUGS, getEducationDetailHref } = await import('@/lib/education/entries')
     const { default: sitemap } = await import('../app/sitemap')
     const entries = await sitemap()
     const sitemapPaths = entries.map((e: { url: string }) => {
       try { return new URL(e.url).pathname } catch { return e.url }
     })
 
-    expect(sitemapPaths).toContain('/education/weather-systems/cyclones')
-    expect(sitemapPaths).toContain('/education/cloud-types/cirrus')
-    expect(sitemapPaths).toContain('/education/phenomena/thundersnow')
+    const expectedPaths = [
+      ...FEATURED_DETAIL_SLUGS['weather-system'].map((slug) =>
+        getEducationDetailHref('weather-system', slug),
+      ),
+      ...FEATURED_DETAIL_SLUGS.cloud.map((slug) => getEducationDetailHref('cloud', slug)),
+      ...FEATURED_DETAIL_SLUGS.phenomenon.map((slug) => getEducationDetailHref('phenomenon', slug)),
+    ]
+
+    expect(expectedPaths).toHaveLength(20)
+    for (const path of expectedPaths) {
+      expect(sitemapPaths).toContain(path)
+    }
   })
 })

--- a/__tests__/sitemap-seo.test.ts
+++ b/__tests__/sitemap-seo.test.ts
@@ -85,4 +85,16 @@ describe('Sitemap SEO', () => {
     expect(sitemapPaths).toContain('/stargazer')
     expect(sitemapPaths.some((p) => p.startsWith('/stargazer/objects/'))).toBe(true)
   })
+
+  it('sitemap should include education detail guide pages', async () => {
+    const { default: sitemap } = await import('../app/sitemap')
+    const entries = await sitemap()
+    const sitemapPaths = entries.map((e: { url: string }) => {
+      try { return new URL(e.url).pathname } catch { return e.url }
+    })
+
+    expect(sitemapPaths).toContain('/education/weather-systems/cyclones')
+    expect(sitemapPaths).toContain('/education/cloud-types/cirrus')
+    expect(sitemapPaths).toContain('/education/phenomena/thundersnow')
+  })
 })

--- a/__tests__/weather-concepts.test.ts
+++ b/__tests__/weather-concepts.test.ts
@@ -1,0 +1,20 @@
+import { getAllConcepts, getConceptDefinition } from '@/lib/weather-concepts'
+
+describe('weather concepts glossary', () => {
+  it('includes blog-linked concept anchors', () => {
+    expect(getConceptDefinition('supercell')?.name).toBe('Supercell')
+    expect(getConceptDefinition('cape')?.name).toBe('CAPE')
+    expect(getConceptDefinition('mesocyclone')).toBeDefined()
+    expect(getConceptDefinition('wind-shear')).toBeDefined()
+    expect(getConceptDefinition('updraft')).toBeDefined()
+  })
+
+  it('returns stable ids for glossary hash links', () => {
+    for (const concept of getAllConcepts()) {
+      expect(concept.id).toBeTruthy()
+      expect(concept.detailed.length).toBeGreaterThan(20)
+      expect(concept.ranges.length).toBeGreaterThan(0)
+      expect(concept.practicalTips.length).toBeGreaterThan(0)
+    }
+  })
+})

--- a/app/cloud-types/page.tsx
+++ b/app/cloud-types/page.tsx
@@ -18,6 +18,8 @@
 import React, { useState } from "react"
 import { useTheme } from "next-themes"
 import PageWrapper from "@/components/page-wrapper"
+import EducationBreadcrumb from "@/components/education/education-breadcrumb"
+import EducationBackLink from "@/components/education/education-back-link"
 import { getComponentStyles, type ThemeType } from "@/lib/theme-utils"
 
 // Shadcn UI components
@@ -113,6 +115,13 @@ export default function CloudTypesPage() {
   return (
     <PageWrapper>
       <div className="container mx-auto px-4 py-8">
+        <EducationBreadcrumb
+          items={[
+            { label: 'Education', href: '/education' },
+            { label: 'Cloud Atlas' },
+          ]}
+        />
+        <EducationBackLink />
         {/* Achievement Notification */}
         {achievementUnlocked && (
           <Card className={`fixed top-4 right-4 z-50 container-primary ${themeClasses.glow}`}>

--- a/app/education/cloud-types/[slug]/page.tsx
+++ b/app/education/cloud-types/[slug]/page.tsx
@@ -1,0 +1,44 @@
+import type { Metadata } from 'next'
+import { notFound } from 'next/navigation'
+import CloudDetail from '@/components/education/cloud-detail'
+import {
+  FEATURED_DETAIL_SLUGS,
+  getCloudBySlug,
+  getEducationDetailHref,
+} from '@/lib/education/entries'
+
+interface PageProps {
+  params: Promise<{ slug: string }>
+}
+
+export function generateStaticParams() {
+  return FEATURED_DETAIL_SLUGS.cloud.map((slug) => ({ slug }))
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { slug } = await params
+  const cloud = getCloudBySlug(slug)
+  if (!cloud) return { title: 'Cloud Type Not Found' }
+
+  const url = `https://www.16bitweather.co${getEducationDetailHref('cloud', slug)}`
+  const title = `${cloud.name} — Cloud Atlas`
+
+  return {
+    title: `${title} | 16 Bit Weather`,
+    description: cloud.description16bit,
+    alternates: { canonical: url },
+    openGraph: {
+      title,
+      description: cloud.weatherPrediction,
+      url,
+      type: 'article',
+    },
+  }
+}
+
+export default async function CloudDetailPage({ params }: PageProps) {
+  const { slug } = await params
+  const cloud = getCloudBySlug(slug)
+  if (!cloud) notFound()
+  return <CloudDetail cloud={cloud} />
+}

--- a/app/education/glossary/page.tsx
+++ b/app/education/glossary/page.tsx
@@ -1,22 +1,15 @@
 "use client"
 
-/**
- * Weather Glossary Page
- *
- * In-depth definitions of all weather metrics displayed on the dashboard.
- * Each section explains what the metric is, how it's measured, what values mean,
- * and practical tips for everyday use.
- */
-
 import React from "react"
-import Link from "next/link"
-import { useTheme } from "next-themes"
 import PageWrapper from "@/components/page-wrapper"
+import { useTheme } from "next-themes"
 import { getComponentStyles, type ThemeType } from "@/lib/theme-utils"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Badge } from "@/components/ui/badge"
+import { Card, CardContent } from "@/components/ui/card"
 import { cn } from "@/lib/utils"
 import { getAllMetrics } from "@/lib/weather-definitions"
+import { getAllConcepts } from "@/lib/weather-concepts"
+import EducationBreadcrumb from "@/components/education/education-breadcrumb"
+import { GlossaryEntryCard } from "@/components/education/glossary-entry-card"
 import {
   Sun,
   Droplets,
@@ -28,214 +21,146 @@ import {
   Leaf,
   Sunrise,
   Moon,
-  ArrowLeft,
-  Lightbulb,
-  Ruler,
-  BarChart3,
+  Zap,
   type LucideIcon,
 } from "lucide-react"
 
 const METRIC_ICONS: Record<string, LucideIcon> = {
   'uv-index': Sun,
-  'humidity': Droplets,
-  'pressure': Gauge,
-  'wind': Wind,
-  'visibility': Eye,
+  humidity: Droplets,
+  pressure: Gauge,
+  wind: Wind,
+  visibility: Eye,
   'feels-like': Thermometer,
-  'precipitation': CloudRain,
-  'pollen': Leaf,
+  precipitation: CloudRain,
+  pollen: Leaf,
   'sun-times': Sunrise,
   'moon-phase': Moon,
+}
+
+const CONCEPT_ICONS: Record<string, LucideIcon> = {
+  supercell: Zap,
+  cape: Zap,
+  mesocyclone: Wind,
+  'wind-shear': Wind,
+  updraft: CloudRain,
+  'dew-point': Droplets,
+}
+
+function JumpNav({
+  title,
+  items,
+  icons,
+}: {
+  title: string
+  items: { id: string; name: string }[]
+  icons: Record<string, LucideIcon>
+}) {
+  const { theme } = useTheme()
+  const themeClasses = getComponentStyles((theme || 'nord') as ThemeType, 'weather')
+
+  return (
+    <div className="mb-6">
+      <p className={cn('text-xs font-mono uppercase tracking-widest mb-3', themeClasses.text)}>{title}</p>
+      <div className="flex flex-wrap gap-2">
+        {items.map((item) => {
+          const Icon = icons[item.id]
+          return (
+            <a
+              key={item.id}
+              href={`#${item.id}`}
+              className={cn(
+                'inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-mono font-medium transition-colors',
+                'border border-primary/20 hover:border-primary/60 hover:bg-primary/10',
+              )}
+            >
+              {Icon && <Icon size={12} />}
+              {item.name}
+            </a>
+          )
+        })}
+      </div>
+    </div>
+  )
 }
 
 export default function GlossaryPage() {
   const { theme } = useTheme()
   const themeClasses = getComponentStyles((theme || 'nord') as ThemeType, 'weather')
   const metrics = getAllMetrics()
+  const concepts = getAllConcepts()
 
   return (
     <PageWrapper>
-      <div className={cn("container mx-auto px-4 py-8", themeClasses.background)}>
-        {/* Back link */}
-        <Link
-          href="/education"
-          className={cn(
-            "inline-flex items-center gap-1.5 text-sm font-mono mb-6 hover:underline transition-colors",
-            themeClasses.accentText
-          )}
-        >
-          <ArrowLeft size={14} />
-          Back to Education Hub
-        </Link>
+      <div className={cn('container mx-auto px-4 py-8', themeClasses.background)}>
+        <EducationBreadcrumb
+          items={[
+            { label: 'Education', href: '/education' },
+            { label: 'Weather Glossary' },
+          ]}
+        />
 
-        {/* Header */}
         <div className="mb-10">
           <h1
             className={cn(
-              "text-4xl sm:text-5xl md:text-6xl font-extrabold mb-4 font-mono",
+              'text-4xl sm:text-5xl md:text-6xl font-extrabold mb-4 font-mono',
               themeClasses.accentText,
-              themeClasses.glow
+              themeClasses.glow,
             )}
           >
             WEATHER GLOSSARY
           </h1>
-          <p className={cn("text-base sm:text-lg font-mono max-w-3xl", themeClasses.text)}>
-            Understand every weather metric on your dashboard. Each entry explains what the measurement
-            means, how it&apos;s calculated, what the values indicate, and practical tips you can use every day.
+          <p className={cn('text-base sm:text-lg font-mono max-w-3xl', themeClasses.text)}>
+            Dashboard metrics and storm-spotter concepts in one reference. Each entry explains what it
+            means, how it is measured, what values indicate, and practical tips you can use every day.
           </p>
         </div>
 
-        {/* Quick Navigation */}
-        <Card className={cn("container-nested mb-10", themeClasses.background)}>
+        <Card className={cn('container-nested mb-10', themeClasses.background)}>
           <CardContent className="p-4">
-            <p className={cn("text-xs font-mono uppercase tracking-widest mb-3", themeClasses.text)}>
-              Jump to metric
-            </p>
-            <div className="flex flex-wrap gap-2">
-              {metrics.map((metric) => {
-                const Icon = METRIC_ICONS[metric.id]
-                return (
-                  <a
-                    key={metric.id}
-                    href={`#${metric.id}`}
-                    className={cn(
-                      "inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-mono font-medium transition-colors",
-                      "border border-primary/20 hover:border-primary/60 hover:bg-primary/10"
-                    )}
-                  >
-                    {Icon && <Icon size={12} />}
-                    {metric.name}
-                  </a>
-                )
-              })}
-            </div>
+            <JumpNav title="Dashboard metrics" items={metrics} icons={METRIC_ICONS} />
+            <JumpNav title="Meteorology concepts" items={concepts} icons={CONCEPT_ICONS} />
           </CardContent>
         </Card>
 
-        {/* Metric Sections */}
-        <div className="space-y-8">
-          {metrics.map((metric) => {
-            const Icon = METRIC_ICONS[metric.id]
-            return (
-              <section
-                key={metric.id}
-                id={metric.id}
-                className="scroll-mt-24"
-              >
-                <Card className="weather-card-gradient border-0 border-t-2 border-t-primary/40 shadow-md">
-                  <CardHeader className="pb-4 pt-6 px-6">
-                    <CardTitle className={cn(
-                      "text-xl sm:text-2xl font-bold tracking-wide uppercase flex items-center gap-3 font-mono",
-                      themeClasses.headerText
-                    )}>
-                      {Icon && <Icon size={22} className="text-primary" />}
-                      {metric.name}
-                    </CardTitle>
-                  </CardHeader>
-                  <CardContent className="px-6 pb-6 space-y-6">
-                    {/* What is it? */}
-                    <div>
-                      <h3 className={cn(
-                        "text-sm font-bold uppercase tracking-widest mb-2 flex items-center gap-2 font-mono",
-                        themeClasses.accentText
-                      )}>
-                        <BarChart3 size={14} />
-                        What is it?
-                      </h3>
-                      <p className={cn("text-sm leading-relaxed", themeClasses.text)}>
-                        {metric.detailed}
-                      </p>
-                    </div>
+        <div className="space-y-10">
+          <div>
+            <h2 className={cn('text-2xl font-bold font-mono uppercase mb-6', themeClasses.headerText)}>
+              Dashboard Metrics
+            </h2>
+            <div className="space-y-8">
+              {metrics.map((metric) => (
+                <GlossaryEntryCard
+                  key={metric.id}
+                  metric={metric}
+                  icon={METRIC_ICONS[metric.id]}
+                />
+              ))}
+            </div>
+          </div>
 
-                    {/* How is it measured? */}
-                    <div>
-                      <h3 className={cn(
-                        "text-sm font-bold uppercase tracking-widest mb-2 flex items-center gap-2 font-mono",
-                        themeClasses.accentText
-                      )}>
-                        <Ruler size={14} />
-                        How is it measured?
-                      </h3>
-                      <p className={cn("text-sm leading-relaxed", themeClasses.text)}>
-                        {metric.howMeasured}
-                      </p>
-                    </div>
-
-                    {/* Value Ranges */}
-                    <div>
-                      <h3 className={cn(
-                        "text-sm font-bold uppercase tracking-widest mb-3 flex items-center gap-2 font-mono",
-                        themeClasses.accentText
-                      )}>
-                        <BarChart3 size={14} />
-                        What do the values mean?
-                      </h3>
-                      <div className="grid gap-2">
-                        {metric.ranges.map((range) => (
-                          <div
-                            key={range.label}
-                            className={cn(
-                              "flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-4 p-3 rounded-lg",
-                              "bg-background/50 border border-primary/10"
-                            )}
-                          >
-                            <div className="flex items-center gap-2 sm:min-w-[160px]">
-                              <Badge
-                                variant="outline"
-                                className="border-primary/30 font-mono text-xs"
-                              >
-                                {range.label}
-                              </Badge>
-                              <span className={cn("text-xs font-mono tabular-nums", themeClasses.accentText)}>
-                                {range.range}
-                              </span>
-                            </div>
-                            <p className={cn("text-xs leading-relaxed", themeClasses.text)}>
-                              {range.description}
-                            </p>
-                          </div>
-                        ))}
-                      </div>
-                    </div>
-
-                    {/* Practical Tips */}
-                    <div>
-                      <h3 className={cn(
-                        "text-sm font-bold uppercase tracking-widest mb-3 flex items-center gap-2 font-mono",
-                        themeClasses.accentText
-                      )}>
-                        <Lightbulb size={14} />
-                        Practical Tips
-                      </h3>
-                      <ul className="space-y-2">
-                        {metric.practicalTips.map((tip, i) => (
-                          <li
-                            key={i}
-                            className={cn(
-                              "flex items-start gap-2 text-sm leading-relaxed",
-                              themeClasses.text
-                            )}
-                          >
-                            <span className="text-primary mt-0.5 font-bold">&#x203A;</span>
-                            {tip}
-                          </li>
-                        ))}
-                      </ul>
-                    </div>
-                  </CardContent>
-                </Card>
-              </section>
-            )
-          })}
+          <div>
+            <h2 className={cn('text-2xl font-bold font-mono uppercase mb-6', themeClasses.headerText)}>
+              Meteorology Concepts
+            </h2>
+            <div className="space-y-8">
+              {concepts.map((concept) => (
+                <GlossaryEntryCard
+                  key={concept.id}
+                  metric={concept}
+                  icon={CONCEPT_ICONS[concept.id]}
+                />
+              ))}
+            </div>
+          </div>
         </div>
 
-        {/* Back to top */}
         <div className="text-center mt-10">
           <a
             href="#"
             className={cn(
-              "inline-flex items-center gap-2 px-4 py-2 text-xs font-mono font-bold rounded transition-colors",
-              themeClasses.accentBg
+              'inline-flex items-center gap-2 px-4 py-2 text-xs font-mono font-bold rounded transition-colors',
+              themeClasses.accentBg,
             )}
           >
             Back to top

--- a/app/education/page.tsx
+++ b/app/education/page.tsx
@@ -1,15 +1,25 @@
 import { getAllPosts } from '@/lib/blog'
 import EducationHubClient from '@/components/education/education-hub-client'
+import { decodeHtmlEntities } from '@/lib/services/rss/html-utils'
+
+function formatPostDate(date: string): string {
+  return new Date(date).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    timeZone: 'UTC',
+  })
+}
 
 export default function EducationPage() {
   const latestPosts = getAllPosts()
     .slice(0, 3)
     .map((post) => ({
       slug: post.slug,
-      title: post.title,
-      summary: post.summary,
-      date: post.date,
-      href: `/blog/${post.slug}`,
+      title: decodeHtmlEntities(post.title),
+      summary: decodeHtmlEntities(post.summary),
+      displayDate: formatPostDate(post.date),
+      href: `/blog/${encodeURIComponent(post.slug)}`,
     }))
 
   return <EducationHubClient latestPosts={latestPosts} />

--- a/app/education/page.tsx
+++ b/app/education/page.tsx
@@ -1,140 +1,16 @@
-/**
- * 16-Bit Weather Platform - Education Hub Page
- *
- * Copyright (C) 2025 16-Bit Weather
- * Licensed under Fair Source License, Version 0.9
- *
- * Consolidated hub for all educational weather content
- */
-
-'use client';
-
-import React from 'react';
-import { Cloud, Zap, BookOpen, Thermometer, BookMarked } from 'lucide-react';
-import { cn } from '@/lib/utils';
-import { useTheme } from '@/components/theme-provider';
-import { getComponentStyles, type ThemeType } from '@/lib/theme-utils';
-import PageWrapper from '@/components/page-wrapper';
-import LearningCard from '@/components/learn/LearningCard';
-import { Card, CardContent } from '@/components/ui/card';
-import { ShareButtons } from '@/components/share-buttons';
+import { getAllPosts } from '@/lib/blog'
+import EducationHubClient from '@/components/education/education-hub-client'
 
 export default function EducationPage() {
-  const { theme } = useTheme();
-  const themeClasses = getComponentStyles((theme || 'nord') as ThemeType, 'weather');
+  const latestPosts = getAllPosts()
+    .slice(0, 3)
+    .map((post) => ({
+      slug: post.slug,
+      title: post.title,
+      summary: post.summary,
+      date: post.date,
+      href: `/blog/${post.slug}`,
+    }))
 
-  const educationTopics = [
-    {
-      href: '/weather-systems',
-      icon: Zap,
-      title: 'Weather Systems',
-      description: 'Analyze the atmospheric dynamics of 16 major storm types with historical case studies and threat levels.',
-      itemCount: 16
-    },
-    {
-      href: '/cloud-types',
-      icon: Cloud,
-      title: 'Cloud Atlas',
-      description: 'Comprehensive cloud database covering genera, species, varieties, and rare formations with altitude data.',
-      itemCount: 35
-    },
-    {
-      href: '/fun-facts',
-      icon: BookOpen,
-      title: '16-Bit Takes',
-      description: 'The science behind the strange. From Ball Lightning to Thundersnow, explore rare weather phenomena.',
-      itemCount: 25
-    },
-    {
-      href: '/extremes',
-      icon: Thermometer,
-      title: 'Extremes',
-      description: 'Live monitoring of the hottest and coldest places on Earth. Track real-time temperature champions.',
-      itemCount: undefined
-    },
-    {
-      href: '/education/glossary',
-      icon: BookMarked,
-      title: 'Weather Glossary',
-      description: 'In-depth definitions of weather metrics. UV index, pressure, humidity, wind, and more explained.',
-      itemCount: 10
-    },
-  ];
-
-  return (
-    <PageWrapper>
-      <div className={cn('container mx-auto px-4 py-8', themeClasses.background)}>
-        <div className="mb-10">
-          <h1
-            className={cn(
-              'text-4xl sm:text-5xl md:text-6xl font-extrabold mb-4 font-mono',
-              themeClasses.accentText,
-              themeClasses.glow
-            )}
-          >
-            EDUCATION HUB
-          </h1>
-          <p className={cn('text-base sm:text-lg font-mono max-w-3xl', themeClasses.text)}>
-            Your portal to weather knowledge. From cloud identification to extreme events,
-            expand your meteorological expertise with our retro-styled learning platform.
-          </p>
-          <ShareButtons
-            config={{
-              title: 'Weather Education Hub',
-              text: 'Learn meteorology with interactive weather lessons at 16bitweather.co',
-              url: 'https://www.16bitweather.co/education',
-            }}
-            className="mt-3"
-          />
-        </div>
-
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-10">
-          <Card className={cn('container-nested', themeClasses.background)}>
-            <CardContent className="p-4 text-center">
-              <div className={cn('text-3xl font-bold font-mono', themeClasses.accentText)}>5</div>
-              <div className={cn('text-xs font-mono uppercase', themeClasses.text)}>Topics</div>
-            </CardContent>
-          </Card>
-          <Card className={cn('container-nested', themeClasses.background)}>
-            <CardContent className="p-4 text-center">
-              <div className={cn('text-3xl font-bold font-mono', themeClasses.accentText)}>50+</div>
-              <div className={cn('text-xs font-mono uppercase', themeClasses.text)}>Items</div>
-            </CardContent>
-          </Card>
-          <Card className={cn('container-nested', themeClasses.background)}>
-            <CardContent className="p-4 text-center">
-              <div className={cn('text-3xl font-bold font-mono', themeClasses.accentText)}>100%</div>
-              <div className={cn('text-xs font-mono uppercase', themeClasses.text)}>Free</div>
-            </CardContent>
-          </Card>
-          <Card className={cn('container-nested', themeClasses.background)}>
-            <CardContent className="p-4 text-center">
-              <div className={cn('text-3xl font-bold font-mono', themeClasses.accentText)}>24/7</div>
-              <div className={cn('text-xs font-mono uppercase', themeClasses.text)}>Updated</div>
-            </CardContent>
-          </Card>
-        </div>
-
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-10">
-          {educationTopics.map((topic) => (
-            <LearningCard key={topic.href} {...topic} />
-          ))}
-        </div>
-
-        <Card className={cn('container-primary text-center', themeClasses.background)}>
-          <CardContent className="p-8">
-            <h2 className={cn('text-2xl font-bold font-mono mb-3', themeClasses.headerText)}>
-              STAY CURIOUS
-            </h2>
-            <p className={cn('text-sm font-mono mb-4', themeClasses.text)}>
-              Explore our comprehensive weather education resources. New content added regularly.
-            </p>
-            <div className={cn('inline-block px-4 py-2 text-xs font-mono font-bold rounded', themeClasses.accentBg)}>
-              LAST UPDATED: MARCH 2026
-            </div>
-          </CardContent>
-        </Card>
-      </div>
-    </PageWrapper>
-  );
+  return <EducationHubClient latestPosts={latestPosts} />
 }

--- a/app/education/phenomena/[slug]/page.tsx
+++ b/app/education/phenomena/[slug]/page.tsx
@@ -1,0 +1,44 @@
+import type { Metadata } from 'next'
+import { notFound } from 'next/navigation'
+import PhenomenonDetail from '@/components/education/phenomenon-detail'
+import {
+  FEATURED_DETAIL_SLUGS,
+  getEducationDetailHref,
+  getPhenomenonBySlug,
+} from '@/lib/education/entries'
+
+interface PageProps {
+  params: Promise<{ slug: string }>
+}
+
+export function generateStaticParams() {
+  return FEATURED_DETAIL_SLUGS.phenomenon.map((slug) => ({ slug }))
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { slug } = await params
+  const phenomenon = getPhenomenonBySlug(slug)
+  if (!phenomenon) return { title: 'Phenomenon Not Found' }
+
+  const url = `https://www.16bitweather.co${getEducationDetailHref('phenomenon', slug)}`
+  const title = `${phenomenon.name} — 16-Bit Takes`
+
+  return {
+    title: `${title} | 16 Bit Weather`,
+    description: phenomenon.description,
+    alternates: { canonical: url },
+    openGraph: {
+      title,
+      description: phenomenon.description,
+      url,
+      type: 'article',
+    },
+  }
+}
+
+export default async function PhenomenonDetailPage({ params }: PageProps) {
+  const { slug } = await params
+  const phenomenon = getPhenomenonBySlug(slug)
+  if (!phenomenon) notFound()
+  return <PhenomenonDetail phenomenon={phenomenon} />
+}

--- a/app/education/weather-systems/[slug]/page.tsx
+++ b/app/education/weather-systems/[slug]/page.tsx
@@ -1,0 +1,44 @@
+import type { Metadata } from 'next'
+import { notFound } from 'next/navigation'
+import WeatherSystemDetail from '@/components/education/weather-system-detail'
+import {
+  FEATURED_DETAIL_SLUGS,
+  getEducationDetailHref,
+  getWeatherSystemBySlug,
+} from '@/lib/education/entries'
+
+interface PageProps {
+  params: Promise<{ slug: string }>
+}
+
+export function generateStaticParams() {
+  return FEATURED_DETAIL_SLUGS['weather-system'].map((slug) => ({ slug }))
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { slug } = await params
+  const system = getWeatherSystemBySlug(slug)
+  if (!system) return { title: 'Weather System Not Found' }
+
+  const url = `https://www.16bitweather.co${getEducationDetailHref('weather-system', slug)}`
+  const title = `${system.name} — Weather Systems Guide`
+
+  return {
+    title: `${title} | 16 Bit Weather`,
+    description: system.description16bit,
+    alternates: { canonical: url },
+    openGraph: {
+      title,
+      description: system.formationProcess.slice(0, 160),
+      url,
+      type: 'article',
+    },
+  }
+}
+
+export default async function WeatherSystemDetailPage({ params }: PageProps) {
+  const { slug } = await params
+  const system = getWeatherSystemBySlug(slug)
+  if (!system) notFound()
+  return <WeatherSystemDetail system={system} />
+}

--- a/app/extremes/page.tsx
+++ b/app/extremes/page.tsx
@@ -16,6 +16,8 @@
 
 import { useCallback, useState, useEffect, useRef } from "react"
 import PageWrapper from "@/components/page-wrapper"
+import EducationBreadcrumb from "@/components/education/education-breadcrumb"
+import EducationBackLink from "@/components/education/education-back-link"
 import { TrendingUp, TrendingDown, MapPin, RefreshCw, Thermometer } from "lucide-react"
 import type { ExtremesData, LocationTemperature } from "@/lib/extremes/extremes-data"
 import { Card, CardContent, CardHeader, CardTitle, CardFooter } from "@/components/ui/card"
@@ -249,6 +251,13 @@ export default function ExtremesPage() {
   return (
     <PageWrapper>
       <div className="min-h-screen p-4 sm:p-6 lg:p-8">
+        <EducationBreadcrumb
+          items={[
+            { label: 'Education', href: '/education' },
+            { label: 'Extremes' },
+          ]}
+        />
+        <EducationBackLink />
         {/* Header */}
         <div className="text-center mb-8">
           <h1 className="text-3xl sm:text-4xl lg:text-5xl font-mono font-bold mb-2 text-weather-primary glow">

--- a/app/extremes/page.tsx
+++ b/app/extremes/page.tsx
@@ -67,6 +67,20 @@ function setCachedExtremesClient(cacheKey: string, data: ExtremesData): void {
   }
 }
 
+function ExtremesEducationNav() {
+  return (
+    <>
+      <EducationBreadcrumb
+        items={[
+          { label: 'Education', href: '/education' },
+          { label: 'Extremes' },
+        ]}
+      />
+      <EducationBackLink />
+    </>
+  )
+}
+
 export default function ExtremesPage() {
   const [data, setData] = useState<ExtremesData | null>(null)
   const [loading, setLoading] = useState(true)
@@ -211,6 +225,7 @@ export default function ExtremesPage() {
     return (
       <PageWrapper>
         <div className="min-h-screen p-4 sm:p-6 lg:p-8 space-y-8">
+          <ExtremesEducationNav />
           <div className="text-center mb-8 space-y-4">
             <Skeleton className="h-12 w-3/4 max-w-lg mx-auto" />
             <Skeleton className="h-4 w-1/2 max-w-md mx-auto" />
@@ -228,7 +243,9 @@ export default function ExtremesPage() {
   if (error) {
     return (
       <PageWrapper>
-        <div className="min-h-screen flex items-center justify-center">
+        <div className="min-h-screen p-4 sm:p-6 lg:p-8">
+          <ExtremesEducationNav />
+          <div className="flex items-center justify-center min-h-[50vh]">
           <div className="text-center text-destructive">
             <div className="text-xl font-mono uppercase tracking-wider mb-4">
               ERROR: {error}
@@ -241,6 +258,7 @@ export default function ExtremesPage() {
               RETRY
             </Button>
           </div>
+          </div>
         </div>
       </PageWrapper>
     )
@@ -251,13 +269,7 @@ export default function ExtremesPage() {
   return (
     <PageWrapper>
       <div className="min-h-screen p-4 sm:p-6 lg:p-8">
-        <EducationBreadcrumb
-          items={[
-            { label: 'Education', href: '/education' },
-            { label: 'Extremes' },
-          ]}
-        />
-        <EducationBackLink />
+        <ExtremesEducationNav />
         {/* Header */}
         <div className="text-center mb-8">
           <h1 className="text-3xl sm:text-4xl lg:text-5xl font-mono font-bold mb-2 text-weather-primary glow">

--- a/app/fun-facts/page.tsx
+++ b/app/fun-facts/page.tsx
@@ -18,6 +18,8 @@
 import { useState } from "react"
 import { useTheme } from "next-themes"
 import PageWrapper from "@/components/page-wrapper"
+import EducationBreadcrumb from "@/components/education/education-breadcrumb"
+import EducationBackLink from "@/components/education/education-back-link"
 import { ChevronDown, ChevronUp } from "lucide-react"
 import type { ThemeType} from "@/lib/theme-utils";
 import { getComponentStyles } from "@/lib/theme-utils"
@@ -59,6 +61,13 @@ export default function FunFactsPage() {
   return (
     <PageWrapper>
       <div className="container mx-auto px-4 py-8">
+        <EducationBreadcrumb
+          items={[
+            { label: 'Education', href: '/education' },
+            { label: '16-Bit Takes' },
+          ]}
+        />
+        <EducationBackLink />
         <div className="text-center mb-12">
           <h1 className={`text-4xl md:text-6xl font-bold mb-4 font-mono uppercase tracking-wider ${themeClasses.headerText} ${themeClasses.glow}`}>
             16-BIT TAKES

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -3,6 +3,7 @@ import { cityData as cityMetadata } from '@/lib/city-metadata'
 import { getAllPosts } from '@/lib/blog'
 import deepSkyCatalog from '@/data/deep-sky-catalog.json'
 import type { DeepSkyObject } from '@/lib/stargazer/types'
+import { FEATURED_DETAIL_SLUGS, getEducationDetailHref } from '@/lib/education/entries'
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const baseUrl = 'https://www.16bitweather.co'
@@ -36,6 +37,27 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       { url: `${baseUrl}/education/glossary`, lastModified: new Date(), changeFrequency: 'monthly' as const, priority: 0.7 },
       { url: `${baseUrl}/llms.txt`, lastModified: new Date(), changeFrequency: 'monthly' as const, priority: 0.5 },
     ]
+
+    const educationDetailPages: MetadataRoute.Sitemap = [
+      ...FEATURED_DETAIL_SLUGS['weather-system'].map((slug) => ({
+        url: `${baseUrl}${getEducationDetailHref('weather-system', slug)}`,
+        lastModified: new Date(),
+        changeFrequency: 'monthly' as const,
+        priority: 0.75,
+      })),
+      ...FEATURED_DETAIL_SLUGS.cloud.map((slug) => ({
+        url: `${baseUrl}${getEducationDetailHref('cloud', slug)}`,
+        lastModified: new Date(),
+        changeFrequency: 'monthly' as const,
+        priority: 0.75,
+      })),
+      ...FEATURED_DETAIL_SLUGS.phenomenon.map((slug) => ({
+        url: `${baseUrl}${getEducationDetailHref('phenomenon', slug)}`,
+        lastModified: new Date(),
+        changeFrequency: 'monthly' as const,
+        priority: 0.75,
+      })),
+    ]
   
     // Dynamic city pages
     const cityPages: MetadataRoute.Sitemap = Object.keys(cityMetadata || {}).map(citySlug => ({
@@ -67,7 +89,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       console.error('[sitemap] Failed to load blog posts')
     }
 
-    return [...staticPages, ...cityPages, ...stargazerObjectPages, ...blogPosts]
+    return [...staticPages, ...educationDetailPages, ...cityPages, ...stargazerObjectPages, ...blogPosts]
   } catch (error) {
     console.error('Error generating sitemap:', error)
     return [

--- a/app/weather-systems/page.tsx
+++ b/app/weather-systems/page.tsx
@@ -18,6 +18,8 @@
 import React, { useState } from "react"
 import { useTheme } from "next-themes"
 import PageWrapper from "@/components/page-wrapper"
+import EducationBreadcrumb from "@/components/education/education-breadcrumb"
+import EducationBackLink from "@/components/education/education-back-link"
 import type { ThemeType} from "@/lib/theme-utils";
 import { getComponentStyles } from "@/lib/theme-utils"
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
@@ -94,6 +96,13 @@ export default function WeatherSystemsPage() {
   return (
     <PageWrapper>
       <div className="container mx-auto px-4 py-8">
+        <EducationBreadcrumb
+          items={[
+            { label: 'Education', href: '/education' },
+            { label: 'Weather Systems' },
+          ]}
+        />
+        <EducationBackLink />
         {/* Header Section */}
         <div className="text-center mb-12">
           <h1 className={`text-4xl md:text-6xl font-bold mb-4 font-mono uppercase tracking-wider ${themeClasses.headerText} ${themeClasses.glow}`}>

--- a/components/education/cloud-altitude-stack.tsx
+++ b/components/education/cloud-altitude-stack.tsx
@@ -2,156 +2,190 @@
 
 import { useState } from 'react'
 import Link from 'next/link'
+import { CheckCircle2, XCircle } from 'lucide-react'
 import { cn } from '@/lib/utils'
-import { useTheme } from '@/components/theme-provider'
-import { getComponentStyles, type ThemeType } from '@/lib/theme-utils'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 
 type AltitudeLayer = 'high' | 'mid' | 'low' | 'vertical'
 
-interface CloudChip {
+export interface CloudQuizQuestion {
   id: string
   name: string
   layer: AltitudeLayer
   hint: string
 }
 
-const CLOUD_CHIPS: CloudChip[] = [
-  { id: 'cirrus', name: 'Cirrus', layer: 'high', hint: 'Wispy ice crystals above 20,000 ft' },
-  { id: 'altocumulus', name: 'Altocumulus', layer: 'mid', hint: 'Mackerel sky patches at mid levels' },
-  { id: 'stratus', name: 'Stratus', layer: 'low', hint: 'Flat gray deck near the surface' },
-  { id: 'cumulonimbus', name: 'Cumulonimbus', layer: 'vertical', hint: 'Storm tower through the whole troposphere' },
+export const CLOUD_QUIZ_QUESTIONS: CloudQuizQuestion[] = [
+  {
+    id: 'cirrus',
+    name: 'Cirrus',
+    layer: 'high',
+    hint: 'Thin, wispy ice-crystal clouds you see on fair-weather days.',
+  },
+  {
+    id: 'altocumulus',
+    name: 'Altocumulus',
+    layer: 'mid',
+    hint: 'Patchy “mackerel sky” clouds in the middle of the troposphere.',
+  },
+  {
+    id: 'stratus',
+    name: 'Stratus',
+    layer: 'low',
+    hint: 'A flat gray deck that often brings drizzle or overcast skies.',
+  },
+  {
+    id: 'cumulonimbus',
+    name: 'Cumulonimbus',
+    layer: 'vertical',
+    hint: 'The towering storm cloud that can span the entire troposphere.',
+  },
 ]
 
-const LAYERS: { id: AltitudeLayer; label: string; range: string }[] = [
-  { id: 'high', label: 'High', range: '20,000–40,000 ft' },
-  { id: 'mid', label: 'Mid', range: '6,500–20,000 ft' },
-  { id: 'low', label: 'Low', range: 'Surface–6,500 ft' },
-  { id: 'vertical', label: 'Vertical', range: 'Full stack' },
+const LAYER_OPTIONS: { id: AltitudeLayer; label: string; range: string }[] = [
+  { id: 'high', label: 'High clouds', range: '20,000–40,000 ft' },
+  { id: 'mid', label: 'Mid-level clouds', range: '6,500–20,000 ft' },
+  { id: 'low', label: 'Low clouds', range: 'Surface–6,500 ft' },
+  { id: 'vertical', label: 'Vertical development', range: 'Surface to tropopause' },
 ]
+
+export function isCorrectCloudLayer(question: CloudQuizQuestion, layer: AltitudeLayer): boolean {
+  return question.layer === layer
+}
 
 export default function CloudAltitudeStack() {
-  const { theme } = useTheme()
-  const themeClasses = getComponentStyles((theme || 'nord') as ThemeType, 'weather')
-  const [selectedCloud, setSelectedCloud] = useState<string | null>(null)
-  const [assignments, setAssignments] = useState<Record<string, AltitudeLayer | null>>({})
-  const [feedback, setFeedback] = useState<string | null>(null)
+  const [step, setStep] = useState(0)
+  const [correctCount, setCorrectCount] = useState(0)
+  const [feedback, setFeedback] = useState<{ kind: 'success' | 'error'; message: string } | null>(
+    null,
+  )
 
-  const correctCount = CLOUD_CHIPS.filter((c) => assignments[c.id] === c.layer).length
-  const complete = correctCount === CLOUD_CHIPS.length
+  const question = CLOUD_QUIZ_QUESTIONS[step]
+  const complete = step >= CLOUD_QUIZ_QUESTIONS.length
 
-  const handleLayerClick = (layer: AltitudeLayer) => {
-    if (!selectedCloud) {
-      setFeedback('Pick a cloud type first, then tap a layer.')
+  const handleAnswer = (layer: AltitudeLayer) => {
+    if (complete || !question) return
+
+    if (isCorrectCloudLayer(question, layer)) {
+      const nextCorrect = correctCount + 1
+      setCorrectCount(nextCorrect)
+      if (step === CLOUD_QUIZ_QUESTIONS.length - 1) {
+        setFeedback({
+          kind: 'success',
+          message: 'Nice work — all four clouds classified correctly.',
+        })
+        setStep(CLOUD_QUIZ_QUESTIONS.length)
+      } else {
+        setStep((prev) => prev + 1)
+        setFeedback(null)
+      }
       return
     }
-    const cloud = CLOUD_CHIPS.find((c) => c.id === selectedCloud)
-    if (!cloud) return
 
-    setAssignments((prev) => ({ ...prev, [selectedCloud]: layer }))
-    if (cloud.layer === layer) {
-      setFeedback(`${cloud.name} belongs in the ${layer} layer. Nice!`)
-    } else {
-      setFeedback(`Not quite — ${cloud.hint}`)
-    }
-    setSelectedCloud(null)
+    setFeedback({
+      kind: 'error',
+      message: `Not quite. ${question.hint}`,
+    })
   }
 
   const reset = () => {
-    setAssignments({})
-    setSelectedCloud(null)
+    setStep(0)
+    setCorrectCount(0)
     setFeedback(null)
   }
 
   return (
-    <Card className={cn('container-primary', themeClasses.background)}>
-      <CardHeader>
-        <CardTitle className={cn('text-xl font-mono uppercase', themeClasses.headerText)}>
-          Cloud Altitude Lab
+    <Card className="container-nested border border-border/60">
+      <CardHeader className="pb-3">
+        <CardTitle className="text-lg font-mono uppercase tracking-wide text-primary">
+          Cloud altitude quiz
         </CardTitle>
-        <p className={cn('text-sm font-mono', themeClasses.text)}>
-          Select a cloud, then place it in the correct altitude layer. Sort all four to complete the lab.
+        <p className="text-sm text-muted-foreground leading-relaxed max-w-2xl">
+          One question at a time — pick the altitude layer where each cloud usually lives.
         </p>
       </CardHeader>
-      <CardContent className="space-y-4">
-        <div className="flex flex-wrap gap-2">
-          {CLOUD_CHIPS.map((cloud) => {
-            const assigned = assignments[cloud.id]
-            const isCorrect = assigned === cloud.layer
-            return (
-              <button
-                key={cloud.id}
-                type="button"
-                onClick={() => {
-                  if (assigned === cloud.layer) return
-                  setSelectedCloud(cloud.id)
-                  setFeedback(`Place ${cloud.name}…`)
-                }}
-                className={cn(
-                  'px-3 py-2 rounded-md text-xs font-mono font-bold border transition-colors',
-                  selectedCloud === cloud.id && 'ring-2 ring-primary',
-                  isCorrect
-                    ? 'border-green-500/60 bg-green-500/10 text-green-400'
-                    : 'border-primary/30 hover:border-primary/60',
-                )}
-                disabled={isCorrect}
-              >
-                {cloud.name}
-                {isCorrect && ' ✓'}
-              </button>
-            )
-          })}
-        </div>
+      <CardContent className="space-y-5">
+        {!complete && question && (
+          <>
+            <div className="flex items-center justify-between gap-4 text-xs font-mono text-muted-foreground">
+              <span>
+                Question {step + 1} of {CLOUD_QUIZ_QUESTIONS.length}
+              </span>
+              <span>
+                Score {correctCount}/{CLOUD_QUIZ_QUESTIONS.length}
+              </span>
+            </div>
 
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
-          {LAYERS.map((layer) => (
-            <button
-              key={layer.id}
-              type="button"
-              onClick={() => handleLayerClick(layer.id)}
-              className={cn(
-                'p-4 rounded-lg border text-left transition-all hover:scale-[1.02]',
-                'border-primary/20 hover:border-primary/50 bg-background/40',
-              )}
-            >
-              <div className={cn('text-sm font-mono font-bold uppercase', themeClasses.accentText)}>
-                {layer.label}
-              </div>
-              <div className={cn('text-xs font-mono mt-1', themeClasses.text)}>{layer.range}</div>
-              <div className="mt-3 flex flex-wrap gap-1">
-                {CLOUD_CHIPS.filter((c) => assignments[c.id] === layer.id).map((c) => (
-                  <Badge key={c.id} variant="outline" className="font-mono text-[10px]">
-                    {c.name}
-                  </Badge>
-                ))}
-              </div>
-            </button>
-          ))}
-        </div>
+            <div className="rounded-lg border border-border/60 bg-card/50 p-5">
+              <p className="text-xs font-mono uppercase tracking-widest text-primary mb-2">
+                Which layer?
+              </p>
+              <h3 className="text-2xl font-bold text-foreground">{question.name}</h3>
+              <p className="text-sm text-muted-foreground mt-2 leading-relaxed">{question.hint}</p>
+            </div>
 
-        {feedback && (
-          <p className={cn('text-xs font-mono', complete ? themeClasses.successText : themeClasses.text)}>
-            {complete ? 'All clouds classified — you are sky-ready. Explore the Cloud Atlas next.' : feedback}
-          </p>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              {LAYER_OPTIONS.map((option) => (
+                <Button
+                  key={option.id}
+                  type="button"
+                  variant="outline"
+                  onClick={() => handleAnswer(option.id)}
+                  className="h-auto min-h-[4.5rem] flex flex-col items-start gap-1 px-4 py-3 text-left whitespace-normal"
+                >
+                  <span className="font-semibold text-foreground">{option.label}</span>
+                  <span className="text-xs text-muted-foreground font-normal">{option.range}</span>
+                </Button>
+              ))}
+            </div>
+          </>
         )}
 
-        <div className="flex flex-wrap items-center gap-3">
-          <span className={cn('text-xs font-mono', themeClasses.text)}>
-            Progress: {correctCount}/{CLOUD_CHIPS.length}
-          </span>
-          <Button type="button" variant="outline" size="sm" onClick={reset} className="font-mono text-xs">
-            Reset lab
+        {complete && (
+          <div className="rounded-lg border border-green-500/30 bg-green-500/10 p-5">
+            <div className="flex items-start gap-3">
+              <CheckCircle2 className="w-5 h-5 text-green-500 shrink-0 mt-0.5" />
+              <div>
+                <p className="font-semibold text-foreground">Quiz complete</p>
+                <p className="text-sm text-muted-foreground mt-1 leading-relaxed">
+                  You matched all four cloud types to their altitude layers. Explore the full atlas
+                  for species, rare formations, and spotting tips.
+                </p>
+                <Link
+                  href="/cloud-types"
+                  className="inline-block mt-3 text-sm font-semibold text-primary hover:underline"
+                >
+                  Open Cloud Atlas
+                </Link>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {feedback && (
+          <div
+            className={cn(
+              'flex items-start gap-2 rounded-md px-3 py-2 text-sm leading-relaxed',
+              feedback.kind === 'success'
+                ? 'bg-green-500/10 text-green-700 dark:text-green-300'
+                : 'bg-destructive/10 text-destructive',
+            )}
+            role="status"
+          >
+            {feedback.kind === 'success' ? (
+              <CheckCircle2 className="w-4 h-4 shrink-0 mt-0.5" />
+            ) : (
+              <XCircle className="w-4 h-4 shrink-0 mt-0.5" />
+            )}
+            <span>{feedback.message}</span>
+          </div>
+        )}
+
+        <div className="flex flex-wrap gap-3">
+          <Button type="button" variant="ghost" size="sm" onClick={reset}>
+            {complete ? 'Try again' : 'Reset quiz'}
           </Button>
-          {complete && (
-            <Link
-              href="/cloud-types"
-              className={cn('text-xs font-mono font-bold underline', themeClasses.accentText)}
-            >
-              Open Cloud Atlas →
-            </Link>
-          )}
         </div>
       </CardContent>
     </Card>

--- a/components/education/cloud-altitude-stack.tsx
+++ b/components/education/cloud-altitude-stack.tsx
@@ -1,0 +1,159 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { cn } from '@/lib/utils'
+import { useTheme } from '@/components/theme-provider'
+import { getComponentStyles, type ThemeType } from '@/lib/theme-utils'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+
+type AltitudeLayer = 'high' | 'mid' | 'low' | 'vertical'
+
+interface CloudChip {
+  id: string
+  name: string
+  layer: AltitudeLayer
+  hint: string
+}
+
+const CLOUD_CHIPS: CloudChip[] = [
+  { id: 'cirrus', name: 'Cirrus', layer: 'high', hint: 'Wispy ice crystals above 20,000 ft' },
+  { id: 'altocumulus', name: 'Altocumulus', layer: 'mid', hint: 'Mackerel sky patches at mid levels' },
+  { id: 'stratus', name: 'Stratus', layer: 'low', hint: 'Flat gray deck near the surface' },
+  { id: 'cumulonimbus', name: 'Cumulonimbus', layer: 'vertical', hint: 'Storm tower through the whole troposphere' },
+]
+
+const LAYERS: { id: AltitudeLayer; label: string; range: string }[] = [
+  { id: 'high', label: 'High', range: '20,000–40,000 ft' },
+  { id: 'mid', label: 'Mid', range: '6,500–20,000 ft' },
+  { id: 'low', label: 'Low', range: 'Surface–6,500 ft' },
+  { id: 'vertical', label: 'Vertical', range: 'Full stack' },
+]
+
+export default function CloudAltitudeStack() {
+  const { theme } = useTheme()
+  const themeClasses = getComponentStyles((theme || 'nord') as ThemeType, 'weather')
+  const [selectedCloud, setSelectedCloud] = useState<string | null>(null)
+  const [assignments, setAssignments] = useState<Record<string, AltitudeLayer | null>>({})
+  const [feedback, setFeedback] = useState<string | null>(null)
+
+  const correctCount = CLOUD_CHIPS.filter((c) => assignments[c.id] === c.layer).length
+  const complete = correctCount === CLOUD_CHIPS.length
+
+  const handleLayerClick = (layer: AltitudeLayer) => {
+    if (!selectedCloud) {
+      setFeedback('Pick a cloud type first, then tap a layer.')
+      return
+    }
+    const cloud = CLOUD_CHIPS.find((c) => c.id === selectedCloud)
+    if (!cloud) return
+
+    setAssignments((prev) => ({ ...prev, [selectedCloud]: layer }))
+    if (cloud.layer === layer) {
+      setFeedback(`${cloud.name} belongs in the ${layer} layer. Nice!`)
+    } else {
+      setFeedback(`Not quite — ${cloud.hint}`)
+    }
+    setSelectedCloud(null)
+  }
+
+  const reset = () => {
+    setAssignments({})
+    setSelectedCloud(null)
+    setFeedback(null)
+  }
+
+  return (
+    <Card className={cn('container-primary', themeClasses.background)}>
+      <CardHeader>
+        <CardTitle className={cn('text-xl font-mono uppercase', themeClasses.headerText)}>
+          Cloud Altitude Lab
+        </CardTitle>
+        <p className={cn('text-sm font-mono', themeClasses.text)}>
+          Select a cloud, then place it in the correct altitude layer. Sort all four to complete the lab.
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex flex-wrap gap-2">
+          {CLOUD_CHIPS.map((cloud) => {
+            const assigned = assignments[cloud.id]
+            const isCorrect = assigned === cloud.layer
+            return (
+              <button
+                key={cloud.id}
+                type="button"
+                onClick={() => {
+                  if (assigned === cloud.layer) return
+                  setSelectedCloud(cloud.id)
+                  setFeedback(`Place ${cloud.name}…`)
+                }}
+                className={cn(
+                  'px-3 py-2 rounded-md text-xs font-mono font-bold border transition-colors',
+                  selectedCloud === cloud.id && 'ring-2 ring-primary',
+                  isCorrect
+                    ? 'border-green-500/60 bg-green-500/10 text-green-400'
+                    : 'border-primary/30 hover:border-primary/60',
+                )}
+                disabled={isCorrect}
+              >
+                {cloud.name}
+                {isCorrect && ' ✓'}
+              </button>
+            )
+          })}
+        </div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+          {LAYERS.map((layer) => (
+            <button
+              key={layer.id}
+              type="button"
+              onClick={() => handleLayerClick(layer.id)}
+              className={cn(
+                'p-4 rounded-lg border text-left transition-all hover:scale-[1.02]',
+                'border-primary/20 hover:border-primary/50 bg-background/40',
+              )}
+            >
+              <div className={cn('text-sm font-mono font-bold uppercase', themeClasses.accentText)}>
+                {layer.label}
+              </div>
+              <div className={cn('text-xs font-mono mt-1', themeClasses.text)}>{layer.range}</div>
+              <div className="mt-3 flex flex-wrap gap-1">
+                {CLOUD_CHIPS.filter((c) => assignments[c.id] === layer.id).map((c) => (
+                  <Badge key={c.id} variant="outline" className="font-mono text-[10px]">
+                    {c.name}
+                  </Badge>
+                ))}
+              </div>
+            </button>
+          ))}
+        </div>
+
+        {feedback && (
+          <p className={cn('text-xs font-mono', complete ? themeClasses.successText : themeClasses.text)}>
+            {complete ? 'All clouds classified — you are sky-ready. Explore the Cloud Atlas next.' : feedback}
+          </p>
+        )}
+
+        <div className="flex flex-wrap items-center gap-3">
+          <span className={cn('text-xs font-mono', themeClasses.text)}>
+            Progress: {correctCount}/{CLOUD_CHIPS.length}
+          </span>
+          <Button type="button" variant="outline" size="sm" onClick={reset} className="font-mono text-xs">
+            Reset lab
+          </Button>
+          {complete && (
+            <Link
+              href="/cloud-types"
+              className={cn('text-xs font-mono font-bold underline', themeClasses.accentText)}
+            >
+              Open Cloud Atlas →
+            </Link>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/education/cloud-detail.tsx
+++ b/components/education/cloud-detail.tsx
@@ -1,0 +1,97 @@
+'use client'
+
+import Link from 'next/link'
+import { ShareButtons } from '@/components/share-buttons'
+import EducationBreadcrumb from '@/components/education/education-breadcrumb'
+import EducationBackLink from '@/components/education/education-back-link'
+import PageWrapper from '@/components/page-wrapper'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import type { CloudData } from '@/data/cloud-types'
+import { cloudSlug, getEducationDetailHref } from '@/lib/education/entries'
+import { cn } from '@/lib/utils'
+import { useTheme } from '@/components/theme-provider'
+import { getComponentStyles, type ThemeType } from '@/lib/theme-utils'
+
+interface CloudDetailProps {
+  cloud: CloudData
+}
+
+export default function CloudDetail({ cloud }: CloudDetailProps) {
+  const { theme } = useTheme()
+  const themeClasses = getComponentStyles((theme || 'nord') as ThemeType, 'weather')
+  const slug = cloudSlug(cloud)
+  const url = `https://www.16bitweather.co${getEducationDetailHref('cloud', slug)}`
+
+  return (
+    <PageWrapper>
+      <div className={cn('container mx-auto px-4 py-8 max-w-4xl', themeClasses.background)}>
+        <EducationBreadcrumb
+          items={[
+            { label: 'Education', href: '/education' },
+            { label: 'Cloud Atlas', href: '/cloud-types' },
+            { label: cloud.name },
+          ]}
+        />
+        <EducationBackLink href="/cloud-types" label="All cloud types" />
+
+        <div className="text-center mb-8">
+          <Badge variant="outline" className="font-mono mb-3">[{cloud.abbreviation}]</Badge>
+          <h1 className={cn('text-3xl md:text-5xl font-bold font-mono uppercase', themeClasses.headerText, themeClasses.glow)}>
+            {cloud.name}
+          </h1>
+          <p className={cn('text-sm font-mono mt-2', themeClasses.secondaryText)}>
+            {cloud.category.toUpperCase()} · {cloud.cloudType.toUpperCase()}
+          </p>
+          <ShareButtons
+            config={{ title: `${cloud.name} — Cloud Atlas`, text: cloud.description16bit, url }}
+            className="mt-4 justify-center"
+          />
+        </div>
+
+        <Card className={cn('container-primary mb-6', themeClasses.background)}>
+          <CardContent className="p-6">
+            <p className={cn('font-mono text-sm italic text-center', themeClasses.text)}>&ldquo;{cloud.description16bit}&rdquo;</p>
+          </CardContent>
+        </Card>
+
+        <div className="grid gap-6 md:grid-cols-2 mb-6">
+          <Card className="container-nested">
+            <CardHeader><CardTitle className="font-mono text-sm uppercase">Formation</CardTitle></CardHeader>
+            <CardContent className="text-sm font-mono">{cloud.formation}</CardContent>
+          </Card>
+          <Card className="container-nested">
+            <CardHeader><CardTitle className="font-mono text-sm uppercase">Weather signal</CardTitle></CardHeader>
+            <CardContent className="text-sm font-mono">{cloud.weatherPrediction}</CardContent>
+          </Card>
+        </div>
+
+        <Card className="container-nested mb-6">
+          <CardHeader><CardTitle className="font-mono text-sm uppercase">Technical specs</CardTitle></CardHeader>
+          <CardContent className="space-y-2 text-sm font-mono">
+            <div className="flex justify-between gap-4"><span className="opacity-70">Altitude</span><span>{cloud.altitudeRange}</span></div>
+            <div className="flex justify-between gap-4"><span className="opacity-70">Appearance</span><span className="text-right">{cloud.appearance}</span></div>
+            <div className="flex justify-between gap-4"><span className="opacity-70">Fun fact</span><span className="text-right">{cloud.funFact}</span></div>
+            <Badge variant="outline" className="font-mono mt-2">{cloud.rarity}</Badge>
+          </CardContent>
+        </Card>
+
+        {cloud.etymology && (
+          <Card className="container-nested mb-6">
+            <CardHeader><CardTitle className="font-mono text-sm uppercase">Etymology</CardTitle></CardHeader>
+            <CardContent className="text-sm font-mono">{cloud.etymology}</CardContent>
+          </Card>
+        )}
+
+        <div className="flex flex-wrap gap-4 justify-center">
+          <Link href="/radar" className={cn('text-sm font-mono font-bold uppercase underline', themeClasses.accentText)}>
+            Open Radar lab →
+          </Link>
+          <Link href="/cloud-types" className={cn('text-sm font-mono uppercase', themeClasses.text)}>
+            Browse all clouds
+          </Link>
+        </div>
+      </div>
+    </PageWrapper>
+  )
+}

--- a/components/education/education-back-link.tsx
+++ b/components/education/education-back-link.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import Link from 'next/link'
+import { ArrowLeft } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { useTheme } from '@/components/theme-provider'
+import { getComponentStyles, type ThemeType } from '@/lib/theme-utils'
+
+interface EducationBackLinkProps {
+  href?: string
+  label?: string
+  className?: string
+}
+
+export default function EducationBackLink({
+  href = '/education',
+  label = 'Back to Education Hub',
+  className,
+}: EducationBackLinkProps) {
+  const { theme } = useTheme()
+  const themeClasses = getComponentStyles((theme || 'nord') as ThemeType, 'weather')
+
+  return (
+    <Link
+      href={href}
+      className={cn(
+        'inline-flex items-center gap-1.5 text-sm font-mono mb-6 hover:underline transition-colors',
+        themeClasses.accentText,
+        className,
+      )}
+    >
+      <ArrowLeft size={14} />
+      {label}
+    </Link>
+  )
+}

--- a/components/education/education-breadcrumb.tsx
+++ b/components/education/education-breadcrumb.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+import Link from 'next/link'
+import { ChevronRight } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { useTheme } from '@/components/theme-provider'
+import { getComponentStyles, type ThemeType } from '@/lib/theme-utils'
+
+export interface EducationBreadcrumbItem {
+  label: string
+  href?: string
+}
+
+interface EducationBreadcrumbProps {
+  items: EducationBreadcrumbItem[]
+  className?: string
+}
+
+export default function EducationBreadcrumb({ items, className }: EducationBreadcrumbProps) {
+  const { theme } = useTheme()
+  const themeClasses = getComponentStyles((theme || 'nord') as ThemeType, 'weather')
+
+  return (
+    <nav
+      aria-label="Breadcrumb"
+      className={cn('flex flex-wrap items-center gap-1 text-xs font-mono mb-6', className)}
+    >
+      {items.map((item, index) => {
+        const isLast = index === items.length - 1
+        return (
+          <span key={`${item.label}-${index}`} className="inline-flex items-center gap-1">
+            {index > 0 && (
+              <ChevronRight size={12} className={cn('opacity-50', themeClasses.text)} aria-hidden />
+            )}
+            {item.href && !isLast ? (
+              <Link
+                href={item.href}
+                className={cn('hover:underline transition-colors', themeClasses.accentText)}
+              >
+                {item.label}
+              </Link>
+            ) : (
+              <span className={cn(isLast ? themeClasses.headerText : themeClasses.text, isLast && 'font-bold')}>
+                {item.label}
+              </span>
+            )}
+          </span>
+        )
+      })}
+    </nav>
+  )
+}

--- a/components/education/education-hub-client.tsx
+++ b/components/education/education-hub-client.tsx
@@ -28,6 +28,7 @@ import { countEncyclopediaEntries } from '@/lib/education/entries'
 import { cloudDatabase } from '@/data/cloud-types'
 import { weatherPhenomena } from '@/data/fun-facts'
 import { weatherSystemsDatabase } from '@/data/weather-systems'
+import { decodeHtmlEntities } from '@/lib/services/rss/html-utils'
 import { getAllConcepts } from '@/lib/weather-concepts'
 import { getAllMetrics } from '@/lib/weather-definitions'
 
@@ -35,7 +36,7 @@ export interface EducationHubPost {
   slug: string
   title: string
   summary: string
-  date: string
+  displayDate: string
   href: string
 }
 
@@ -256,23 +257,21 @@ export default function EducationHubClient({ latestPosts }: EducationHubClientPr
               </Link>
             </div>
             <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-              {latestPosts.map((post) => (
-                <Link key={post.slug} href={post.href} className="block h-full">
+              {latestPosts.map((post, index) => (
+                <Link key={index} href={post.href} className="block h-full">
                   <Card className={cn('container-nested h-full glow-interactive hover:scale-[1.02] transition-transform', themeClasses.background)}>
                     <CardHeader className="pb-2">
                       <CardTitle className={cn('text-base font-mono uppercase leading-snug', themeClasses.headerText)}>
-                        {post.title}
+                        {decodeHtmlEntities(post.title)}
                       </CardTitle>
                       <p className={cn('text-[10px] font-mono uppercase', themeClasses.text)}>
-                        {new Date(post.date).toLocaleDateString('en-US', {
-                          month: 'short',
-                          day: 'numeric',
-                          year: 'numeric',
-                        })}
+                        {post.displayDate}
                       </p>
                     </CardHeader>
                     <CardContent>
-                      <p className={cn('text-sm font-mono line-clamp-3', themeClasses.text)}>{post.summary}</p>
+                      <p className={cn('text-sm font-mono line-clamp-3', themeClasses.text)}>
+                        {decodeHtmlEntities(post.summary)}
+                      </p>
                     </CardContent>
                   </Card>
                 </Link>

--- a/components/education/education-hub-client.tsx
+++ b/components/education/education-hub-client.tsx
@@ -16,9 +16,6 @@ import {
   ArrowRight,
 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
-import { cn } from '@/lib/utils'
-import { useTheme } from '@/components/theme-provider'
-import { getComponentStyles, type ThemeType } from '@/lib/theme-utils'
 import PageWrapper from '@/components/page-wrapper'
 import LearningCard from '@/components/learn/LearningCard'
 import CloudAltitudeStack from '@/components/education/cloud-altitude-stack'
@@ -73,44 +70,56 @@ const LIVE_LABS: { href: string; icon: LucideIcon; title: string; description: s
     href: '/severe',
     icon: CloudLightning,
     title: 'Severe Weather',
-    description: 'Active warnings and SPC outlook — see what you just studied in the wild.',
+    description: 'Active warnings and SPC outlook.',
   },
   {
     href: '/space-weather',
     icon: Sun,
     title: 'Space Weather',
-    description: 'Kp index, aurora, and solar wind tied to upper-atmosphere lessons.',
+    description: 'Kp index, aurora, and solar wind.',
   },
   {
     href: '/stargazer',
     icon: Star,
     title: 'Stargazer',
-    description: 'Sky clarity, moon phase, and seeing conditions for night-sky readers.',
+    description: 'Sky clarity and moon phase.',
   },
   {
     href: '/radar',
     icon: Radar,
     title: 'Radar',
-    description: 'Watch reflectivity and velocity while learning storm structure.',
+    description: 'Reflectivity and velocity loops.',
   },
   {
     href: '/earth-sciences',
     icon: Activity,
     title: 'Earth Sciences',
-    description: 'Quakes, volcanoes, and planetary context for weather extremes.',
+    description: 'Quakes, volcanoes, and planetary context.',
   },
   {
     href: '/news',
     icon: Newspaper,
     title: 'News Feed',
-    description: 'NOAA, NASA, and USGS headlines to extend classroom topics.',
+    description: 'NOAA, NASA, and USGS headlines.',
   },
 ]
 
-export default function EducationHubClient({ latestPosts }: EducationHubClientProps) {
-  const { theme } = useTheme()
-  const themeClasses = getComponentStyles((theme || 'nord') as ThemeType, 'weather')
+function SectionHeading({ title, description }: { title: string; description?: string }) {
+  return (
+    <div className="mb-5">
+      <h2 className="text-xl sm:text-2xl font-bold font-mono uppercase tracking-wide text-primary">
+        {title}
+      </h2>
+      {description && (
+        <p className="text-sm sm:text-base text-muted-foreground mt-2 max-w-3xl leading-relaxed">
+          {description}
+        </p>
+      )}
+    </div>
+  )
+}
 
+export default function EducationHubClient({ latestPosts }: EducationHubClientProps) {
   const encyclopediaCount = countEncyclopediaEntries()
   const glossaryCount = getAllMetrics().length + getAllConcepts().length
 
@@ -120,7 +129,7 @@ export default function EducationHubClient({ latestPosts }: EducationHubClientPr
       icon: Zap,
       title: 'Weather Systems',
       description:
-        'Atmospheric dynamics of 16 major storm types with historical case studies and threat levels.',
+        'Sixteen major storm types with formation notes, threat levels, and historical case studies.',
       itemCount: weatherSystemsDatabase.length,
     },
     {
@@ -128,7 +137,7 @@ export default function EducationHubClient({ latestPosts }: EducationHubClientPr
       icon: Cloud,
       title: 'Cloud Atlas',
       description:
-        'Cloud database covering genera, species, varieties, and rare formations with altitude data.',
+        'Genera, species, varieties, and rare formations with altitude and weather signals.',
       itemCount: cloudDatabase.length,
     },
     {
@@ -136,41 +145,39 @@ export default function EducationHubClient({ latestPosts }: EducationHubClientPr
       icon: BookOpen,
       title: '16-Bit Takes',
       description:
-        'The science behind the strange — from ball lightning to thundersnow and rare phenomena.',
+        'Rare phenomena from ball lightning to thundersnow — science with retro flavor.',
       itemCount: weatherPhenomena.length,
     },
     {
       href: '/extremes',
       icon: Thermometer,
       title: 'Extremes',
-      description: 'Live hottest and coldest places on Earth with climate context modals.',
+      description: 'Live hottest and coldest places on Earth with climate context.',
       itemCount: undefined,
     },
     {
       href: '/education/glossary',
       icon: BookMarked,
       title: 'Weather Glossary',
-      description: 'Dashboard metrics plus storm-spotter concepts — UV, CAPE, supercells, and more.',
+      description: 'Dashboard metrics plus spotter concepts like CAPE, supercells, and dew point.',
       itemCount: glossaryCount,
     },
   ]
 
   return (
     <PageWrapper>
-      <div className={cn('container mx-auto px-4 py-8', themeClasses.background)}>
-        <div className="mb-10">
-          <h1
-            className={cn(
-              'text-4xl sm:text-5xl md:text-6xl font-extrabold mb-4 font-mono',
-              themeClasses.accentText,
-              themeClasses.glow,
-            )}
-          >
-            EDUCATION HUB
+      <div className="max-w-5xl mx-auto px-4 py-8 space-y-12">
+        {/* Hero */}
+        <div className="space-y-4">
+          <p className="text-xs font-mono tracking-widest text-muted-foreground uppercase">
+            // Learn // Explore // Spot
+          </p>
+          <h1 className="text-3xl sm:text-4xl md:text-5xl font-extrabold font-mono uppercase text-primary">
+            Education Hub
           </h1>
-          <p className={cn('text-base sm:text-lg font-mono max-w-3xl', themeClasses.text)}>
-            Your portal to weather knowledge — encyclopedias, live labs, glossary reference, and
-            weekly deep dives from the blog.
+          <p className="text-base sm:text-lg text-muted-foreground max-w-3xl leading-relaxed">
+            Encyclopedias, glossary reference, live weather tools, and weekly blog deep dives — all
+            in one place.
           </p>
           <ShareButtons
             config={{
@@ -178,60 +185,42 @@ export default function EducationHubClient({ latestPosts }: EducationHubClientPr
               text: 'Learn meteorology with interactive weather lessons at 16bitweather.co',
               url: 'https://www.16bitweather.co/education',
             }}
-            className="mt-3"
+            className="mt-2"
           />
         </div>
 
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-10">
-          <Card className={cn('container-nested', themeClasses.background)}>
-            <CardContent className="p-4 text-center">
-              <div className={cn('text-3xl font-bold font-mono', themeClasses.accentText)}>
-                {encyclopediaCount}
-              </div>
-              <div className={cn('text-xs font-mono uppercase', themeClasses.text)}>Encyclopedia entries</div>
-            </CardContent>
-          </Card>
-          <Card className={cn('container-nested', themeClasses.background)}>
-            <CardContent className="p-4 text-center">
-              <div className={cn('text-3xl font-bold font-mono', themeClasses.accentText)}>
-                {glossaryCount}
-              </div>
-              <div className={cn('text-xs font-mono uppercase', themeClasses.text)}>Glossary terms</div>
-            </CardContent>
-          </Card>
-          <Card className={cn('container-nested', themeClasses.background)}>
-            <CardContent className="p-4 text-center">
-              <div className={cn('text-3xl font-bold font-mono', themeClasses.accentText)}>20</div>
-              <div className={cn('text-xs font-mono uppercase', themeClasses.text)}>Shareable guides</div>
-            </CardContent>
-          </Card>
-          <Card className={cn('container-nested', themeClasses.background)}>
-            <CardContent className="p-4 text-center">
-              <div className={cn('text-3xl font-bold font-mono', themeClasses.accentText)}>6</div>
-              <div className={cn('text-xs font-mono uppercase', themeClasses.text)}>Live labs</div>
-            </CardContent>
-          </Card>
+        {/* Compact stats */}
+        <div className="flex flex-wrap gap-x-6 gap-y-2 text-sm text-muted-foreground border-y border-border/50 py-4">
+          <span>
+            <strong className="text-foreground font-mono">{encyclopediaCount}</strong> encyclopedia
+            entries
+          </span>
+          <span>
+            <strong className="text-foreground font-mono">{glossaryCount}</strong> glossary terms
+          </span>
+          <span>
+            <strong className="text-foreground font-mono">20</strong> shareable guides
+          </span>
         </div>
 
-        <section className="mb-10">
-          <h2 className={cn('text-2xl font-bold font-mono uppercase mb-4', themeClasses.headerText)}>
-            Start Here
-          </h2>
+        {/* Start here */}
+        <section>
+          <SectionHeading
+            title="Start here"
+            description="New to meteorology? Follow this path before diving into the full encyclopedia."
+          />
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
             {START_HERE.map((item) => (
-              <Card key={item.step} className={cn('container-nested h-full', themeClasses.background)}>
+              <Card key={item.step} className="container-nested h-full border border-border/60">
                 <CardContent className="p-5 flex flex-col h-full">
-                  <span className={cn('text-xs font-mono font-bold', themeClasses.accentText)}>{item.step}</span>
-                  <h3 className={cn('text-lg font-mono font-bold uppercase mt-2', themeClasses.headerText)}>
-                    {item.title}
-                  </h3>
-                  <p className={cn('text-sm font-mono mt-2 flex-1', themeClasses.text)}>{item.description}</p>
+                  <span className="text-xs font-mono font-bold text-primary">{item.step}</span>
+                  <h3 className="text-lg font-semibold text-foreground mt-2">{item.title}</h3>
+                  <p className="text-sm text-muted-foreground mt-2 flex-1 leading-relaxed">
+                    {item.description}
+                  </p>
                   <Link
                     href={item.href}
-                    className={cn(
-                      'inline-flex items-center gap-1 mt-4 text-sm font-mono font-bold uppercase',
-                      themeClasses.accentText,
-                    )}
+                    className="inline-flex items-center gap-1 mt-4 text-sm font-semibold text-primary hover:underline"
                   >
                     {item.cta}
                     <ArrowRight size={14} />
@@ -242,34 +231,41 @@ export default function EducationHubClient({ latestPosts }: EducationHubClientPr
           </div>
         </section>
 
-        <section className="mb-10">
-          <CloudAltitudeStack />
+        {/* Main encyclopedia — moved up */}
+        <section>
+          <SectionHeading
+            title="Encyclopedia"
+            description="Browse the full reference libraries. Each section opens into detailed entries."
+          />
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
+            {educationTopics.map((topic) => (
+              <LearningCard key={topic.href} {...topic} />
+            ))}
+          </div>
         </section>
 
         {latestPosts.length > 0 && (
-          <section className="mb-10">
-            <div className="flex items-center justify-between gap-4 mb-4">
-              <h2 className={cn('text-2xl font-bold font-mono uppercase', themeClasses.headerText)}>
-                Latest From The Blog
+          <section>
+            <div className="flex items-end justify-between gap-4 mb-5">
+              <h2 className="text-xl sm:text-2xl font-bold font-mono uppercase tracking-wide text-primary">
+                Latest from the blog
               </h2>
-              <Link href="/blog" className={cn('text-xs font-mono font-bold uppercase', themeClasses.accentText)}>
-                All posts →
+              <Link href="/blog" className="text-sm font-semibold text-primary hover:underline shrink-0 pb-1">
+                All posts
               </Link>
             </div>
             <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
               {latestPosts.map((post, index) => (
-                <Link key={index} href={post.href} className="block h-full">
-                  <Card className={cn('container-nested h-full glow-interactive hover:scale-[1.02] transition-transform', themeClasses.background)}>
+                <Link key={index} href={post.href} className="block h-full group">
+                  <Card className="h-full border border-border/60 hover:border-primary/40 transition-colors">
                     <CardHeader className="pb-2">
-                      <CardTitle className={cn('text-base font-mono uppercase leading-snug', themeClasses.headerText)}>
+                      <CardTitle className="text-base font-semibold leading-snug text-foreground group-hover:text-primary transition-colors line-clamp-2">
                         {decodeHtmlEntities(post.title)}
                       </CardTitle>
-                      <p className={cn('text-[10px] font-mono uppercase', themeClasses.text)}>
-                        {post.displayDate}
-                      </p>
+                      <p className="text-xs text-muted-foreground">{post.displayDate}</p>
                     </CardHeader>
                     <CardContent>
-                      <p className={cn('text-sm font-mono line-clamp-3', themeClasses.text)}>
+                      <p className="text-sm text-muted-foreground leading-relaxed line-clamp-3">
                         {decodeHtmlEntities(post.summary)}
                       </p>
                     </CardContent>
@@ -280,30 +276,28 @@ export default function EducationHubClient({ latestPosts }: EducationHubClientPr
           </section>
         )}
 
-        <section className="mb-10">
-          <h2 className={cn('text-2xl font-bold font-mono uppercase mb-4', themeClasses.headerText)}>
-            Live Labs
-          </h2>
-          <p className={cn('text-sm font-mono mb-4 max-w-3xl', themeClasses.text)}>
-            Pair lessons with live data — watch the atmosphere while you learn.
-          </p>
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        <section>
+          <SectionHeading
+            title="Live labs"
+            description="Pair what you read with live data from the rest of the site."
+          />
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
             {LIVE_LABS.map((lab) => {
               const Icon = lab.icon
               return (
-                <Link key={lab.href} href={lab.href} className="block h-full">
-                  <Card className={cn('container-nested h-full hover:scale-[1.02] transition-transform', themeClasses.background)}>
-                    <CardContent className="p-4">
-                      <div className="flex items-start gap-3">
-                        <div className={cn('p-2 rounded-md', themeClasses.accentBg)}>
-                          <Icon className="w-5 h-5 text-black" />
-                        </div>
-                        <div>
-                          <h3 className={cn('font-mono font-bold uppercase text-sm', themeClasses.headerText)}>
-                            {lab.title}
-                          </h3>
-                          <p className={cn('text-xs font-mono mt-1', themeClasses.text)}>{lab.description}</p>
-                        </div>
+                <Link key={lab.href} href={lab.href} className="block group">
+                  <Card className="border border-border/60 hover:border-primary/40 transition-colors">
+                    <CardContent className="p-4 flex items-start gap-3">
+                      <div className="p-2 rounded-md bg-primary/15 text-primary shrink-0">
+                        <Icon className="w-5 h-5" />
+                      </div>
+                      <div>
+                        <h3 className="font-semibold text-foreground group-hover:text-primary transition-colors">
+                          {lab.title}
+                        </h3>
+                        <p className="text-sm text-muted-foreground mt-1 leading-relaxed">
+                          {lab.description}
+                        </p>
                       </div>
                     </CardContent>
                   </Card>
@@ -313,26 +307,22 @@ export default function EducationHubClient({ latestPosts }: EducationHubClientPr
           </div>
         </section>
 
-        <section className="mb-10">
-          <h2 className={cn('text-2xl font-bold font-mono uppercase mb-4', themeClasses.headerText)}>
-            Encyclopedia
-          </h2>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {educationTopics.map((topic) => (
-              <LearningCard key={topic.href} {...topic} />
-            ))}
-          </div>
+        {/* Quiz at bottom — optional practice */}
+        <section>
+          <SectionHeading
+            title="Practice"
+            description="A quick four-question check on cloud altitude layers. Wrong answers let you retry immediately."
+          />
+          <CloudAltitudeStack />
         </section>
 
-        <Card className={cn('container-primary text-center', themeClasses.background)}>
+        <Card className="border border-border/60 text-center">
           <CardContent className="p-8">
-            <h2 className={cn('text-2xl font-bold font-mono mb-3', themeClasses.headerText)}>STAY CURIOUS</h2>
-            <p className={cn('text-sm font-mono mb-4', themeClasses.text)}>
+            <h2 className="text-xl font-mono font-bold uppercase text-primary">Stay curious</h2>
+            <p className="text-sm text-muted-foreground mt-2 leading-relaxed">
               New guides, glossary terms, and blog dispatches added regularly.
             </p>
-            <div className={cn('inline-block px-4 py-2 text-xs font-mono font-bold rounded', themeClasses.accentBg)}>
-              LAST UPDATED: JUNE 2026
-            </div>
+            <p className="text-xs font-mono text-muted-foreground mt-4">Last updated: June 2026</p>
           </CardContent>
         </Card>
       </div>

--- a/components/education/education-hub-client.tsx
+++ b/components/education/education-hub-client.tsx
@@ -1,0 +1,342 @@
+'use client'
+
+import Link from 'next/link'
+import {
+  Cloud,
+  Zap,
+  BookOpen,
+  Thermometer,
+  BookMarked,
+  CloudLightning,
+  Sun,
+  Star,
+  Activity,
+  Radar,
+  Newspaper,
+  ArrowRight,
+} from 'lucide-react'
+import type { LucideIcon } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { useTheme } from '@/components/theme-provider'
+import { getComponentStyles, type ThemeType } from '@/lib/theme-utils'
+import PageWrapper from '@/components/page-wrapper'
+import LearningCard from '@/components/learn/LearningCard'
+import CloudAltitudeStack from '@/components/education/cloud-altitude-stack'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { ShareButtons } from '@/components/share-buttons'
+import { countEncyclopediaEntries } from '@/lib/education/entries'
+import { cloudDatabase } from '@/data/cloud-types'
+import { weatherPhenomena } from '@/data/fun-facts'
+import { weatherSystemsDatabase } from '@/data/weather-systems'
+import { getAllConcepts } from '@/lib/weather-concepts'
+import { getAllMetrics } from '@/lib/weather-definitions'
+
+export interface EducationHubPost {
+  slug: string
+  title: string
+  summary: string
+  date: string
+  href: string
+}
+
+interface EducationHubClientProps {
+  latestPosts: EducationHubPost[]
+}
+
+const START_HERE = [
+  {
+    step: '01',
+    title: 'Read the sky',
+    description: 'Start with common cloud types and altitude layers.',
+    href: '/cloud-types',
+    cta: 'Cloud Atlas',
+  },
+  {
+    step: '02',
+    title: 'Understand storms',
+    description: 'Learn fronts, cyclones, and what drives severe weather.',
+    href: '/weather-systems',
+    cta: 'Weather Systems',
+  },
+  {
+    step: '03',
+    title: 'Decode your dashboard',
+    description: 'Metrics and spotter concepts explained in plain language.',
+    href: '/education/glossary',
+    cta: 'Glossary',
+  },
+]
+
+const LIVE_LABS: { href: string; icon: LucideIcon; title: string; description: string }[] = [
+  {
+    href: '/severe',
+    icon: CloudLightning,
+    title: 'Severe Weather',
+    description: 'Active warnings and SPC outlook — see what you just studied in the wild.',
+  },
+  {
+    href: '/space-weather',
+    icon: Sun,
+    title: 'Space Weather',
+    description: 'Kp index, aurora, and solar wind tied to upper-atmosphere lessons.',
+  },
+  {
+    href: '/stargazer',
+    icon: Star,
+    title: 'Stargazer',
+    description: 'Sky clarity, moon phase, and seeing conditions for night-sky readers.',
+  },
+  {
+    href: '/radar',
+    icon: Radar,
+    title: 'Radar',
+    description: 'Watch reflectivity and velocity while learning storm structure.',
+  },
+  {
+    href: '/earth-sciences',
+    icon: Activity,
+    title: 'Earth Sciences',
+    description: 'Quakes, volcanoes, and planetary context for weather extremes.',
+  },
+  {
+    href: '/news',
+    icon: Newspaper,
+    title: 'News Feed',
+    description: 'NOAA, NASA, and USGS headlines to extend classroom topics.',
+  },
+]
+
+export default function EducationHubClient({ latestPosts }: EducationHubClientProps) {
+  const { theme } = useTheme()
+  const themeClasses = getComponentStyles((theme || 'nord') as ThemeType, 'weather')
+
+  const encyclopediaCount = countEncyclopediaEntries()
+  const glossaryCount = getAllMetrics().length + getAllConcepts().length
+
+  const educationTopics = [
+    {
+      href: '/weather-systems',
+      icon: Zap,
+      title: 'Weather Systems',
+      description:
+        'Atmospheric dynamics of 16 major storm types with historical case studies and threat levels.',
+      itemCount: weatherSystemsDatabase.length,
+    },
+    {
+      href: '/cloud-types',
+      icon: Cloud,
+      title: 'Cloud Atlas',
+      description:
+        'Cloud database covering genera, species, varieties, and rare formations with altitude data.',
+      itemCount: cloudDatabase.length,
+    },
+    {
+      href: '/fun-facts',
+      icon: BookOpen,
+      title: '16-Bit Takes',
+      description:
+        'The science behind the strange — from ball lightning to thundersnow and rare phenomena.',
+      itemCount: weatherPhenomena.length,
+    },
+    {
+      href: '/extremes',
+      icon: Thermometer,
+      title: 'Extremes',
+      description: 'Live hottest and coldest places on Earth with climate context modals.',
+      itemCount: undefined,
+    },
+    {
+      href: '/education/glossary',
+      icon: BookMarked,
+      title: 'Weather Glossary',
+      description: 'Dashboard metrics plus storm-spotter concepts — UV, CAPE, supercells, and more.',
+      itemCount: glossaryCount,
+    },
+  ]
+
+  return (
+    <PageWrapper>
+      <div className={cn('container mx-auto px-4 py-8', themeClasses.background)}>
+        <div className="mb-10">
+          <h1
+            className={cn(
+              'text-4xl sm:text-5xl md:text-6xl font-extrabold mb-4 font-mono',
+              themeClasses.accentText,
+              themeClasses.glow,
+            )}
+          >
+            EDUCATION HUB
+          </h1>
+          <p className={cn('text-base sm:text-lg font-mono max-w-3xl', themeClasses.text)}>
+            Your portal to weather knowledge — encyclopedias, live labs, glossary reference, and
+            weekly deep dives from the blog.
+          </p>
+          <ShareButtons
+            config={{
+              title: 'Weather Education Hub',
+              text: 'Learn meteorology with interactive weather lessons at 16bitweather.co',
+              url: 'https://www.16bitweather.co/education',
+            }}
+            className="mt-3"
+          />
+        </div>
+
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-10">
+          <Card className={cn('container-nested', themeClasses.background)}>
+            <CardContent className="p-4 text-center">
+              <div className={cn('text-3xl font-bold font-mono', themeClasses.accentText)}>
+                {encyclopediaCount}
+              </div>
+              <div className={cn('text-xs font-mono uppercase', themeClasses.text)}>Encyclopedia entries</div>
+            </CardContent>
+          </Card>
+          <Card className={cn('container-nested', themeClasses.background)}>
+            <CardContent className="p-4 text-center">
+              <div className={cn('text-3xl font-bold font-mono', themeClasses.accentText)}>
+                {glossaryCount}
+              </div>
+              <div className={cn('text-xs font-mono uppercase', themeClasses.text)}>Glossary terms</div>
+            </CardContent>
+          </Card>
+          <Card className={cn('container-nested', themeClasses.background)}>
+            <CardContent className="p-4 text-center">
+              <div className={cn('text-3xl font-bold font-mono', themeClasses.accentText)}>20</div>
+              <div className={cn('text-xs font-mono uppercase', themeClasses.text)}>Shareable guides</div>
+            </CardContent>
+          </Card>
+          <Card className={cn('container-nested', themeClasses.background)}>
+            <CardContent className="p-4 text-center">
+              <div className={cn('text-3xl font-bold font-mono', themeClasses.accentText)}>6</div>
+              <div className={cn('text-xs font-mono uppercase', themeClasses.text)}>Live labs</div>
+            </CardContent>
+          </Card>
+        </div>
+
+        <section className="mb-10">
+          <h2 className={cn('text-2xl font-bold font-mono uppercase mb-4', themeClasses.headerText)}>
+            Start Here
+          </h2>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            {START_HERE.map((item) => (
+              <Card key={item.step} className={cn('container-nested h-full', themeClasses.background)}>
+                <CardContent className="p-5 flex flex-col h-full">
+                  <span className={cn('text-xs font-mono font-bold', themeClasses.accentText)}>{item.step}</span>
+                  <h3 className={cn('text-lg font-mono font-bold uppercase mt-2', themeClasses.headerText)}>
+                    {item.title}
+                  </h3>
+                  <p className={cn('text-sm font-mono mt-2 flex-1', themeClasses.text)}>{item.description}</p>
+                  <Link
+                    href={item.href}
+                    className={cn(
+                      'inline-flex items-center gap-1 mt-4 text-sm font-mono font-bold uppercase',
+                      themeClasses.accentText,
+                    )}
+                  >
+                    {item.cta}
+                    <ArrowRight size={14} />
+                  </Link>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        </section>
+
+        <section className="mb-10">
+          <CloudAltitudeStack />
+        </section>
+
+        {latestPosts.length > 0 && (
+          <section className="mb-10">
+            <div className="flex items-center justify-between gap-4 mb-4">
+              <h2 className={cn('text-2xl font-bold font-mono uppercase', themeClasses.headerText)}>
+                Latest From The Blog
+              </h2>
+              <Link href="/blog" className={cn('text-xs font-mono font-bold uppercase', themeClasses.accentText)}>
+                All posts →
+              </Link>
+            </div>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              {latestPosts.map((post) => (
+                <Link key={post.slug} href={post.href} className="block h-full">
+                  <Card className={cn('container-nested h-full glow-interactive hover:scale-[1.02] transition-transform', themeClasses.background)}>
+                    <CardHeader className="pb-2">
+                      <CardTitle className={cn('text-base font-mono uppercase leading-snug', themeClasses.headerText)}>
+                        {post.title}
+                      </CardTitle>
+                      <p className={cn('text-[10px] font-mono uppercase', themeClasses.text)}>
+                        {new Date(post.date).toLocaleDateString('en-US', {
+                          month: 'short',
+                          day: 'numeric',
+                          year: 'numeric',
+                        })}
+                      </p>
+                    </CardHeader>
+                    <CardContent>
+                      <p className={cn('text-sm font-mono line-clamp-3', themeClasses.text)}>{post.summary}</p>
+                    </CardContent>
+                  </Card>
+                </Link>
+              ))}
+            </div>
+          </section>
+        )}
+
+        <section className="mb-10">
+          <h2 className={cn('text-2xl font-bold font-mono uppercase mb-4', themeClasses.headerText)}>
+            Live Labs
+          </h2>
+          <p className={cn('text-sm font-mono mb-4 max-w-3xl', themeClasses.text)}>
+            Pair lessons with live data — watch the atmosphere while you learn.
+          </p>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {LIVE_LABS.map((lab) => {
+              const Icon = lab.icon
+              return (
+                <Link key={lab.href} href={lab.href} className="block h-full">
+                  <Card className={cn('container-nested h-full hover:scale-[1.02] transition-transform', themeClasses.background)}>
+                    <CardContent className="p-4">
+                      <div className="flex items-start gap-3">
+                        <div className={cn('p-2 rounded-md', themeClasses.accentBg)}>
+                          <Icon className="w-5 h-5 text-black" />
+                        </div>
+                        <div>
+                          <h3 className={cn('font-mono font-bold uppercase text-sm', themeClasses.headerText)}>
+                            {lab.title}
+                          </h3>
+                          <p className={cn('text-xs font-mono mt-1', themeClasses.text)}>{lab.description}</p>
+                        </div>
+                      </div>
+                    </CardContent>
+                  </Card>
+                </Link>
+              )
+            })}
+          </div>
+        </section>
+
+        <section className="mb-10">
+          <h2 className={cn('text-2xl font-bold font-mono uppercase mb-4', themeClasses.headerText)}>
+            Encyclopedia
+          </h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {educationTopics.map((topic) => (
+              <LearningCard key={topic.href} {...topic} />
+            ))}
+          </div>
+        </section>
+
+        <Card className={cn('container-primary text-center', themeClasses.background)}>
+          <CardContent className="p-8">
+            <h2 className={cn('text-2xl font-bold font-mono mb-3', themeClasses.headerText)}>STAY CURIOUS</h2>
+            <p className={cn('text-sm font-mono mb-4', themeClasses.text)}>
+              New guides, glossary terms, and blog dispatches added regularly.
+            </p>
+            <div className={cn('inline-block px-4 py-2 text-xs font-mono font-bold rounded', themeClasses.accentBg)}>
+              LAST UPDATED: JUNE 2026
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </PageWrapper>
+  )
+}

--- a/components/education/glossary-entry-card.tsx
+++ b/components/education/glossary-entry-card.tsx
@@ -1,0 +1,123 @@
+'use client'
+
+/**
+ * Shared glossary entry card for metrics and meteorological concepts.
+ */
+
+import React from 'react'
+import type { LucideIcon } from 'lucide-react'
+import { BarChart3, Lightbulb, Ruler } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { useTheme } from '@/components/theme-provider'
+import { getComponentStyles, type ThemeType } from '@/lib/theme-utils'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import type { WeatherMetricDefinition } from '@/lib/weather-definitions'
+
+interface GlossaryEntryCardProps {
+  metric: WeatherMetricDefinition
+  icon?: LucideIcon
+}
+
+export function GlossaryEntryCard({ metric, icon: Icon }: GlossaryEntryCardProps) {
+  const { theme } = useTheme()
+  const themeClasses = getComponentStyles((theme || 'nord') as ThemeType, 'weather')
+
+  return (
+    <section id={metric.id} className="scroll-mt-24">
+      <Card className="weather-card-gradient border-0 border-t-2 border-t-primary/40 shadow-md">
+        <CardHeader className="pb-4 pt-6 px-6">
+          <CardTitle
+            className={cn(
+              'text-xl sm:text-2xl font-bold tracking-wide uppercase flex items-center gap-3 font-mono',
+              themeClasses.headerText,
+            )}
+          >
+            {Icon && <Icon size={22} className="text-primary" />}
+            {metric.name}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="px-6 pb-6 space-y-6">
+          <div>
+            <h3
+              className={cn(
+                'text-sm font-bold uppercase tracking-widest mb-2 flex items-center gap-2 font-mono',
+                themeClasses.accentText,
+              )}
+            >
+              <BarChart3 size={14} />
+              What is it?
+            </h3>
+            <p className={cn('text-sm leading-relaxed', themeClasses.text)}>{metric.detailed}</p>
+          </div>
+
+          <div>
+            <h3
+              className={cn(
+                'text-sm font-bold uppercase tracking-widest mb-2 flex items-center gap-2 font-mono',
+                themeClasses.accentText,
+              )}
+            >
+              <Ruler size={14} />
+              How is it measured?
+            </h3>
+            <p className={cn('text-sm leading-relaxed', themeClasses.text)}>{metric.howMeasured}</p>
+          </div>
+
+          <div>
+            <h3
+              className={cn(
+                'text-sm font-bold uppercase tracking-widest mb-3 flex items-center gap-2 font-mono',
+                themeClasses.accentText,
+              )}
+            >
+              <BarChart3 size={14} />
+              What do the values mean?
+            </h3>
+            <div className="grid gap-2">
+              {metric.ranges.map((range) => (
+                <div
+                  key={range.label}
+                  className={cn(
+                    'flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-4 p-3 rounded-lg',
+                    'bg-background/50 border border-primary/10',
+                  )}
+                >
+                  <div className="flex items-center gap-2 sm:min-w-[160px]">
+                    <Badge variant="outline" className="border-primary/30 font-mono text-xs">
+                      {range.label}
+                    </Badge>
+                    <span className={cn('text-xs font-mono tabular-nums', themeClasses.accentText)}>
+                      {range.range}
+                    </span>
+                  </div>
+                  <p className={cn('text-xs leading-relaxed', themeClasses.text)}>{range.description}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <h3
+              className={cn(
+                'text-sm font-bold uppercase tracking-widest mb-3 flex items-center gap-2 font-mono',
+                themeClasses.accentText,
+              )}
+            >
+              <Lightbulb size={14} />
+              Practical Tips
+            </h3>
+            <ul className="space-y-2">
+              {metric.practicalTips.map((tip, i) => (
+                <li key={i} className={cn('flex items-start gap-2 text-sm leading-relaxed', themeClasses.text)}>
+                  <span className="text-primary mt-0.5 font-bold">&#x203A;</span>
+                  {tip}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </CardContent>
+      </Card>
+    </section>
+  )
+}

--- a/components/education/phenomenon-detail.tsx
+++ b/components/education/phenomenon-detail.tsx
@@ -1,0 +1,104 @@
+'use client'
+
+import Link from 'next/link'
+import { ShareButtons } from '@/components/share-buttons'
+import EducationBreadcrumb from '@/components/education/education-breadcrumb'
+import EducationBackLink from '@/components/education/education-back-link'
+import PageWrapper from '@/components/page-wrapper'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import type { WeatherPhenomena } from '@/data/fun-facts'
+import { getEducationDetailHref } from '@/lib/education/entries'
+import { cn } from '@/lib/utils'
+import { useTheme } from '@/components/theme-provider'
+import { getComponentStyles, type ThemeType } from '@/lib/theme-utils'
+
+interface PhenomenonDetailProps {
+  phenomenon: WeatherPhenomena
+}
+
+export default function PhenomenonDetail({ phenomenon }: PhenomenonDetailProps) {
+  const { theme } = useTheme()
+  const themeClasses = getComponentStyles((theme || 'nord') as ThemeType, 'weather')
+  const url = `https://www.16bitweather.co${getEducationDetailHref('phenomenon', phenomenon.id)}`
+
+  return (
+    <PageWrapper>
+      <div className={cn('container mx-auto px-4 py-8 max-w-4xl', themeClasses.background)}>
+        <EducationBreadcrumb
+          items={[
+            { label: 'Education', href: '/education' },
+            { label: '16-Bit Takes', href: '/fun-facts' },
+            { label: phenomenon.name },
+          ]}
+        />
+        <EducationBackLink href="/fun-facts" label="All phenomena" />
+
+        <div className="text-center mb-8">
+          <div className="text-5xl mb-3">{phenomenon.emoji}</div>
+          <h1 className={cn('text-3xl md:text-5xl font-bold font-mono uppercase', themeClasses.headerText, themeClasses.glow)}>
+            {phenomenon.name}
+          </h1>
+          <p className={cn('text-sm font-mono mt-2', themeClasses.secondaryText)}>
+            {phenomenon.category} · {phenomenon.rarity}
+          </p>
+          <ShareButtons
+            config={{ title: `${phenomenon.name} — 16-Bit Takes`, text: phenomenon.description, url }}
+            className="mt-4 justify-center"
+          />
+        </div>
+
+        <Card className={cn('container-primary mb-6', themeClasses.background)}>
+          <CardContent className="p-6">
+            <p className={cn('font-mono text-sm', themeClasses.text)}>{phenomenon.description}</p>
+            <p className={cn('font-mono text-xs italic mt-4', themeClasses.secondaryText)}>{phenomenon.bitFact}</p>
+          </CardContent>
+        </Card>
+
+        {phenomenon.scientificMechanism && (
+          <Card className="container-nested mb-6">
+            <CardHeader><CardTitle className="font-mono text-sm uppercase">The science</CardTitle></CardHeader>
+            <CardContent className="text-sm font-mono">{phenomenon.scientificMechanism}</CardContent>
+          </Card>
+        )}
+
+        <Card className="container-nested mb-6">
+          <CardHeader><CardTitle className="font-mono text-sm uppercase">How to spot it</CardTitle></CardHeader>
+          <CardContent className="text-sm font-mono">{phenomenon.howToSpot}</CardContent>
+        </Card>
+
+        <div className="grid gap-6 md:grid-cols-2 mb-6">
+          <Card className="container-nested">
+            <CardHeader><CardTitle className="font-mono text-sm uppercase">Where</CardTitle></CardHeader>
+            <CardContent className="text-sm font-mono">{phenomenon.whereToSee}</CardContent>
+          </Card>
+          <Card className="container-nested">
+            <CardHeader><CardTitle className="font-mono text-sm uppercase">Best season</CardTitle></CardHeader>
+            <CardContent className="text-sm font-mono">{phenomenon.bestSeason}</CardContent>
+          </Card>
+        </div>
+
+        {phenomenon.historicalOccurrence && (
+          <Card className="container-nested mb-6">
+            <CardHeader><CardTitle className="font-mono text-sm uppercase">Famous encounter</CardTitle></CardHeader>
+            <CardContent className="text-sm font-mono">{phenomenon.historicalOccurrence}</CardContent>
+          </Card>
+        )}
+
+        <ul className="space-y-2 mb-6">
+          {phenomenon.facts.map((fact) => (
+            <li key={fact} className={cn('text-sm font-mono flex gap-2', themeClasses.text)}>
+              <span className={themeClasses.accentText}>▸</span>
+              {fact}
+            </li>
+          ))}
+        </ul>
+
+        <div className="flex flex-wrap gap-4 justify-center">
+          <Link href="/fun-facts" className={cn('text-sm font-mono uppercase', themeClasses.text)}>
+            Browse all phenomena
+          </Link>
+        </div>
+      </div>
+    </PageWrapper>
+  )
+}

--- a/components/education/weather-system-detail.tsx
+++ b/components/education/weather-system-detail.tsx
@@ -1,0 +1,107 @@
+'use client'
+
+import Link from 'next/link'
+import { ShareButtons } from '@/components/share-buttons'
+import EducationBreadcrumb from '@/components/education/education-breadcrumb'
+import EducationBackLink from '@/components/education/education-back-link'
+import PageWrapper from '@/components/page-wrapper'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import type { WeatherSystemData } from '@/data/weather-systems'
+import { getEducationDetailHref, systemSlug } from '@/lib/education/entries'
+import { cn } from '@/lib/utils'
+import { useTheme } from '@/components/theme-provider'
+import { getComponentStyles, type ThemeType } from '@/lib/theme-utils'
+
+interface WeatherSystemDetailProps {
+  system: WeatherSystemData
+}
+
+export default function WeatherSystemDetail({ system }: WeatherSystemDetailProps) {
+  const { theme } = useTheme()
+  const themeClasses = getComponentStyles((theme || 'nord') as ThemeType, 'weather')
+  const slug = systemSlug(system)
+  const url = `https://www.16bitweather.co${getEducationDetailHref('weather-system', slug)}`
+
+  return (
+    <PageWrapper>
+      <div className={cn('container mx-auto px-4 py-8 max-w-4xl', themeClasses.background)}>
+        <EducationBreadcrumb
+          items={[
+            { label: 'Education', href: '/education' },
+            { label: 'Weather Systems', href: '/weather-systems' },
+            { label: system.name },
+          ]}
+        />
+        <EducationBackLink href="/weather-systems" label="All weather systems" />
+
+        <div className="text-center mb-8">
+          <div className="text-5xl mb-3">{system.emoji}</div>
+          <h1 className={cn('text-3xl md:text-5xl font-bold font-mono uppercase', themeClasses.headerText, themeClasses.glow)}>
+            {system.name}
+          </h1>
+          <p className={cn('text-sm font-mono mt-2', themeClasses.secondaryText)}>{system.classification}</p>
+          <ShareButtons
+            config={{ title: `${system.name} — Weather Systems`, text: system.description16bit, url }}
+            className="mt-4 justify-center"
+          />
+        </div>
+
+        <Card className={cn('container-primary mb-6', themeClasses.background)}>
+          <CardContent className="p-6">
+            <p className={cn('font-mono text-sm italic text-center', themeClasses.text)}>&ldquo;{system.description16bit}&rdquo;</p>
+          </CardContent>
+        </Card>
+
+        <div className="grid gap-6 md:grid-cols-2 mb-6">
+          <Card className="container-nested">
+            <CardHeader><CardTitle className="font-mono text-sm uppercase">Formation</CardTitle></CardHeader>
+            <CardContent className="text-sm font-mono">{system.formationProcess}</CardContent>
+          </Card>
+          <Card className="container-nested">
+            <CardHeader><CardTitle className="font-mono text-sm uppercase">Impact</CardTitle></CardHeader>
+            <CardContent className="text-sm font-mono">{system.weatherImpact}</CardContent>
+          </Card>
+        </div>
+
+        <Card className="container-nested mb-6">
+          <CardHeader><CardTitle className="font-mono text-sm uppercase">Technical specs</CardTitle></CardHeader>
+          <CardContent className="space-y-2 text-sm font-mono">
+            <div className="flex justify-between gap-4"><span className="opacity-70">Wind</span><span>{system.windSpeed}</span></div>
+            {system.pressureRange && (
+              <div className="flex justify-between gap-4"><span className="opacity-70">Pressure</span><span>{system.pressureRange}</span></div>
+            )}
+            {system.temperatureRange && (
+              <div className="flex justify-between gap-4"><span className="opacity-70">Temperature</span><span>{system.temperatureRange}</span></div>
+            )}
+            <div className="flex justify-between gap-4"><span className="opacity-70">Regions</span><span className="text-right">{system.geographicRegions}</span></div>
+            <Badge variant="outline" className="font-mono mt-2">{system.rarity.replace('-', ' ')}</Badge>
+          </CardContent>
+        </Card>
+
+        {system.notableEvent && (
+          <Card className="container-nested mb-6">
+            <CardHeader><CardTitle className="font-mono text-sm uppercase">Famous encounter</CardTitle></CardHeader>
+            <CardContent className="text-sm font-mono">{system.notableEvent}</CardContent>
+          </Card>
+        )}
+
+        {system.etymology && (
+          <Card className="container-nested mb-6">
+            <CardHeader><CardTitle className="font-mono text-sm uppercase">Etymology</CardTitle></CardHeader>
+            <CardContent className="text-sm font-mono">{system.etymology}</CardContent>
+          </Card>
+        )}
+
+        <div className="flex flex-wrap gap-4 justify-center">
+          <Link href="/severe" className={cn('text-sm font-mono font-bold uppercase underline', themeClasses.accentText)}>
+            Open Severe Weather lab →
+          </Link>
+          <Link href="/weather-systems" className={cn('text-sm font-mono uppercase', themeClasses.text)}>
+            Browse all systems
+          </Link>
+        </div>
+      </div>
+    </PageWrapper>
+  )
+}

--- a/components/learn/LearningCard.tsx
+++ b/components/learn/LearningCard.tsx
@@ -53,7 +53,7 @@ export default function LearningCard({
             <Icon className="w-8 h-8 text-black" />
           </div>
           <CardTitle className={cn(
-            'text-xl font-bold font-mono uppercase mb-2 transition-colors',
+            'text-lg font-bold font-mono uppercase mb-2 transition-colors',
             'group-hover:' + themeClasses.accentText,
             themeClasses.headerText
           )}>
@@ -61,10 +61,7 @@ export default function LearningCard({
           </CardTitle>
         </CardHeader>
         <CardContent className="flex-1 text-center">
-          <p className={cn(
-            'text-sm font-mono mb-4',
-            themeClasses.text
-          )}>
+          <p className="text-sm text-muted-foreground mb-4 leading-relaxed">
             {description}
           </p>
 

--- a/components/metric-info-tooltip.tsx
+++ b/components/metric-info-tooltip.tsx
@@ -53,7 +53,7 @@ export function MetricInfoTooltip({ metricId }: MetricInfoTooltipProps): React.R
           {metric.brief}
         </p>
         <Link
-          href={`/learn/glossary#${metric.id}`}
+          href={`/education/glossary#${metric.id}`}
           className="text-xs font-medium text-primary hover:underline inline-flex items-center gap-1"
         >
           Learn more →

--- a/lib/education/entries.ts
+++ b/lib/education/entries.ts
@@ -1,0 +1,129 @@
+/**
+ * Education encyclopedia entry registry — slugs, lookups, and featured detail pages.
+ */
+
+import { cloudDatabase } from '@/data/cloud-types'
+import { weatherPhenomena } from '@/data/fun-facts'
+import { weatherSystemsDatabase } from '@/data/weather-systems'
+import type { CloudData } from '@/data/cloud-types'
+import type { WeatherPhenomena } from '@/data/fun-facts'
+import type { WeatherSystemData } from '@/data/weather-systems'
+import { toEducationSlug } from '@/lib/education/slugs'
+
+export type EducationEntryKind = 'weather-system' | 'cloud' | 'phenomenon'
+
+export interface EducationEntryRef {
+  kind: EducationEntryKind
+  slug: string
+  title: string
+  summary: string
+  href: string
+}
+
+/** Top 20 shareable detail pages (7 systems + 7 clouds + 6 phenomena). */
+export const FEATURED_DETAIL_SLUGS: Record<EducationEntryKind, string[]> = {
+  'weather-system': [
+    'cyclones',
+    'anticyclones',
+    'warm-fronts',
+    'cold-fronts',
+    'jet-streams',
+    'tropical-cyclones',
+    'polar-vortex',
+  ],
+  cloud: [
+    'cirrus',
+    'cumulus',
+    'cumulonimbus',
+    'stratus',
+    'nimbostratus',
+    'altocumulus',
+    'lenticular',
+  ],
+  phenomenon: [
+    'ball-lightning',
+    'thundersnow',
+    'microbursts',
+    'sun-dogs',
+    'haboob',
+    'sprites',
+  ],
+}
+
+function systemSlug(system: WeatherSystemData): string {
+  return toEducationSlug(system.name)
+}
+
+function cloudSlug(cloud: CloudData): string {
+  return toEducationSlug(cloud.name)
+}
+
+export function getWeatherSystemBySlug(slug: string): WeatherSystemData | undefined {
+  return weatherSystemsDatabase.find((s) => systemSlug(s) === slug)
+}
+
+export function getCloudBySlug(slug: string): CloudData | undefined {
+  return cloudDatabase.find((c) => cloudSlug(c) === slug)
+}
+
+export function getPhenomenonBySlug(slug: string): WeatherPhenomena | undefined {
+  return weatherPhenomena.find((p) => p.id === slug)
+}
+
+export function getEducationDetailHref(kind: EducationEntryKind, slug: string): string {
+  const segment =
+    kind === 'weather-system' ? 'weather-systems' : kind === 'cloud' ? 'cloud-types' : 'phenomena'
+  return `/education/${segment}/${slug}`
+}
+
+export function getFeaturedDetailEntries(): EducationEntryRef[] {
+  const systems = FEATURED_DETAIL_SLUGS['weather-system']
+    .map((slug) => {
+      const entry = getWeatherSystemBySlug(slug)
+      if (!entry) return null
+      return {
+        kind: 'weather-system' as const,
+        slug,
+        title: entry.name,
+        summary: entry.description16bit,
+        href: getEducationDetailHref('weather-system', slug),
+      }
+    })
+    .filter(Boolean) as EducationEntryRef[]
+
+  const clouds = FEATURED_DETAIL_SLUGS.cloud
+    .map((slug) => {
+      const entry = getCloudBySlug(slug)
+      if (!entry) return null
+      return {
+        kind: 'cloud' as const,
+        slug,
+        title: entry.name,
+        summary: entry.description16bit,
+        href: getEducationDetailHref('cloud', slug),
+      }
+    })
+    .filter(Boolean) as EducationEntryRef[]
+
+  const phenomena = FEATURED_DETAIL_SLUGS.phenomenon
+    .map((slug) => {
+      const entry = getPhenomenonBySlug(slug)
+      if (!entry) return null
+      return {
+        kind: 'phenomenon' as const,
+        slug,
+        title: entry.name,
+        summary: entry.description,
+        href: getEducationDetailHref('phenomenon', slug),
+      }
+    })
+    .filter(Boolean) as EducationEntryRef[]
+
+  return [...systems, ...clouds, ...phenomena]
+}
+
+export function countEncyclopediaEntries(): number {
+  return weatherSystemsDatabase.length + cloudDatabase.length + weatherPhenomena.length
+}
+
+export { systemSlug, cloudSlug }

--- a/lib/education/slugs.ts
+++ b/lib/education/slugs.ts
@@ -1,0 +1,8 @@
+/** Slug helpers for education encyclopedia entries. */
+
+export function toEducationSlug(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}

--- a/lib/utils/redirect-validation.ts
+++ b/lib/utils/redirect-validation.ts
@@ -25,8 +25,8 @@ const ALLOWED_REDIRECT_PATHS = [
 const ALLOWED_REDIRECT_PATTERNS = [
   /^\/weather\/[^\/]+$/,           // /weather/[city]
   /^\/gfs-model\/[^\/]+\/[^\/]+$/, // /gfs-model/[region]/[run]
-  /^\/education\/[^\/]+$/,                    // /education/glossary
-  /^\/education\/[^\/]+\/[^\/]+$/,           // /education/weather-systems/[slug]
+  /^\/education\/glossary$/,
+  /^\/education\/(?:weather-systems|cloud-types|phenomena)\/[a-z0-9]+(?:-[a-z0-9]+)*$/,
 ]
 
 /**

--- a/lib/utils/redirect-validation.ts
+++ b/lib/utils/redirect-validation.ts
@@ -25,7 +25,8 @@ const ALLOWED_REDIRECT_PATHS = [
 const ALLOWED_REDIRECT_PATTERNS = [
   /^\/weather\/[^\/]+$/,           // /weather/[city]
   /^\/gfs-model\/[^\/]+\/[^\/]+$/, // /gfs-model/[region]/[run]
-  /^\/education\/[^\/]+$/,         // /education/[topic]
+  /^\/education\/[^\/]+$/,                    // /education/glossary
+  /^\/education\/[^\/]+\/[^\/]+$/,           // /education/weather-systems/[slug]
 ]
 
 /**

--- a/lib/weather-concepts.ts
+++ b/lib/weather-concepts.ts
@@ -1,0 +1,140 @@
+/**
+ * Meteorological concept definitions for the education glossary.
+ * Complements dashboard metric definitions in weather-definitions.ts.
+ */
+
+import type { WeatherMetricDefinition } from '@/lib/weather-definitions'
+
+export const WEATHER_CONCEPTS: Record<string, WeatherMetricDefinition> = {
+  supercell: {
+    id: 'supercell',
+    name: 'Supercell',
+    brief:
+      'A long-lived thunderstorm with a deep, persistently rotating updraft called a mesocyclone — the rarest but most dangerous storm type.',
+    detailed:
+      'Supercells are organized thunderstorms maintained by a rotating updraft. Wind shear tilts the storm so the updraft and downdraft do not cancel each other, allowing the cell to live for hours and travel hundreds of miles. They produce the strongest tornadoes, largest hail, and most destructive downbursts. Only a small fraction of thunderstorms become supercells, but they account for a disproportionate share of severe weather damage.',
+    howMeasured:
+      'Identified on radar by a persistent mesocyclone (rotating velocity couplet), a bounded weak echo region (BWER), and often a hook echo on reflectivity. Storm spotters look for a rotating wall cloud, tail cloud, and anvil with crisp edges.',
+    ranges: [
+      { label: 'Classic', range: 'Plains profile', description: 'Large hail and tornadoes common. Most photographed supercell type.' },
+      { label: 'Low-precip', range: 'LP supercell', description: 'Sculpted structure, less rain, still tornado-capable.' },
+      { label: 'High-precip', range: 'HP supercell', description: 'Heavy rain wraps the mesocyclone; tornadoes can be rain-wrapped and hard to see.' },
+    ],
+    practicalTips: [
+      'Supercells need CAPE, moisture, and wind shear — watch the SPC outlook during spring on the Plains.',
+      'A rotating wall cloud under a supercell is a tornado warning sign even before a funnel appears.',
+      'Never chase without training — supercells produce lightning, hail, and flooding in addition to tornadoes.',
+    ],
+  },
+  cape: {
+    id: 'cape',
+    name: 'CAPE',
+    brief:
+      'Convective Available Potential Energy — how much buoyancy is available to fuel thunderstorm updrafts, measured in J/kg.',
+    detailed:
+      'CAPE represents the energy a parcel of air would gain if lifted through the atmosphere. Higher CAPE means stronger potential updrafts and more vigorous thunderstorms. Values below 500 J/kg rarely support severe storms; 1000–2500 J/kg is typical for summer afternoon storms; above 3000 J/kg can support explosive supercell development when shear is present.',
+    howMeasured:
+      'Calculated from a radiosonde (weather balloon) or model sounding by integrating the area between the environmental temperature profile and the lifted parcel curve on a skew-T diagram.',
+    ranges: [
+      { label: 'Weak', range: '< 500 J/kg', description: 'Little thunderstorm potential.' },
+      { label: 'Moderate', range: '500–1500 J/kg', description: 'Scattered thunderstorms possible.' },
+      { label: 'Strong', range: '1500–3000 J/kg', description: 'Robust convection; severe storms possible with shear.' },
+      { label: 'Extreme', range: '> 3000 J/kg', description: 'Explosive thunderstorm growth possible — monitor warnings closely.' },
+    ],
+    practicalTips: [
+      'CAPE alone does not make supercells — wind shear organizes rotation.',
+      'Morning CAPE can be misleading; afternoon heating often doubles values in summer.',
+      'High CAPE with a cap (CIN) may mean storms wait until the cap breaks — watch timing.',
+    ],
+  },
+  mesocyclone: {
+    id: 'mesocyclone',
+    name: 'Mesocyclone',
+    brief:
+      'A cyclonically rotating vortex 2–10 km wide within a thunderstorm — the rotating heart of a supercell and precursor to most strong tornadoes.',
+    detailed:
+      'Mesocyclones form when horizontal vorticity in the environment is tilted vertically by a strong updraft and stretched, increasing rotation rate. They persist for tens of minutes to hours, much longer than short-lived gustnado rotation. Not every mesocyclone produces a tornado, but nearly every significant tornado comes from a mesocyclone.',
+    howMeasured:
+      'Doppler radar detects mesocyclones via a velocity couplet — inbound and outbound winds side by side. Rotation must meet depth, duration, and shear thresholds to be classified.',
+    ranges: [
+      { label: 'Weak', range: 'Broad rotation', description: 'Organized storm possible; tornado risk lower.' },
+      { label: 'Strong', range: 'Tight couplet', description: 'Tornado watch/warning territory.' },
+      { label: 'Violent', range: 'Persistent + tight', description: 'Significant tornado potential — take shelter immediately.' },
+    ],
+    practicalTips: [
+      'A tornado warning means rotation is detected or a funnel is reported — do not wait for visual confirmation.',
+      'Mesocyclones can produce tornadoes with little warning when rain-wrapped.',
+      'Learn the difference between a mesocyclone (storm-scale) and a tornado (ground contact).',
+    ],
+  },
+  'wind-shear': {
+    id: 'wind-shear',
+    name: 'Wind Shear',
+    brief:
+      'Change in wind speed or direction with height — critical for organizing storm rotation and aviation safety.',
+    detailed:
+      'Vertical wind shear separates updraft from downdraft in supercells, allowing them to survive. Speed shear (winds increasing with height) and directional shear (wind backing or veering) both matter. Low-level shear in the 0–3 km layer is especially important for tornado formation. Horizontal wind shear at fronts can also trigger turbulence.',
+    howMeasured:
+      'Derived from radiosonde winds at multiple heights, Doppler radar velocity profiles, or pilot reports (PIREPs). Aviation uses shear alerts when speed changes exceed 15 kt in the lowest few thousand feet.',
+    ranges: [
+      { label: 'Weak', range: '< 10 kt / 6 km', description: 'Pulse storms or clusters; short-lived.' },
+      { label: 'Moderate', range: '10–20 kt', description: 'Organized multicells; some supercell potential.' },
+      { label: 'Strong', range: '> 20 kt', description: 'Supercells and tornadoes more likely.' },
+    ],
+    practicalTips: [
+      'Sudden wind shifts at the surface often mean a front or outflow boundary is passing.',
+      'Pilots should review shear forecasts before takeoff and landing in thunderstorm season.',
+      'Directional shear + high CAPE is the classic supercell setup in Tornado Alley.',
+    ],
+  },
+  updraft: {
+    id: 'updraft',
+    name: 'Updraft',
+    brief:
+      'A column of rising air inside a storm — in supercells it rotates and can exceed 100 mph vertically.',
+    detailed:
+      'Updrafts form when air is warmer and moister than its surroundings and becomes buoyant. In ordinary storms, updrafts last 15–30 minutes. In supercells, rotation and shear help sustain updrafts for hours. Updraft strength determines hail size (stronger updrafts suspend larger hailstones longer) and tornado potential when paired with rotation.',
+    howMeasured:
+      'Estimated from radar reflectivity cores, satellite cloud-top temperature, lightning rates, and dual-pol radar products. Storm spotters infer strength from cloud base lowering and rapid vertical growth.',
+    ranges: [
+      { label: 'Weak', range: '< 20 mph', description: 'Fair-weather cumulus or weak showers.' },
+      { label: 'Moderate', range: '20–50 mph', description: 'Garden-variety thunderstorms.' },
+      { label: 'Strong', range: '50–100 mph', description: 'Severe hail and wind likely.' },
+      { label: 'Extreme', range: '> 100 mph', description: 'Supercell core — giant hail and tornado risk.' },
+    ],
+    practicalTips: [
+      'Rapidly rising cloud towers signal strengthening updrafts — seek shelter if storms approach.',
+      'Anvil tops spreading downwind mark the top of the updraft hitting the tropopause.',
+      'Avoid flying through strong updrafts — severe turbulence and icing are guaranteed.',
+    ],
+  },
+  'dew-point': {
+    id: 'dew-point',
+    name: 'Dew Point',
+    brief:
+      'The temperature air must cool to for saturation — a direct measure of moisture that drives heat index and storm fuel.',
+    detailed:
+      'Unlike relative humidity, dew point is comparable across temperatures. Dew points above 65°F feel muggy; above 70°F is oppressive in summer. In storm forecasting, dew points above 60°F in the Plains often provide enough moisture for severe thunderstorms when other ingredients align.',
+    howMeasured:
+      'Calculated from wet-bulb temperature or measured directly with chilled-mirror hygrometers at weather stations.',
+    ranges: [
+      { label: 'Dry', range: '< 40°F', description: 'Comfortable; low storm moisture.' },
+      { label: 'Moderate', range: '40–60°F', description: 'Pleasant to slightly humid.' },
+      { label: 'Humid', range: '60–70°F', description: 'Muggy; good thunderstorm moisture.' },
+      { label: 'Oppressive', range: '> 70°F', description: 'Dangerous heat index combinations possible.' },
+    ],
+    practicalTips: [
+      'Watch dew point more than humidity percentage when judging comfort.',
+      'Rising dew points ahead of a front often signal increasing storm potential.',
+      'Dew point spreading from the Gulf is a key ingredient in Plains severe weather setups.',
+    ],
+  },
+}
+
+export function getConceptDefinition(id: string): WeatherMetricDefinition | undefined {
+  return WEATHER_CONCEPTS[id]
+}
+
+export function getAllConcepts(): WeatherMetricDefinition[] {
+  return Object.values(WEATHER_CONCEPTS)
+}


### PR DESCRIPTION
## Summary
- Expand the weather glossary with meteorology concepts (supercell, CAPE, mesocyclone, wind shear, updraft, dew point) so blog keyTerms anchors resolve and dashboard tooltips link to `/education/glossary`.
- Rebuild the education hub with real encyclopedia stats, a Start Here path, latest blog posts, Live Labs links, and an interactive Cloud Altitude Lab.
- Add breadcrumbs and back navigation across weather systems, cloud atlas, fun facts, and extremes.
- Ship 20 shareable SEO detail pages under `/education/weather-systems/[slug]`, `/education/cloud-types/[slug]`, and `/education/phenomena/[slug]`, with sitemap and redirect allowlist updates.

## Commits
1. feat(education): expand glossary with meteorology concepts
2. feat(education): rebuild hub with blog feed, live labs, and cloud lab
3. feat(education): add breadcrumbs and back navigation on encyclopedia pages
4. feat(education): add shareable detail pages for top 20 encyclopedia entries

## Test plan
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test -- education-entries.test.ts weather-concepts.test.ts sitemap-seo.test.ts blog-key-terms.test.tsx`
- [x] `npx playwright test tests/e2e/weather-app.spec.ts tests/e2e/blog.spec.ts --project=chromium`
- [ ] Manual: visit `/education`, complete Cloud Altitude Lab, open `/education/glossary#supercell`, open `/education/weather-systems/cyclones`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new education detail pages for featured weather systems, cloud types, and phenomena, with share-ready canonical URLs.
  * Expanded the Education Hub with an interactive cloud altitude quiz and enriched learning/glossary content.
  * Refreshed the education glossary using reusable entry cards and improved jump navigation.
* **Bug Fixes**
  * Improved sitemap coverage and SEO metadata for education detail pages to help them appear correctly when sharing/discovering.
  * Updated the “Learn more” glossary link and tightened education redirect allowlisting.
* **Documentation**
  * Enhanced breadcrumb and back-link navigation across education-related pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->