### PR TITLE
chore: refresh README, agent docs, and knip cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,9 @@ Before making code changes, read and follow `./CODING.md`. Treat `CODING.md` as 
 
 ## Project Snapshot
 
-16-Bit Weather is a retro-styled weather education platform built with Next.js 16 App Router and React 19. It includes real-time weather data, educational content, interactive games, global weather tracking, tool-backed AI assistance, and Supabase-backed user AI memory.
+16-Bit Weather is a retro-styled weather education platform built with Next.js 16 App Router and React 19. It combines Open-Meteo forecasts, structured education (cloud atlas, weather systems, glossary, shareable guides), live hazard tools (severe, warnings, radar, space weather, aviation, stargazer), and Supabase auth for saved locations and theme preferences.
+
+The AI chat subsystem and weather arcade/games were removed; if either returns, re-audit that surface first.
 
 Product specs live in `planning/prds/`. Start with `planning/prds/README.md` for product-level changes.
 
@@ -17,7 +19,7 @@ Product specs live in `planning/prds/`. Start with `planning/prds/README.md` for
 - TypeScript strict mode
 - Tailwind CSS v4
 - Supabase
-- Open-Meteo weather data
+- Open-Meteo weather data (primary)
 - Jest unit tests
 - Playwright E2E tests
 - Lighthouse CI performance validation
@@ -49,7 +51,7 @@ Use targeted commands first, then broaden validation when changing shared behavi
 - Use `gh` for GitHub workflow tasks when requested.
 - Before opening a PR, summarize what changed, why it changed, tests run, and known risks.
 - Do not push, open PRs, bypass hooks, delete files, or reset git state unless explicitly asked.
-- The pre-push hook runs Playwright, production build, and Lighthouse CI.
+- The pre-push hook runs gitleaks on unpushed commits; E2E and Lighthouse run in GitHub Actions.
 
 ## Agent Operating Rules
 

--- a/README.md
+++ b/README.md
@@ -6,48 +6,47 @@ Retro-styled weather education platform that pairs live environmental data with 
 
 ## Version 1.589 highlights
 
-Weekly blog posts with NOAA public domain imagery, precipitation history accuracy improvements, and continued SEO refinements for city pages.
+Recent shipping focused on education, search discoverability, and auth onboarding.
 
-- **Weekly blog**: Super El Nino coverage and severe weather outlook with inline NOAA CPC and NSSL imagery.
-- **Precipitation accuracy**: Reworked 24-hour precipitation history endpoint for more reliable readings.
-- **SEO city pages**: Enriched metadata and restored missing H1 spacing on city weather pages.
-- **Stargazer**: Night sky observing score, education pages, and launch link integration.
-- **Space weather redesign**: Tabbed dashboard with interactive Kp index, solar wind, and X-ray flux charts. ENLIL model viewer, CME tracker, and aurora forecast maps.
-- **Social sharing**: Fixed blank OG previews. Share buttons on all major pages with dynamic OG images.
-- **SPC outlooks and travel corridors**: Day 1-3 convective outlook maps on the severe weather page. Interstate corridor driving condition scores with hazard maps.
-- **Education hub**: Consolidated learning pages with expanded cloud types, weather systems, fun facts, extremes, and glossary content.
-- **Supabase hardening**: RLS policies on user_ai_memory, initplan performance fixes, duplicate policy cleanup, and missing foreign key indexes.
+- **Education hub**: Rebuilt `/education` with encyclopedia links, live labs, cloud altitude quiz, glossary, and **29 shareable reference guides** under `/education/*`.
+- **Weather systems**: 16 encyclopedia entries with expanded cards plus canonical guide pages for Google Search (`/education/weather-systems/[slug]`).
+- **Glossary**: Meteorology concepts (supercell, CAPE, mesocyclone, wind shear, and more) with blog anchor support.
+- **SEO / GSC**: Sitemap coverage for all guide URLs, internal linking from the indexed education hub, Article JSON-LD, and `llms.txt` patterns for AI citation.
+- **Auth onboarding**: Post-signup dashboard welcome flow and improved registration UX.
+- **Weekly blog**: NOAA public-domain imagery and severe weather deep dives.
+- **Stargazer & space weather**: Observing scores, tabbed space-weather dashboard, Kp/solar wind/X-ray charts, aurora and ENLIL tools.
+- **Severe & travel**: SPC Day 1–3 outlook maps, NWS warnings hub, interstate corridor scores.
+- **Social sharing**: Dynamic OG images and share buttons on major pages.
 
 ## About
 
