### PR TITLE
Improve SEO for radar indexing and city climate queries

### DIFF
--- a/__tests__/city-page-seo.test.ts
+++ b/__tests__/city-page-seo.test.ts
@@ -1,0 +1,37 @@
+import {
+  buildCityPageDescription,
+  buildCityPageMetadata,
+  buildCityPageTitle,
+  PRIORITY_SEO_CITY_SLUGS,
+} from '@/lib/seo/city-page-seo'
+
+describe('city-page-seo', () => {
+  const boston = { name: 'Boston', state: 'MA' }
+
+  it('uses climate-focused titles for priority GSC cities', () => {
+    const title = buildCityPageTitle(boston, 'boston-ma')
+    expect(title).toContain('Climate')
+    expect(title).toContain('Year-Round Weather')
+    expect(title).toContain('Boston MA')
+  })
+
+  it('includes climate and year-round language in descriptions', () => {
+    const description = buildCityPageDescription(boston)
+    expect(description).toContain('climate averages')
+    expect(description).toContain('monthly weather')
+    expect(description).toContain('best time to visit')
+  })
+
+  it('builds metadata with canonical www URL and OG image', () => {
+    const metadata = buildCityPageMetadata(boston, 'boston-ma')
+    expect(metadata.alternates?.canonical).toBe('https://www.16bitweather.co/weather/boston-ma')
+    expect(JSON.stringify(metadata.openGraph?.images)).toContain('/api/og?')
+    expect(metadata.keywords).toContain('Boston climate')
+  })
+
+  it('lists ten priority city slugs from GSC traffic', () => {
+    expect(PRIORITY_SEO_CITY_SLUGS).toHaveLength(10)
+    expect(PRIORITY_SEO_CITY_SLUGS).toContain('boston-ma')
+    expect(PRIORITY_SEO_CITY_SLUGS).toContain('pittsburgh-pa')
+  })
+})

--- a/__tests__/radar-seo.test.ts
+++ b/__tests__/radar-seo.test.ts
@@ -1,0 +1,28 @@
+/**
+ * SEO tests for radar page crawlable content.
+ */
+
+import fs from 'fs'
+import path from 'path'
+
+describe('Radar SEO', () => {
+  it('radar page should be a server component with crawlable SEO content', () => {
+    const pagePath = path.join(process.cwd(), 'app', 'radar', 'page.tsx')
+    const content = fs.readFileSync(pagePath, 'utf-8')
+
+    expect(content).not.toContain("'use client'")
+    expect(content).toContain('RadarSeoContent')
+    expect(content).toContain('buildRadarFaqJsonLd')
+    expect(content).toContain('RadarClient')
+  })
+
+  it('radar SEO content includes h1, FAQ, and internal links', () => {
+    const seoPath = path.join(process.cwd(), 'components', 'radar', 'radar-seo-content.tsx')
+    const content = fs.readFileSync(seoPath, 'utf-8')
+
+    expect(content).toContain('<h1')
+    expect(content).toContain('href="/warnings"')
+    expect(content).toContain('href="/severe"')
+    expect(content).toContain('RADAR_FAQS')
+  })
+})

