### PR TITLE
fix(seo): map all weather-system guides for GSC indexing

### DIFF
--- a/__tests__/education-entries.test.ts
+++ b/__tests__/education-entries.test.ts
@@ -1,6 +1,8 @@
 import {
   FEATURED_DETAIL_SLUGS,
   countEncyclopediaEntries,
+  countShareableGuidePages,
+  getAllWeatherSystemSlugs,
   getCloudBySlug,
   getEducationDetailHref,
   getPhenomenonBySlug,
@@ -22,6 +24,20 @@ describe('education entries', () => {
     expect(getWeatherSystemBySlug('jet-streams')?.name).toBe('JET STREAMS')
   })
 
+  it('generates slugs for every weather system encyclopedia entry', () => {
+    const slugs = getAllWeatherSystemSlugs()
+    expect(slugs).toHaveLength(weatherSystemsDatabase.length)
+    expect(slugs.every((slug) => getWeatherSystemBySlug(slug))).toBe(true)
+  })
+
+  it('counts shareable guide pages', () => {
+    expect(countShareableGuidePages()).toBe(
+      weatherSystemsDatabase.length +
+        FEATURED_DETAIL_SLUGS.cloud.length +
+        FEATURED_DETAIL_SLUGS.phenomenon.length,
+    )
+  })
+
   it('resolves featured cloud slugs', () => {
     expect(getCloudBySlug('cumulonimbus')?.name).toBe('CUMULONIMBUS')
     expect(getCloudBySlug('lenticular')?.name).toBe('LENTICULAR')
@@ -40,11 +56,11 @@ describe('education entries', () => {
     expect(getEducationDetailHref('phenomenon', 'haboob')).toBe('/education/phenomena/haboob')
   })
 
-  it('defines exactly 20 featured detail pages', () => {
-    const total =
+  it('defines featured spotlight pages for hub highlights', () => {
+    const spotlightTotal =
       FEATURED_DETAIL_SLUGS['weather-system'].length +
       FEATURED_DETAIL_SLUGS.cloud.length +
       FEATURED_DETAIL_SLUGS.phenomenon.length
-    expect(total).toBe(20)
+    expect(spotlightTotal).toBe(20)
   })
 })

--- a/__tests__/sitemap-seo.test.ts
+++ b/__tests__/sitemap-seo.test.ts
@@ -86,8 +86,12 @@ describe('Sitemap SEO', () => {
     expect(sitemapPaths.some((p) => p.startsWith('/stargazer/objects/'))).toBe(true)
   })
 
-  it('sitemap should include all featured education detail guide pages', async () => {
-    const { FEATURED_DETAIL_SLUGS, getEducationDetailHref } = await import('@/lib/education/entries')
+  it('sitemap should include all shareable education detail guide pages', async () => {
+    const {
+      FEATURED_DETAIL_SLUGS,
+      getAllWeatherSystemSlugs,
+      getEducationDetailHref,
+    } = await import('@/lib/education/entries')
     const { default: sitemap } = await import('../app/sitemap')
     const entries = await sitemap()
     const sitemapPaths = entries.map((e: { url: string }) => {
@@ -95,14 +99,14 @@ describe('Sitemap SEO', () => {
     })
 
     const expectedPaths = [
-      ...FEATURED_DETAIL_SLUGS['weather-system'].map((slug) =>
+      ...getAllWeatherSystemSlugs().map((slug) =>
         getEducationDetailHref('weather-system', slug),
       ),
       ...FEATURED_DETAIL_SLUGS.cloud.map((slug) => getEducationDetailHref('cloud', slug)),
       ...FEATURED_DETAIL_SLUGS.phenomenon.map((slug) => getEducationDetailHref('phenomenon', slug)),
     ]
 
-    expect(expectedPaths).toHaveLength(20)
+    expect(expectedPaths.length).toBeGreaterThan(20)
     for (const path of expectedPaths) {
       expect(sitemapPaths).toContain(path)
     }

--- a/app/education/page.tsx
+++ b/app/education/page.tsx
@@ -1,5 +1,6 @@
 import { getAllPosts } from '@/lib/blog'
 import EducationHubClient from '@/components/education/education-hub-client'
+import { getShareableGuideEntries } from '@/lib/education/entries'
 import { decodeHtmlEntities } from '@/lib/services/rss/html-utils'
 
 function formatPostDate(date: string): string {
@@ -22,5 +23,5 @@ export default function EducationPage() {
       href: `/blog/${encodeURIComponent(post.slug)}`,
     }))
 
-  return <EducationHubClient latestPosts={latestPosts} />
+  return <EducationHubClient latestPosts={latestPosts} shareableGuides={getShareableGuideEntries()} />
 }

--- a/app/education/weather-systems/[slug]/page.tsx
+++ b/app/education/weather-systems/[slug]/page.tsx
@@ -2,17 +2,22 @@ import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 import WeatherSystemDetail from '@/components/education/weather-system-detail'
 import {
-  FEATURED_DETAIL_SLUGS,
+  getAllWeatherSystemSlugs,
   getEducationDetailHref,
   getWeatherSystemBySlug,
 } from '@/lib/education/entries'
+import { safeJsonLd } from '@/lib/utils'
 
 interface PageProps {
   params: Promise<{ slug: string }>
 }
 
 export function generateStaticParams() {
-  return FEATURED_DETAIL_SLUGS['weather-system'].map((slug) => ({ slug }))
+  return getAllWeatherSystemSlugs().map((slug) => ({ slug }))
+}
+
+function guideDescription(system: NonNullable<ReturnType<typeof getWeatherSystemBySlug>>): string {
+  return system.formationProcess.slice(0, 160)
 }
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
@@ -22,16 +27,33 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
   const url = `https://www.16bitweather.co${getEducationDetailHref('weather-system', slug)}`
   const title = `${system.name} — Weather Systems Guide`
+  const description = guideDescription(system)
 
   return {
     title: `${title} | 16 Bit Weather`,
-    description: system.description16bit,
+    description,
     alternates: { canonical: url },
     openGraph: {
       title,
-      description: system.formationProcess.slice(0, 160),
+      description,
       url,
       type: 'article',
+      images: [
+        {
+          url: `/api/og?title=${encodeURIComponent(system.name)}&subtitle=${encodeURIComponent('Weather Systems Guide')}`,
+          width: 1200,
+          height: 630,
+          alt: title,
+        },
+      ],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: [
+        `/api/og?title=${encodeURIComponent(system.name)}&subtitle=${encodeURIComponent('Weather Systems Guide')}`,
+      ],
     },
   }
 }
@@ -40,5 +62,28 @@ export default async function WeatherSystemDetailPage({ params }: PageProps) {
   const { slug } = await params
   const system = getWeatherSystemBySlug(slug)
   if (!system) notFound()
-  return <WeatherSystemDetail system={system} />
+
+  const url = `https://www.16bitweather.co${getEducationDetailHref('weather-system', slug)}`
+  const articleSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: `${system.name} — Weather Systems Guide`,
+    description: guideDescription(system),
+    url,
+    mainEntityOfPage: { '@type': 'WebPage', '@id': url },
+    author: { '@type': 'Organization', name: '16 Bit Weather', url: 'https://www.16bitweather.co' },
+    publisher: { '@type': 'Organization', name: '16 Bit Weather', url: 'https://www.16bitweather.co' },
+    about: { '@type': 'Thing', name: system.name },
+    keywords: system.classification,
+  }
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: safeJsonLd(articleSchema) }}
+      />
+      <WeatherSystemDetail system={system} />
+    </>
+  )
 }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -3,7 +3,7 @@ import { cityData as cityMetadata } from '@/lib/city-metadata'
 import { getAllPosts } from '@/lib/blog'
 import deepSkyCatalog from '@/data/deep-sky-catalog.json'
 import type { DeepSkyObject } from '@/lib/stargazer/types'
-import { FEATURED_DETAIL_SLUGS, getEducationDetailHref } from '@/lib/education/entries'
+import { FEATURED_DETAIL_SLUGS, getAllWeatherSystemSlugs, getEducationDetailHref } from '@/lib/education/entries'
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const baseUrl = 'https://www.16bitweather.co'
@@ -39,7 +39,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     ]
 
     const educationDetailPages: MetadataRoute.Sitemap = [
-      ...FEATURED_DETAIL_SLUGS['weather-system'].map((slug) => ({
+      ...getAllWeatherSystemSlugs().map((slug) => ({
         url: `${baseUrl}${getEducationDetailHref('weather-system', slug)}`,
         lastModified: new Date(),
         changeFrequency: 'monthly' as const,

--- a/app/weather-systems/page.tsx
+++ b/app/weather-systems/page.tsx
@@ -16,6 +16,7 @@
 
 
 import React, { useState } from "react"
+import Link from "next/link"
 import { useTheme } from "next-themes"
 import PageWrapper from "@/components/page-wrapper"
 import EducationBreadcrumb from "@/components/education/education-breadcrumb"
@@ -25,6 +26,7 @@ import { getComponentStyles } from "@/lib/theme-utils"
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { weatherSystemsDatabase } from "@/data/weather-systems"
+import { getEducationDetailHref, systemSlug } from "@/lib/education/entries"
 
 
 export default function WeatherSystemsPage() {
@@ -341,6 +343,15 @@ export default function WeatherSystemsPage() {
                             </div>
                           </div>
                         </div>
+                      </div>
+
+                      <div className="mt-6 text-center">
+                        <Link
+                          href={getEducationDetailHref('weather-system', systemSlug(system))}
+                          className={`text-sm font-mono font-bold uppercase ${themeClasses.accentText} hover:underline`}
+                        >
+                          Open shareable guide →
+                        </Link>
                       </div>
 
                       {/* Close Button */}

--- a/components/education/education-hub-client.tsx
+++ b/components/education/education-hub-client.tsx
@@ -21,7 +21,8 @@ import LearningCard from '@/components/learn/LearningCard'
 import CloudAltitudeStack from '@/components/education/cloud-altitude-stack'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { ShareButtons } from '@/components/share-buttons'
-import { countEncyclopediaEntries } from '@/lib/education/entries'
+import { countEncyclopediaEntries, countShareableGuidePages } from '@/lib/education/entries'
+import type { EducationEntryRef } from '@/lib/education/entries'
 import { cloudDatabase } from '@/data/cloud-types'
 import { weatherPhenomena } from '@/data/fun-facts'
 import { weatherSystemsDatabase } from '@/data/weather-systems'
@@ -39,6 +40,7 @@ export interface EducationHubPost {
 
 interface EducationHubClientProps {
   latestPosts: EducationHubPost[]
+  shareableGuides: EducationEntryRef[]
 }
 
 const START_HERE = [
@@ -119,9 +121,10 @@ function SectionHeading({ title, description }: { title: string; description?: s
   )
 }
 
-export default function EducationHubClient({ latestPosts }: EducationHubClientProps) {
+export default function EducationHubClient({ latestPosts, shareableGuides }: EducationHubClientProps) {
   const encyclopediaCount = countEncyclopediaEntries()
   const glossaryCount = getAllMetrics().length + getAllConcepts().length
+  const shareableGuideCount = countShareableGuidePages()
 
   const educationTopics = [
     {
@@ -199,7 +202,8 @@ export default function EducationHubClient({ latestPosts }: EducationHubClientPr
             <strong className="text-foreground font-mono">{glossaryCount}</strong> glossary terms
           </span>
           <span>
-            <strong className="text-foreground font-mono">20</strong> shareable guides
+            <strong className="text-foreground font-mono">{shareableGuideCount}</strong> shareable
+            guides
           </span>
         </div>
 
@@ -242,6 +246,25 @@ export default function EducationHubClient({ latestPosts }: EducationHubClientPr
               <LearningCard key={topic.href} {...topic} />
             ))}
           </div>
+        </section>
+
+        <section>
+          <SectionHeading
+            title="Shareable guides"
+            description="Direct links to reference pages — each has a canonical URL for search and sharing."
+          />
+          <nav aria-label="Shareable education guides" className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+            {shareableGuides.map((guide) => (
+              <Link
+                key={guide.href}
+                href={guide.href}
+                className="text-sm text-muted-foreground hover:text-primary transition-colors py-1 leading-snug"
+              >
+                {guide.title}
+                <span className="text-xs ml-2 opacity-60 capitalize">{guide.kind.replace('-', ' ')}</span>
+              </Link>
+            ))}
+          </nav>
         </section>
 
         {latestPosts.length > 0 && (

--- a/lib/education/entries.ts
+++ b/lib/education/entries.ts
@@ -122,8 +122,41 @@ export function getFeaturedDetailEntries(): EducationEntryRef[] {
   return [...systems, ...clouds, ...phenomena]
 }
 
+/** All statically published shareable guide pages (for sitemap parity and internal linking). */
+export function getShareableGuideEntries(): EducationEntryRef[] {
+  const systems = getAllWeatherSystemSlugs()
+    .map((slug) => {
+      const entry = getWeatherSystemBySlug(slug)
+      if (!entry) return null
+      return {
+        kind: 'weather-system' as const,
+        slug,
+        title: entry.name,
+        summary: entry.description16bit,
+        href: getEducationDetailHref('weather-system', slug),
+      }
+    })
+    .filter(Boolean) as EducationEntryRef[]
+
+  return [...systems, ...getFeaturedDetailEntries().filter((e) => e.kind !== 'weather-system')]
+}
+
 export function countEncyclopediaEntries(): number {
   return weatherSystemsDatabase.length + cloudDatabase.length + weatherPhenomena.length
+}
+
+/** Slugs for every weather system encyclopedia entry (shareable detail pages). */
+export function getAllWeatherSystemSlugs(): string[] {
+  return weatherSystemsDatabase.map((system) => systemSlug(system))
+}
+
+/** Total shareable /education/* detail guide URLs we statically publish. */
+export function countShareableGuidePages(): number {
+  return (
+    getAllWeatherSystemSlugs().length +
+    FEATURED_DETAIL_SLUGS.cloud.length +
+    FEATURED_DETAIL_SLUGS.phenomenon.length
+  )
 }
 
 export { systemSlug, cloudSlug }

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -18,6 +18,11 @@
 - Earth and space hazard news: https://www.16bitweather.co/news
 - Weather education hub: https://www.16bitweather.co/education
 - Weather metric glossary: https://www.16bitweather.co/education/glossary
+- Weather systems reference: https://www.16bitweather.co/weather-systems
+- Cloud atlas: https://www.16bitweather.co/cloud-types
+- Shareable weather system guides: https://www.16bitweather.co/education/weather-systems/{slug} (e.g. /education/weather-systems/cyclones, /education/weather-systems/jet-streams)
+- Shareable cloud guides: https://www.16bitweather.co/education/cloud-types/{slug} (e.g. /education/cloud-types/cumulonimbus)
+- Shareable phenomenon guides: https://www.16bitweather.co/education/phenomena/{slug} (e.g. /education/phenomena/thundersnow)
 - Live radar: https://www.16bitweather.co/radar
 - Stargazer / tonight's sky forecast: https://www.16bitweather.co/stargazer
 - Space weather: https://www.16bitweather.co/space-weather
@@ -32,7 +37,7 @@
 - Hurricane/tropical NHC outlooks
 - Aviation weather tools (METAR, turbulence — educational, not for operational flight planning)
 - Stargazing scores (seeing, transparency, moon phase) by location
-- Cloud types, weather systems, and glossary definitions
+- Cloud types, weather systems, glossary definitions, and shareable reference guides
 
 ## Do not cite or index
 
@@ -41,6 +46,7 @@
 - Auth flows: /auth/*
 - API endpoints: /api/*
 - Internal/dev utilities: /test-sentry, /radar-diagnostic, /gfs-model/*
+- Legacy routes (redirect to /education): /learn, /learn/glossary
 
 ## Data sources (for attribution)
 


### PR DESCRIPTION
## Summary
- Adds all 16 weather-system encyclopedia entries to the sitemap and static detail routes (previously only 7 were published)
- Adds a shareable guides section on `/education` with internal links from an already-indexed page
- Links each expanded `/weather-systems` card to its canonical `/education/weather-systems/[slug]` guide
- Improves weather-system detail metadata with OG/Twitter images and Article JSON-LD
- Updates `llms.txt` with education guide URL patterns for AI citation

## Test plan
- [x] `npm run typecheck`
- [x] `npm test -- education-entries sitemap-seo`
- [ ] CI / E2E / Lighthouse (GitHub Actions)
- [ ] After deploy: re-fetch sitemap in GSC and request indexing for key guide URLs


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shareable education guide pages and surfaced them on the Education hub.
  * Added a direct link from weather system pages to a shareable guide view.

* **Bug Fixes**
  * Updated sitemap and page coverage so all relevant weather system guides are included.
  * Improved page metadata and structured data for weather system detail pages.

* **Documentation**
  * Refreshed site citation guidance to highlight additional education pages and legacy routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->