-The site targets learners and hobbyists who want accurate data without a generic weather app layout. Content mixes forecasts, education, games, and optional sign-in for saved locations and preferences.
+The site targets learners, hobbyists, and weather enthusiasts who want accurate data without a generic app layout. Content mixes forecasts, structured education, live hazard tools, and optional sign-in for saved locations and theme preferences.
 
 ## Features
 
-- **Real-time weather**: Current conditions, forecasts, air quality, pollen, and related environmental metrics
-- **Space weather**: Solar activity monitoring with Kp index, solar wind, aurora forecast, flare tracking, and ENLIL model visualization
-- **Severe weather**: SPC convective outlook maps (Day 1-3) and active NWS alerts filtered by tornado, thunderstorm, wind, hail, and flood
-- **Travel weather**: Interstate corridor driving conditions with hazard scoring and WPC daily outlook maps
-- **Tropical tracker**: NHC 2-day and 7-day outlooks, Atlantic satellite imagery, and sea surface temperature analysis
-- **Aviation weather**: SIGMETs, AIRMETs, turbulence maps, and real-time flight conditions in a terminal-style interface
-- **Learn Hub**: Cloud types, weather systems, extreme phenomena, fun facts, and a weather glossary
-- **Interactive radar**: North America radar with NOAA/Iowa NEXRAD, MSC GeoMet, RainViewer fallback, and severe weather overlays
-- **Global extremes**: Hot and cold location tracking with live data
-- **Custom themes**: Twelve themes with persistence for signed-in users
-- **Weather Arcade**: Educational games with score tracking
+- **Real-time weather**: Current conditions and forecasts via **Open-Meteo** (primary), with legacy OpenWeatherMap endpoints where still required
+- **Space weather**: Kp index, solar wind, aurora forecast, flare tracking, ENLIL model visualization
+- **Severe weather**: SPC convective outlook maps (Day 1–3) and active NWS alerts
+- **Travel weather**: Interstate corridor driving conditions with hazard scoring
+- **Tropical tracker**: NHC outlooks and Atlantic satellite context
+- **Aviation weather**: SIGMETs, AIRMETs, turbulence maps, and flight conditions terminal
+- **Education**: Hub at `/education` — cloud atlas, weather systems, phenomena, extremes, glossary, and shareable detail guides
+- **Interactive radar**: Global RainViewer tiles with severe overlays and shareable URL state
+- **Global extremes**: Hot and cold location tracking
+- **Custom themes**: **Six** retro themes with persistence for signed-in users
 - **User accounts**: Saved locations and preferences via Supabase
 - **News and feeds**: Multi-source RSS including earth science and space categories
-- **Social sharing**: Share buttons on every major page with dynamic OG preview images
+- **Social sharing**: Share buttons with dynamic OG preview images
 
 ## Tech stack
 
 - **Framework**: Next.js 16 (App Router), React 19
 - **Styling**: Tailwind CSS v4, shadcn-style UI primitives
-- **Language**: TypeScript
+- **Language**: TypeScript (strict)
 - **Database**: Supabase (PostgreSQL, Auth, RLS)
-- **APIs**: OpenWeatherMap, NOAA SWPC, USGS, NASA, NHC, SPC, and other providers behind server routes
-- **Monitoring**: Sentry error tracking
-- **Testing**: Jest (unit), Playwright (E2E), Lighthouse CI (performance gate)
+- **Weather data**: Open-Meteo (primary), OpenWeatherMap (legacy/fallback), NOAA, USGS, NASA, NHC, SPC
+- **Monitoring**: Sentry
+- **Testing**: Jest (unit), Playwright (E2E), Lighthouse CI
 - **Deployment**: Vercel
 
 ## Getting started
@@ -55,8 +54,8 @@ The site targets learners and hobbyists who want accurate data without a generic
 ### Prerequisites
 
 - Node.js 20.9 or newer (required by Next.js 16)
-- npm or pnpm
-- API keys for OpenWeatherMap and Supabase, plus any optional keys you enable locally
+- npm
+- Supabase and OpenWeatherMap keys for full local functionality
 
 ### Installation
 
@@ -71,12 +70,11 @@ The site targets learners and hobbyists who want accurate data without a generic
    npm install
    ```
 
-3. Set up environment variables:
-   Create a `.env.local` file in the root directory with:
+3. Set up environment variables — copy `.env.example` to `.env.local` and fill in:
    ```