--- a/__tests__/seo-indexing-fixes.test.ts
+++ b/__tests__/seo-indexing-fixes.test.ts
@@ -67,8 +67,8 @@ describe('SEO Indexing Fixes', () => {
     const { default: sitemap } = await import('../app/sitemap')
     const entries = await sitemap()
 
-    // Includes ~100 cities, ~150 deep-sky object pages, blog posts, and static routes.
-    expect(entries.length).toBeLessThan(350)
+    // ~100 cities, blog posts, education detail pages, and static routes (no deep-sky objects).
+    expect(entries.length).toBeLessThan(250)
   })
 
   it('city pages should use ISR revalidate instead of force-dynamic', () => {

--- a/__tests__/sitemap-seo.test.ts
+++ b/__tests__/sitemap-seo.test.ts
@@ -75,7 +75,7 @@ describe('Sitemap SEO', () => {
     expect(sitemapPaths).not.toContain('/map')
   })
 
-  it('sitemap should include stargazer hub and deep-sky object pages', async () => {
+  it('sitemap should include stargazer hub but not deep-sky object pages', async () => {
     const { default: sitemap } = await import('../app/sitemap')
     const entries = await sitemap()
     const sitemapPaths = entries.map((e: { url: string }) => {
@@ -83,7 +83,7 @@ describe('Sitemap SEO', () => {
     })
 
     expect(sitemapPaths).toContain('/stargazer')
-    expect(sitemapPaths.some((p) => p.startsWith('/stargazer/objects/'))).toBe(true)
+    expect(sitemapPaths.some((p) => p.startsWith('/stargazer/objects/'))).toBe(false)
   })
 
   it('sitemap should include all shareable education detail guide pages', async () => {

--- a/__tests__/weather-city-page-metadata.test.ts
+++ b/__tests__/weather-city-page-metadata.test.ts
@@ -8,17 +8,22 @@ import { cityData } from '@/lib/city-metadata'
 describe('weather/[city]/page generateMetadata', () => {
   const makeParams = (city: string) => Promise.resolve({ city })
 
-  it('returns rich metadata for predefined catalog cities', async () => {
+  it('returns rich climate-focused metadata for predefined catalog cities', async () => {
     const slug = Object.keys(cityData)[0]
     const city = cityData[slug]
     const metadata = await generateMetadata({ params: makeParams(slug) })
 
     expect(metadata.title).toContain(city.name)
-    expect(metadata.title).toContain(city.state)
-    expect(metadata.description).toContain(city.name)
+    expect(metadata.title).toContain('Climate')
+    expect(metadata.description).toContain('climate')
     expect(metadata.alternates?.canonical).toBe(`https://www.16bitweather.co/weather/${slug}`)
     expect(metadata.openGraph?.images).toBeDefined()
     expect(metadata.twitter?.card).toBe('summary_large_image')
+  })
+
+  it('uses year-round wording for priority SEO cities', async () => {
+    const metadata = await generateMetadata({ params: makeParams('boston-ma') })
+    expect(metadata.title).toContain('Year-Round Weather')
   })
 
   it('noindexes unknown city slugs with a canonical URL', async () => {

--- a/app/radar/page.tsx
+++ b/app/radar/page.tsx
@@ -1,195 +1,27 @@
-'use client'
+import { Suspense } from 'react'
+import { safeJsonLd } from '@/lib/utils'
+import RadarSeoContent, { buildRadarFaqJsonLd } from '@/components/radar/radar-seo-content'
+import RadarClient from './radar-client'
 
-/**
- * Full-viewport RainViewer radar — map-first layout with floating top bar and player dock.
- */
-
-import { useEffect, useMemo, useState } from 'react'
-import { useRouter, useSearchParams } from 'next/navigation'
-import dynamicImport from 'next/dynamic'
-import Link from 'next/link'
-import { Home, Map as MapIcon } from 'lucide-react'
-import { useLocationContext } from '@/components/location-context'
-import type { WeatherData } from '@/lib/types'
-import { useTheme } from '@/components/theme-provider'
-import { fetchWeatherData } from '@/lib/weather'
-import WeatherSearch from '@/components/weather-search'
-
-const RadarShell = dynamicImport(() => import('@/components/radar-v2/radar-shell'), {
-  ssr: false,
-  loading: () => (
-    <div className="flex h-full w-full items-center justify-center bg-black">
-      <div className="text-center text-white">
-        <div className="mb-2 text-lg font-semibold">Loading radar…</div>
-        <div className="text-sm text-zinc-400">Fetching RainViewer frames</div>
-      </div>
-    </div>
-  ),
-})
-
-function RadarLoadingShell({ message }: { message: string }) {
-  return (
-    <div className="flex min-h-dvh flex-col bg-black text-white">
-      <div className="flex flex-1 flex-col items-center justify-center gap-4 px-4">
-        <MapIcon className="h-10 w-10 text-cyan-400" aria-hidden="true" />
-        <p className="font-mono text-sm uppercase tracking-widest text-zinc-400">{message}</p>
-        <div className="h-8 w-8 animate-spin rounded-full border-2 border-cyan-400 border-t-transparent" />
-      </div>
-    </div>
-  )
-}
-
-function RadarEmptyShell({
-  title,
-  body,
-  children,
-}: {
-  title: string
-  body: string
-  children?: React.ReactNode
-}) {
-  return (
-    <div className="flex min-h-dvh flex-col bg-black text-white">
-      <header className="flex items-center gap-3 border-b border-white/10 px-4 py-3">
-        <Link
-          href="/"
-          className="inline-flex items-center gap-2 rounded-lg border border-white/15 px-3 py-2 text-xs font-mono hover:bg-white/5"
-        >
-          <Home className="h-4 w-4" />
-          HOME
-        </Link>
-        <span className="text-xs font-mono uppercase tracking-wider text-zinc-400">Live Radar</span>
-      </header>
-      <div className="flex flex-1 flex-col items-center justify-center gap-4 px-4 text-center">
-        <h1 className="text-xl font-bold font-mono text-cyan-300">{title}</h1>
-        <p className="max-w-md text-sm text-zinc-400">{body}</p>
-        {children}
-      </div>
-    </div>
-  )
-}
-
-export default function MapPage() {
-  const router = useRouter()
-  const searchParams = useSearchParams()
-  const urlLocation = searchParams.get('location')
-  const { currentLocation } = useLocationContext()
-  const { theme } = useTheme()
-  const [weatherData, setWeatherData] = useState<WeatherData | null>(null)
-  const [isLoading, setIsLoading] = useState(true)
-  const [searchError, setSearchError] = useState<string | undefined>()
-
-  const targetLocation = urlLocation || currentLocation
-
-  useEffect(() => {
-    const loadWeatherData = async () => {
-      setIsLoading(true)
-
-      if (targetLocation) {
-        try {
-          const freshData = await fetchWeatherData(targetLocation, 'imperial')
-          if (freshData?.coordinates?.lat != null && freshData?.coordinates?.lon != null) {
-            setWeatherData(freshData)
-            setIsLoading(false)
-            return
-          }
-        } catch (fetchError) {
-          console.warn('[MapPage] Failed to fetch weather data:', fetchError)
-        }
-      }
-
-      setWeatherData(null)
-      setIsLoading(false)
-    }
-
-    void loadWeatherData()
-  }, [targetLocation, urlLocation])
-
-  const shareUrl = useMemo(() => {
-    if (!weatherData) return 'https://www.16bitweather.co/radar'
-
-    const params = new URLSearchParams(searchParams.toString())
-    params.set('location', weatherData.location)
-    if (weatherData.coordinates) {
-      params.set('lat', String(weatherData.coordinates.lat))
-      params.set('lon', String(weatherData.coordinates.lon))
-    }
-    return `https://www.16bitweather.co/radar?${params.toString()}`
-  }, [weatherData, searchParams])
-
-  const handleRadarSearch = (location: string) => {
-    const trimmed = location.trim()
-    if (!trimmed) {
-      setSearchError('Enter a location to load radar.')
-      return
-    }
-    setSearchError(undefined)
-    router.push(`/radar?location=${encodeURIComponent(trimmed)}`)
-  }
-
-  if (isLoading) {
-    return <RadarLoadingShell message="Initializing radar terminal" />
-  }
-
-  if (!weatherData) {
-    return (
-      <RadarEmptyShell
-        title="Choose a location"
-        body="Search for a city to open full-screen global precipitation radar with severe weather overlays."
-      >
-        <div className="w-full max-w-xl">
-          <WeatherSearch
-            onSearch={handleRadarSearch}
-            isLoading={isLoading}
-            error={searchError}
-            hideLocationButton
-          />
-        </div>
-      </RadarEmptyShell>
-    )
-  }
-
-  const hasValidCoordinates =
-    weatherData.coordinates?.lat != null && weatherData.coordinates?.lon != null
-
-  if (!hasValidCoordinates) {
-    return (
-      <RadarEmptyShell
-        title="Coordinates unavailable"
-        body={`Could not resolve map coordinates for ${weatherData.location}. Try searching again.`}
-      >
-        <div className="w-full max-w-xl">
-          <WeatherSearch
-            onSearch={handleRadarSearch}
-            isLoading={isLoading}
-            error={searchError}
-            hideLocationButton
-          />
-        </div>
-      </RadarEmptyShell>
-    )
-  }
+export default function RadarPage() {
+  const faqJsonLd = buildRadarFaqJsonLd()
 
   return (
-    <div className="fixed inset-0 z-40 flex flex-col overflow-hidden bg-black">
-      <RadarShell
-        latitude={weatherData.coordinates!.lat}
-        longitude={weatherData.coordinates!.lon}
-        locationName={weatherData.location}
-        theme={theme || 'nord'}
-        displayMode="full-page"
-        onLocationSearch={handleRadarSearch}
-        searchError={searchError}
-        shareConfig={{
-          title: weatherData.location
-            ? `Live Weather Radar - ${weatherData.location}`
-            : 'Live Weather Radar',
-          text: weatherData.location
-            ? `Live radar and severe weather overlays for ${weatherData.location}`
-            : 'Live global precipitation radar at 16bitweather.co',
-          url: shareUrl,
-        }}
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: safeJsonLd(faqJsonLd) }}
       />
-    </div>
+      <RadarSeoContent />
+      <Suspense
+        fallback={
+          <div className="fixed inset-0 z-40 flex items-center justify-center bg-black text-zinc-400">
+            Loading radar…
+          </div>
+        }
+      >
+        <RadarClient />
+      </Suspense>
+    </>
   )
 }

--- a/app/radar/radar-client.tsx
+++ b/app/radar/radar-client.tsx
@@ -1,0 +1,195 @@
+'use client'
+
+/**
+ * Full-viewport RainViewer radar — map-first layout with floating top bar and player dock.
+ */
+
+import { useEffect, useMemo, useState } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import dynamicImport from 'next/dynamic'
+import Link from 'next/link'
+import { Home, Map as MapIcon } from 'lucide-react'
+import { useLocationContext } from '@/components/location-context'
+import type { WeatherData } from '@/lib/types'
+import { useTheme } from '@/components/theme-provider'
+import { fetchWeatherData } from '@/lib/weather'
+import WeatherSearch from '@/components/weather-search'
+
+const RadarShell = dynamicImport(() => import('@/components/radar-v2/radar-shell'), {
+  ssr: false,
+  loading: () => (
+    <div className="flex h-full w-full items-center justify-center bg-black">
+      <div className="text-center text-white">
+        <div className="mb-2 text-lg font-semibold">Loading radar…</div>
+        <div className="text-sm text-zinc-400">Fetching RainViewer frames</div>
+      </div>
+    </div>
+  ),
+})
+
+function RadarOverlayShell({
+  message,
+  title,
+  body,
+  children,
+}: {
+  message?: string
+  title?: string
+  body?: string
+  children?: React.ReactNode
+}) {
+  return (
+    <div className="fixed inset-0 z-40 flex min-h-dvh flex-col bg-black text-white">
+      {title ? (
+        <>
+          <header className="flex items-center gap-3 border-b border-white/10 px-4 py-3">
+            <Link
+              href="/"
+              className="inline-flex items-center gap-2 rounded-lg border border-white/15 px-3 py-2 text-xs font-mono hover:bg-white/5"
+            >
+              <Home className="h-4 w-4" />
+              HOME
+            </Link>
+            <span className="text-xs font-mono uppercase tracking-wider text-zinc-400">Live Radar</span>
+          </header>
+          <div className="flex flex-1 flex-col items-center justify-center gap-4 px-4 text-center">
+            <h2 className="text-xl font-bold font-mono text-cyan-300">{title}</h2>
+            {body ? <p className="max-w-md text-sm text-zinc-400">{body}</p> : null}
+            {children}
+          </div>
+        </>
+      ) : (
+        <div className="flex flex-1 flex-col items-center justify-center gap-4 px-4">
+          <MapIcon className="h-10 w-10 text-cyan-400" aria-hidden="true" />
+          <p className="font-mono text-sm uppercase tracking-widest text-zinc-400">{message}</p>
+          <div className="h-8 w-8 animate-spin rounded-full border-2 border-cyan-400 border-t-transparent" />
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default function RadarClient() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const urlLocation = searchParams.get('location')
+  const { currentLocation } = useLocationContext()
+  const { theme } = useTheme()
+  const [weatherData, setWeatherData] = useState<WeatherData | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [searchError, setSearchError] = useState<string | undefined>()
+
+  const targetLocation = urlLocation || currentLocation
+
+  useEffect(() => {
+    const loadWeatherData = async () => {
+      setIsLoading(true)
+
+      if (targetLocation) {
+        try {
+          const freshData = await fetchWeatherData(targetLocation, 'imperial')
+          if (freshData?.coordinates?.lat != null && freshData?.coordinates?.lon != null) {
+            setWeatherData(freshData)
+            setIsLoading(false)
+            return
+          }
+        } catch (fetchError) {
+          console.warn('[RadarClient] Failed to fetch weather data:', fetchError)
+        }
+      }
+
+      setWeatherData(null)
+      setIsLoading(false)
+    }
+
+    void loadWeatherData()
+  }, [targetLocation, urlLocation])
+
+  const shareUrl = useMemo(() => {
+    if (!weatherData) return 'https://www.16bitweather.co/radar'
+
+    const params = new URLSearchParams(searchParams.toString())
+    params.set('location', weatherData.location)
+    if (weatherData.coordinates) {
+      params.set('lat', String(weatherData.coordinates.lat))
+      params.set('lon', String(weatherData.coordinates.lon))
+    }
+    return `https://www.16bitweather.co/radar?${params.toString()}`
+  }, [weatherData, searchParams])
+
+  const handleRadarSearch = (location: string) => {
+    const trimmed = location.trim()
+    if (!trimmed) {
+      setSearchError('Enter a location to load radar.')
+      return
+    }
+    setSearchError(undefined)
+    router.push(`/radar?location=${encodeURIComponent(trimmed)}`)
+  }
+
+  if (isLoading) {
+    return <RadarOverlayShell message="Initializing radar terminal" />
+  }
+
+  if (!weatherData) {
+    return (
+      <RadarOverlayShell
+        title="Choose a location"
+        body="Search for a city to open full-screen global precipitation radar with severe weather overlays."
+      >
+        <div className="w-full max-w-xl">
+          <WeatherSearch
+            onSearch={handleRadarSearch}
+            isLoading={isLoading}
+            error={searchError}
+            hideLocationButton
+          />
+        </div>
+      </RadarOverlayShell>
+    )
+  }
+
+  const hasValidCoordinates =
+    weatherData.coordinates?.lat != null && weatherData.coordinates?.lon != null
+
+  if (!hasValidCoordinates) {
+    return (
+      <RadarOverlayShell
+        title="Coordinates unavailable"
+        body={`Could not resolve map coordinates for ${weatherData.location}. Try searching again.`}
+      >
+        <div className="w-full max-w-xl">
+          <WeatherSearch
+            onSearch={handleRadarSearch}
+            isLoading={isLoading}
+            error={searchError}
+            hideLocationButton
+          />
+        </div>
+      </RadarOverlayShell>
+    )
+  }
+
+  return (
+    <div className="fixed inset-0 z-40 flex flex-col overflow-hidden bg-black">
+      <RadarShell
+        latitude={weatherData.coordinates!.lat}
+        longitude={weatherData.coordinates!.lon}
+        locationName={weatherData.location}
+        theme={theme || 'nord'}
+        displayMode="full-page"
+        onLocationSearch={handleRadarSearch}
+        searchError={searchError}
+        shareConfig={{
+          title: weatherData.location
+            ? `Live Weather Radar - ${weatherData.location}`
+            : 'Live Weather Radar',
+          text: weatherData.location
+            ? `Live radar and severe weather overlays for ${weatherData.location}`
+            : 'Live global precipitation radar at 16bitweather.co',
+          url: shareUrl,
+        }}
+      />
+    </div>
+  )
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,8 +1,6 @@
 import type { MetadataRoute } from 'next'
 import { cityData as cityMetadata } from '@/lib/city-metadata'
 import { getAllPosts } from '@/lib/blog'
-import deepSkyCatalog from '@/data/deep-sky-catalog.json'
-import type { DeepSkyObject } from '@/lib/stargazer/types'
 import { FEATURED_DETAIL_SLUGS, getAllWeatherSystemSlugs, getEducationDetailHref } from '@/lib/education/entries'
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
@@ -67,16 +65,9 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       priority: 0.9,
     }))
 
-    const stargazerObjectPages: MetadataRoute.Sitemap = (deepSkyCatalog as DeepSkyObject[]).map(
-      (obj) => ({
-        url: `${baseUrl}/stargazer/objects/${obj.id}`,
-        lastModified: new Date(),
-        changeFrequency: 'monthly' as const,
-        priority: 0.6,
-      }),
-    )
-    
-    // Dynamic blog posts
+    // Deep-sky object pages stay indexable via internal links but are omitted
+    // from the sitemap to focus crawl budget on city, education, and tool pages.
+
     let blogPosts: MetadataRoute.Sitemap = []
     try {
       blogPosts = getAllPosts().map(post => ({
@@ -89,7 +80,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       console.error('[sitemap] Failed to load blog posts')
     }
 
-    return [...staticPages, ...educationDetailPages, ...cityPages, ...stargazerObjectPages, ...blogPosts]
+    return [...staticPages, ...educationDetailPages, ...cityPages, ...blogPosts]
   } catch (error) {
     console.error('Error generating sitemap:', error)
     return [

--- a/app/weather/[city]/page.tsx
+++ b/app/weather/[city]/page.tsx
@@ -16,6 +16,7 @@ import {
   getNearbyCities,
 } from '@/lib/city-metadata'
 import { slugToDisplayName, slugToSearchTerm } from '@/lib/city-slug'
+import { buildCityPageMetadata } from '@/lib/seo/city-page-seo'
 
 const BASE_URL = 'https://www.16bitweather.co'
 
@@ -37,39 +38,7 @@ export async function generateMetadata({ params }: { params: Promise<{ city: str
     }
   }
 
-  const pageTitle = `${city.name}, ${city.state} Weather Forecast & Climate Guide | 16 Bit Weather`
-  const description = `${city.name}, ${city.state} weather forecast, climate guide, monthly averages, and best time to visit. Real-time conditions, 7-day outlook, and deep local climate data in retro terminal style.`
-
-  return {
-    title: pageTitle,
-    description,
-    keywords: `${city.name} weather, ${city.name} ${city.state} weather, ${city.name} climate, ${city.name} forecast, ${city.name} temperature, best time to visit ${city.name}, ${city.name} monthly weather, 16 bit weather`,
-    openGraph: {
-      title: pageTitle,
-      description,
-      url: `${BASE_URL}/weather/${citySlug}`,
-      siteName: '16 Bit Weather',
-      images: [
-        {
-          url: `/api/og?title=${encodeURIComponent(city.name + ', ' + city.state)}&subtitle=Weather+Forecast`,
-          width: 1200,
-          height: 630,
-          alt: `${city.name} Weather - 16 Bit Weather Terminal`,
-        },
-      ],
-      locale: 'en_US',
-      type: 'website',
-    },
-    twitter: {
-      card: 'summary_large_image',
-      title: pageTitle,
-      description,
-      images: [`/api/og?title=${encodeURIComponent(city.name + ', ' + city.state)}&subtitle=Weather+Forecast`],
-    },
-    alternates: {
-      canonical: `${BASE_URL}/weather/${citySlug}`,
-    },
-  }
+  return buildCityPageMetadata(city, citySlug)
 }
 
 interface PageParams {
@@ -101,8 +70,8 @@ export default async function CityWeatherPage({ params }: PageParams) {
   const webPageJsonLd = {
     '@context': 'https://schema.org',
     '@type': 'WebPage',
-    name: `${fullLocation} Weather Forecast & Climate Guide`,
-    description: `${fullLocation} weather forecast, climate data, monthly averages, and best time to visit.`,
+    name: `${fullLocation} Climate & Year-Round Weather Guide`,
+    description: `${fullLocation} climate averages, monthly weather patterns, and best time to visit.`,
     url: `${BASE_URL}/weather/${citySlug}`,
     about: {
       '@type': 'Place',

--- a/components/radar/radar-seo-content.tsx
+++ b/components/radar/radar-seo-content.tsx
@@ -46,6 +46,7 @@ export default function RadarSeoContent() {
     <article
       className="mx-auto max-w-3xl px-4 py-8 text-sm leading-relaxed text-zinc-300"
       aria-label="About the live weather radar"
+      data-testid="radar-seo-content"
     >
       <h1 className="mb-4 text-2xl font-bold font-mono text-cyan-300">
         Live Weather Radar Map — Global Precipitation &amp; Severe Overlays

--- a/components/radar/radar-seo-content.tsx
+++ b/components/radar/radar-seo-content.tsx
@@ -1,0 +1,87 @@
+import Link from 'next/link'
+
+const BASE_URL = 'https://www.16bitweather.co'
+
+export const RADAR_FAQS = [
+  {
+    question: 'What radar data does 16 Bit Weather use?',
+    answer:
+      'The live radar map uses RainViewer global precipitation composites with animated frames, layered with NWS severe weather alerts, SPC convective outlooks, and storm reports when available.',
+  },
+  {
+    question: 'Is the weather radar free to use?',
+    answer:
+      'Yes. The radar terminal at 16bitweather.co is free — search any city, animate recent precipitation, and jump to related warnings or severe outlook tools without an account.',
+  },
+  {
+    question: 'How often does the radar update?',
+    answer:
+      'RainViewer frames refresh as new composite imagery is published, typically every few minutes. Severe weather overlays pull from live NWS and SPC sources for active warnings and outlooks.',
+  },
+  {
+    question: 'Can I see tornado or severe thunderstorm warnings on the radar?',
+    answer:
+      'Yes. Enable NWS alert overlays on the map or open the Warnings command center for filtered tornado, severe thunderstorm, flood, and winter alerts with map context.',
+  },
+] as const
+
+export function buildRadarFaqJsonLd() {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: RADAR_FAQS.map((faq) => ({
+      '@type': 'Question',
+      name: faq.question,
+      acceptedAnswer: { '@type': 'Answer', text: faq.answer },
+    })),
+  }
+}
+
+/**
+ * Server-rendered crawlable copy for /radar. Stays in the DOM while the
+ * fullscreen client map loads on top.
+ */
+export default function RadarSeoContent() {
+  return (
+    <article
+      className="mx-auto max-w-3xl px-4 py-8 text-sm leading-relaxed text-zinc-300"
+      aria-label="About the live weather radar"
+    >
+      <h1 className="mb-4 text-2xl font-bold font-mono text-cyan-300">
+        Live Weather Radar Map — Global Precipitation &amp; Severe Overlays
+      </h1>
+      <p className="mb-4">
+        Track rain, snow, and thunderstorms on an animated global precipitation radar powered by
+        RainViewer. Search any city, scrub through recent frames, and layer NWS warnings, SPC
+        outlooks, and storm reports to see where severe weather intersects with active precipitation.
+      </p>
+      <p className="mb-4">
+        Use this page as your radar command center during active weather: zoom to your location,
+        watch echo tops move, then jump to the{' '}
+        <Link href="/warnings" className="text-cyan-400 underline underline-offset-2">
+          Warnings command center
+        </Link>{' '}
+        for filtered NWS alerts or the{' '}
+        <Link href="/severe" className="text-cyan-400 underline underline-offset-2">
+          Severe Weather outlook
+        </Link>{' '}
+        for SPC convective outlook maps and live warning panels.
+      </p>
+      <p className="mb-6">
+        Data sources include RainViewer radar composites, National Weather Service alert polygons,
+        Storm Prediction Center outlooks, and Iowa Environmental Mesonet storm reports. All overlays
+        are free on {BASE_URL.replace('https://', '')} — no account required.
+      </p>
+
+      <h2 className="mb-3 text-lg font-semibold font-mono text-white">Radar FAQ</h2>
+      <dl className="space-y-4">
+        {RADAR_FAQS.map((faq) => (
+          <div key={faq.question}>
+            <dt className="font-semibold text-white">{faq.question}</dt>
+            <dd className="mt-1 text-zinc-400">{faq.answer}</dd>
+          </div>
+        ))}
+      </dl>
+    </article>
+  )
+}

--- a/lib/seo/city-page-seo.ts
+++ b/lib/seo/city-page-seo.ts
@@ -1,0 +1,88 @@
+import type { Metadata } from 'next'
+
+const BASE_URL = 'https://www.16bitweather.co'
+
+/** Cities with the strongest GSC impression volume — climate-focused copy. */
+export const PRIORITY_SEO_CITY_SLUGS = [
+  'boston-ma',
+  'atlanta-ga',
+  'pittsburgh-pa',
+  'denver-co',
+  'virginia-beach-va',
+  'chicago-il',
+  'miami-fl',
+  'new-york-ny',
+  'los-angeles-ca',
+  'seattle-wa',
+] as const
+
+type CityMeta = {
+  name: string
+  state: string
+}
+
+export function buildCityPageTitle(city: CityMeta, citySlug: string): string {
+  const label = `${city.name}, ${city.state}`
+  if ((PRIORITY_SEO_CITY_SLUGS as readonly string[]).includes(citySlug)) {
+    return `${city.name} ${city.state} Climate & Year-Round Weather Guide | 16 Bit Weather`
+  }
+  return `${label} Climate & Year-Round Weather | 16 Bit Weather`
+}
+
+export function buildCityPageDescription(city: CityMeta): string {
+  return `${city.name}, ${city.state} climate averages, monthly weather patterns, and best time to visit. Live forecast, 7-day outlook, and year-round temperature data with retro terminal style.`
+}
+
+export function buildCityPageKeywords(city: CityMeta): string {
+  return [
+    `${city.name} weather`,
+    `${city.name} ${city.state} weather`,
+    `${city.name} climate`,
+    `${city.name} ${city.state} climate`,
+    `${city.name} weather year round`,
+    `${city.name} forecast`,
+    `best time to visit ${city.name}`,
+    `${city.name} monthly weather`,
+    '16 bit weather',
+  ].join(', ')
+}
+
+export function buildCityPageMetadata(city: CityMeta, citySlug: string): Pick<
+  Metadata,
+  'title' | 'description' | 'keywords' | 'openGraph' | 'twitter' | 'alternates'
+> {
+  const pageTitle = buildCityPageTitle(city, citySlug)
+  const description = buildCityPageDescription(city)
+  const ogImage = `/api/og?title=${encodeURIComponent(city.name + ', ' + city.state)}&subtitle=Climate+%26+Weather+Guide`
+
+  return {
+    title: pageTitle,
+    description,
+    keywords: buildCityPageKeywords(city),
+    openGraph: {
+      title: pageTitle,
+      description,
+      url: `${BASE_URL}/weather/${citySlug}`,
+      siteName: '16 Bit Weather',
+      images: [
+        {
+          url: ogImage,
+          width: 1200,
+          height: 630,
+          alt: `${city.name} Climate & Weather - 16 Bit Weather`,
+        },
+      ],
+      locale: 'en_US',
+      type: 'website',
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: pageTitle,
+      description,
+      images: [ogImage],
+    },
+    alternates: {
+      canonical: `${BASE_URL}/weather/${citySlug}`,
+    },
+  }
+}

--- a/tests/e2e/radar.spec.ts
+++ b/tests/e2e/radar.spec.ts
@@ -21,7 +21,9 @@ test.describe('Radar Map', () => {
     
     const radarContainer = page.locator('[data-radar-container]').first();
     await expect(radarContainer).toBeVisible();
-    await expect(page.getByText(/RAINVIEWER RADAR/i)).toBeVisible({ timeout: 15000 });
+    await expect(page.getByTestId('radar-status-chip').getByText(/RAINVIEWER RADAR/i)).toBeVisible({
+      timeout: 15000,
+    });
   });
 
   test('radar visible in synthwave theme', async ({ page }) => {
@@ -59,17 +61,17 @@ test.describe('Radar Map', () => {
     
     await expect(page.getByRole('button', { name: /^(Play|Pause)$/i })).toBeVisible();
     await page.getByRole('button', { name: /LAYERS/i }).click();
-    await expect(page.getByText(/NWS Alerts/i)).toBeVisible();
-    await expect(page.getByText(/SPC Outlook/i)).toBeVisible();
-    await expect(page.getByText(/Storm Reports/i)).toBeVisible();
+    await expect(page.getByRole('checkbox', { name: /NWS Alerts/i })).toBeVisible();
+    await expect(page.getByRole('checkbox', { name: /SPC Outlook/i })).toBeVisible();
+    await expect(page.getByRole('checkbox', { name: /Storm Reports/i })).toBeVisible();
   });
 
   test('radar map displays provider status badge and source attribution', async ({ page }) => {
     await navigateToRadarPage(page);
     await waitForRadarToLoad(page);
     
-    await expect(page.getByText(/RAINVIEWER RADAR/i)).toBeVisible();
-    await expect(page.getByText(/Source:\s*RainViewer/i)).toBeVisible();
+    await expect(page.getByTestId('radar-status-chip').getByText(/RAINVIEWER RADAR/i)).toBeVisible();
+    await expect(page.getByTestId('radar-player-dock').getByText(/Source:\s*RainViewer/i)).toBeVisible();
   });
 
   test('international location uses RainViewer provider', async ({ page }) => {
@@ -83,7 +85,9 @@ test.describe('Radar Map', () => {
     await navigateToRadarPage(page, 'Edmonton, CA');
     await waitForRadarToLoad(page);
 
-    await expect(page.getByText(/RAINVIEWER RADAR/i)).toBeVisible({ timeout: 15000 });
+    await expect(page.getByTestId('radar-status-chip').getByText(/RAINVIEWER RADAR/i)).toBeVisible({
+      timeout: 15000,
+    });
   });
 
   test('radar map fills the viewport below the page header', async ({ page }) => {


### PR DESCRIPTION
## Summary
- Add server-rendered crawlable copy and FAQ schema on `/radar` so Google sees substantive content instead of only a loading shell
- Refocus city page titles and descriptions on climate and year-round weather queries (aligned with GSC impression data for Boston, Atlanta, Pittsburgh, etc.)
- Remove ~150 deep-sky object URLs from the sitemap to concentrate crawl budget on cities, education, tools, and blog content

## GSC context
- Property: `sc-domain:16bitweather.co` (verified)
- Sitemap healthy at 273 URLs; will drop to ~120 after deploy
- `/radar` was "Crawled - currently not indexed" (last crawl March 2026)
- Re-inspection queued via GSC MCP for `/radar` and `/stargazer` after deploy

## Test plan
- [x] `npm run typecheck`
- [x] SEO unit tests (radar-seo, city-page-seo, sitemap-seo, seo-indexing)
- [ ] Playwright E2E (running in CI)
- [ ] After merge: request indexing for `/radar` in GSC once Vercel deploys
- [ ] Monitor GSC Performance report in 2-4 weeks for Boston/Atlanta click-through


Made with [Cursor](https://cursor.com)