### PR TITLE
fix(newsletter): allow-list new image hosts and strip model placeholder images

### DIFF
--- a/__tests__/newsletter/content-match.test.ts
+++ b/__tests__/newsletter/content-match.test.ts
@@ -147,23 +147,29 @@ describe('embedImagesInDraft', () => {
 });
 
 describe('stripBareImageMarkdown', () => {
-  it('removes bare image tags but keeps URL-backed images', () => {
+  it('removes both bare and URL-backed model image markdown', () => {
+    // The model must not embed ANY image — catalog images are spliced in
+    // afterward — so a URL-backed image in the raw draft is still a hallucination.
     const input =
       'Intro.\n\n![A hallucinated figure description.]\n\n' +
-      '![Real caption.](https://example.com/real.png)\n*Credit*';
+      '![Real-looking caption.](https://example.com/real.png)\n*Credit*';
     const out = stripBareImageMarkdown(input);
     expect(out).not.toContain('hallucinated figure');
-    expect(out).toContain('![Real caption.](https://example.com/real.png)');
+    expect(out).not.toContain('https://example.com/real.png');
+    expect(out).not.toMatch(/!\[/);
   });
 
-  it('removes relative image placeholders but keeps absolute image URLs', () => {
+  it('removes relative AND absolute placeholder images (e.g. placehold.co)', () => {
     const input =
       'Intro.\n\n![A hallucinated analysis panel.](image2)\n\n' +
-      '![Real caption.](https://example.com/real.png)\n*Credit*';
+      '![Radar mosaic placeholder.](https://placehold.co/900x500?text=Radar+mosaic+placeholder)\n\n' +
+      'Outro.';
     const out = stripBareImageMarkdown(input);
     expect(out).not.toContain('hallucinated analysis panel');
     expect(out).not.toContain('(image2)');
-    expect(out).toContain('![Real caption.](https://example.com/real.png)');
+    expect(out).not.toContain('placehold.co');
+    expect(out).toContain('Intro.');
+    expect(out).toContain('Outro.');
   });
 
   it('collapses separator pairs left bracketing a removed placeholder', () => {

--- a/__tests__/newsletter/images.test.ts
+++ b/__tests__/newsletter/images.test.ts
@@ -6,6 +6,7 @@ import {
   type ImageEntry,
 } from '../../scripts/newsletter/images';
 import { TOPIC_SLUGS } from '../../scripts/newsletter/topics';
+import { allowedBlogUrl } from '../../lib/blog/allowed-hosts';
 
 describe('IMAGES catalog', () => {
   it('contains at least 50 entries', () => {
@@ -36,6 +37,16 @@ describe('IMAGES catalog', () => {
     for (const img of IMAGES) {
       expect(img.url.startsWith('https://')).toBe(true);
     }
+  });
+
+  it('every catalog image URL is on the blog allow-list', () => {
+    // validate-post.ts rejects body images whose host is not in
+    // lib/blog/allowed-hosts. A catalog entry on an un-allow-listed host fails
+    // the newsletter cron, so the two lists must stay in sync.
+    const offenders = IMAGES.filter((img) => allowedBlogUrl(img.url) === null).map(
+      (img) => `${img.id} (${img.url})`,
+    );
+    expect(offenders).toEqual([]);
   });
 
   it('every license is one of the allowed public-use values', () => {

--- a/lib/blog/allowed-hosts.ts
+++ b/lib/blog/allowed-hosts.ts
@@ -21,11 +21,13 @@ export const ALLOWED_BLOG_LINK_HOSTS: ReadonlySet<string> = new Set([
   'cdn.star.nesdis.noaa.gov',
   'droughtmonitor.unl.edu',
   'ocean.weather.gov',
+  'radar.weather.gov',
   'sdo.gsfc.nasa.gov',
   'services.swpc.noaa.gov',
   'soho.nascom.nasa.gov',
   'www.cpc.ncep.noaa.gov',
   'www.spc.noaa.gov',
+  'www.wpc.ncep.noaa.gov',
 
   // Self-references in posts (canonical links back to the site).
   '16bitweather.co',

--- a/scripts/newsletter/content-match.ts
+++ b/scripts/newsletter/content-match.ts
@@ -177,16 +177,18 @@ function renderImageMarkdown(img: ImageEntry): string {
 }
 
 /**
- * Removes image markdown the model emitted without a usable external URL:
- * `![alt]` not immediately followed by `(`, or `![alt](image1)`-style
- * relative placeholders. Real images use absolute URLs and are added by
- * embedImagesInDraft. Also collapses the horizontal-rule separators the
- * model tends to wrap such placeholders in, plus any blank-line runs left
- * behind.
+ * Removes ALL image markdown the model emitted. The generator is told not to
+ * embed images — real catalog images are spliced in afterward by
+ * embedImagesInDraft — so any `![...](...)` or bare `![...]` left in the draft
+ * is a hallucination: a placeholder (e.g. placehold.co), a relative `(image1)`
+ * ref, or a prompt-injected off-catalog/tracker URL. Stripping every one keeps
+ * the published post limited to allow-listed catalog imagery (the same defense
+ * as lib/blog/allowed-hosts). Also collapses the horizontal-rule separators the
+ * model tends to wrap such placeholders in, plus any blank-line runs left behind.
  */
 export function stripBareImageMarkdown(draft: string): string {
   let out = draft
-    .replace(/!\[[^\]]*\]\(\s*(?!https?:\/\/)[^)]+\)/gi, '')
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, '')
     .replace(/!\[[^\]]*\](?!\()/g, '');
   // Drop horizontal-rule separators that, after the placeholder removal, now
   // bracket only whitespace — i.e. two or more "---" lines in a row.


### PR DESCRIPTION
## Problem

A live dispatch of the Sunday newsletter (after #466 merged) still failed at the **Validate generated post** step — but for two new reasons, not the original one. Content-matching itself worked: the audit showed on-topic picks (`nws-conus-radar-mosaic` for severe, `goes19-fulldisk-water-vapor` for forecast, `tectonic-plate-boundaries-map` for earthquake).

The two blockers:

1. **New catalog hosts were not on the blog allow-list.** `#466` added `radar.weather.gov` and `www.wpc.ncep.noaa.gov` images to `scripts/newsletter/images.ts` but not to `lib/blog/allowed-hosts`, so `validate-post.ts` rejected those body images ("not on the blog allow-list"). The allow-list file warns to keep the two in sync; the sync was missed.

2. **The model injected absolute placeholder images** (`https://placehold.co/...`) into the prose. `stripBareImageMarkdown` only removed relative/bare placeholders, so absolute ones survived and failed the allow-list + catalog checks.

## Fix

- Add `radar.weather.gov` and `www.wpc.ncep.noaa.gov` to `lib/blog/allowed-hosts`, and add a catalog-wide test asserting every `IMAGES` url passes `allowedBlogUrl`, so the two lists can't drift again.
- `stripBareImageMarkdown` now strips **all** model-emitted image markdown (relative and absolute). The generator is told to embed no images — catalog images are spliced in afterward — so any image left in the raw draft is a hallucination. This also closes the prompt-injection vector the allow-list defends against (a headline could otherwise steer the model into embedding a tracker pixel).

## Verification

- 110 newsletter tests pass (new: catalog-host allow-list guard, placehold.co strip regression).
- `npm run typecheck` clean; lint clean on changed files.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Newsletter content cleanup now removes all image markdown consistently, while preserving surrounding draft text.
  * Image URLs in the newsletter catalog now align with the approved blog image sources, reducing broken or unsupported image references.
  * Expanded approved image source coverage so additional trusted weather-image links are accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->