-   NEXT_PUBLIC_SUPABASE_URL=your_supabase_url
-   NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
-   OPENWEATHER_API_KEY=your_openweather_key
+   NEXT_PUBLIC_SUPABASE_URL=
+   NEXT_PUBLIC_SUPABASE_ANON_KEY=
+   OPENWEATHER_API_KEY=
    NEXT_PUBLIC_BASE_URL=http://localhost:3000
    ```
 
@@ -92,16 +90,22 @@ The site targets learners and hobbyists who want accurate data without a generic
 | Command | Description |
 |---------|-------------|
 | `npm run dev` | Start development server |
-| `npm run build` | Build for production |
+| `npm run build` | Production build |
 | `npm run start` | Start production server |
 | `npm test` | Run Jest unit tests |
 | `npm run test:ci` | Jest in CI mode |
 | `npx playwright test` | Run end-to-end tests |
 | `npm run validate:pr` | Build, Playwright, and Lighthouse gate |
+| `npm run knip` | Dead code and unused dependency scan |
 
 ## Documentation
 
-The `docs` folder contains deeper references when present (API notes, architecture, deployment, testing).
+Contributor and agent docs live in the repo root:
+
+- **`CODING.md`** — engineering handbook (architecture, tests, security, PR workflow)
+- **`CLAUDE.md`** / **`AGENTS.md`** — agent and IDE context
+- **`planning/prds/`** — product specs for in-flight features
+- **`CHANGELOG.md`** — release history
 
 ## License
 

--- a/components/radar-v2/radar-constants.ts
+++ b/components/radar-v2/radar-constants.ts
@@ -1,11 +1,6 @@
 export const CARTO_VOYAGER_URL = 'https://{a-d}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png'
 
-/** @deprecated Use CARTO_VOYAGER_URL — kept for imports that still reference dark basemap. */
-export const CARTO_DARK_MATTER_URL = 'https://{a-d}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png'
-
-export const TILE_TRANSITION_MS = 500
 export const BASE_ANIMATION_INTERVAL_MS = 500
-export const LIVE_PAUSE_MS = 1500
 export const URL_SYNC_DEBOUNCE_MS = 300
 export const MANIFEST_REFRESH_MS = 5 * 60 * 1000
 

--- a/components/radar-v2/radar-shell.tsx
+++ b/components/radar-v2/radar-shell.tsx
@@ -130,7 +130,7 @@ function getRadarTileFetchKey(preferences: RadarTilePreferences, tileSize: numbe
   return `${tileSize}:${preferences.smooth}:${preferences.snow}`
 }
 
-export function RadarShell({
+function RadarShell({
   latitude,
   longitude,
   locationName,

--- a/hooks/use-home-hub-data.ts
+++ b/hooks/use-home-hub-data.ts
@@ -13,7 +13,7 @@ import {
 } from '@/lib/home/hub-utils';
 import { isSpcOutlookRegion } from '@/lib/home/hub-location';
 
-export interface HomeHubCoordinates {
+interface HomeHubCoordinates {
   lat: number;
   lon: number;
 }

--- a/lib/featured-city-links.ts
+++ b/lib/featured-city-links.ts
@@ -16,8 +16,6 @@ export const FEATURED_CITY_SLUGS = [
   'miami-fl',
 ] as const
 
-export type FeaturedCitySlug = (typeof FEATURED_CITY_SLUGS)[number]
-
 export function getFeaturedCities() {
   return FEATURED_CITY_SLUGS.map((slug) => {
     const city = cityData[slug]

--- a/lib/radar/providers/registry.ts
+++ b/lib/radar/providers/registry.ts
@@ -45,12 +45,8 @@ export const RAINVIEWER_PROVIDER: RadarProvider = {
   ],
 }
 
-export const RADAR_PROVIDERS: Record<RadarProviderId, RadarProvider> = {
+const RADAR_PROVIDERS: Record<RadarProviderId, RadarProvider> = {
   rainviewer: RAINVIEWER_PROVIDER,
-}
-
-export function getRadarProvider(id: RadarProviderId): RadarProvider {
-  return RADAR_PROVIDERS[id]
 }
 
 export function selectRadarProvider(latitude: number, longitude: number): RadarProviderSelection {

--- a/lib/radar/providers/registry.ts
+++ b/lib/radar/providers/registry.ts
@@ -11,7 +11,6 @@ import type {
   RadarLegendBand,
   RadarMetadata,
   RadarProvider,
-  RadarProviderId,
   RadarProviderSelection,
 } from '@/lib/radar/providers/types'
 
@@ -43,10 +42,6 @@ export const RAINVIEWER_PROVIDER: RadarProvider = {
     'Global composite radar tiles from the RainViewer Weather Maps API.',
     'Frame list and tile host come from weather-maps.json.',
   ],
-}
-
-const RADAR_PROVIDERS: Record<RadarProviderId, RadarProvider> = {
-  rainviewer: RAINVIEWER_PROVIDER,
 }
 
 export function selectRadarProvider(latitude: number, longitude: number): RadarProviderSelection {

--- a/lib/radar/rainviewer/color-schemes.ts
+++ b/lib/radar/rainviewer/color-schemes.ts
@@ -26,7 +26,3 @@ const DISPLAY_FILTERS: Record<RainViewerDisplaySchemeId, string> = {
 export function getRainViewerDisplayFilter(schemeId: number): string {
   return DISPLAY_FILTERS[schemeId as RainViewerDisplaySchemeId] ?? DISPLAY_FILTERS[2]
 }
-
-export function isRainViewerDisplaySchemeId(schemeId: number): schemeId is RainViewerDisplaySchemeId {
-  return RAINVIEWER_DISPLAY_SCHEMES.some((scheme) => scheme.id === schemeId)
-}

--- a/lib/radar/rainviewer/constants.ts
+++ b/lib/radar/rainviewer/constants.ts
@@ -1,15 +1,7 @@
 export const RAINVIEWER_MANIFEST_URL = 'https://api.rainviewer.com/public/weather-maps.json'
 
-export const DEFAULT_RAINVIEWER_TILE_OPTIONS = {
-  size: 512,
-  colorScheme: 6,
-  smooth: true,
-  snow: true,
-} as const
-
 export const RAINVIEWER_MAX_NATIVE_ZOOM = 7
 export const RAINVIEWER_MAX_ZOOM = 12
 export const RAINVIEWER_PAST_MINUTES = 120
 export const RAINVIEWER_FRAME_STEP_MINUTES = 10
 export const RAINVIEWER_ATTRIBUTION = 'RainViewer'
-export const RAINVIEWER_ATTRIBUTION_URL = 'https://www.rainviewer.com/'

--- a/lib/services/rss/enrich-images.ts
+++ b/lib/services/rss/enrich-images.ts
@@ -143,7 +143,3 @@ async function mapWithConcurrency<T>(
   });
   await Promise.all(workers);
 }
-
-export function clearEnrichmentCaches(): void {
-  USGS_DETAIL_CACHE.clear();
-}

--- a/lib/services/rss/resolve-og-image.ts
+++ b/lib/services/rss/resolve-og-image.ts
@@ -124,7 +124,3 @@ function isGenericSiteLogo(url: string): boolean {
     lower.includes('/wp-content/uploads/2022/02/nasa_meatball')
   );
 }
-
-export function clearOgImageCache(): void {
-  OG_CACHE.clear();
-}

--- a/lib/utils/location-utils.ts
+++ b/lib/utils/location-utils.ts
@@ -68,11 +68,3 @@ function getUSRegion(latitude: number, longitude: number): string | null {
 
   return 'Continental US'
 }
-
-/**
- * Check if location is in MRMS coverage area
- * MRMS covers CONUS, Alaska, Caribbean (PR/USVI), Guam, and Hawaii
- */
-export function isInMRMSCoverage(latitude: number, longitude: number): boolean {
-  return isUSLocation(latitude, longitude)
-}


### PR DESCRIPTION
## Summary
- Updates `README.md` with accurate v1.589 highlights (education hub, GSC guides, auth onboarding) and fixes stale claims (12 themes, Weather Arcade, missing docs folder, OpenWeather as sole API)
- Aligns `AGENTS.md` with `CLAUDE.md` — removes references to removed AI chat, games, and AI memory subsystems
- Cleans knip-flagged unused exports in radar, RSS, and location utilities

## Hygiene (local only, not in diff)
- Deleted 5 stale local branches whose remotes were already gone

## Test plan
- [x] `npm run typecheck`
- [x] `npm test` (737 tests)
- [x] `npm run knip` (no unused export issues)
- [ ] CI / E2E / Lighthouse (GitHub Actions)

## Follow-up
- `stash@{0}` still holds the 35-entry weather systems expansion if we want to resume that work separately


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Miami, FL to the featured city highlights.
  * Expanded the README with updated product highlights, setup guidance, and current capabilities.

* **Documentation**
  * Refreshed project notes to reflect the current weather data sources, radar coverage, and development workflow.
  * Clarified local setup steps and available scripts.

* **Refactor**
  * Simplified several internal radar, RSS, and location helpers by reducing exposed APIs and cleanup hooks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->