### PR TITLE
Auth security and UX overhaul

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -98,3 +98,9 @@ NEXT_PUBLIC_BASE_URL=http://localhost:3000
 # WEATHER_RATE_LIMIT_HOURLY=120        # Max requests per hour per user/IP
 # WEATHER_RATE_LIMIT_BURST=30          # Max requests per burst window
 # WEATHER_RATE_LIMIT_BURST_WINDOW_MS=300000  # Burst window in milliseconds (5 min)
+
+# Cloudflare Turnstile CAPTCHA (optional)
+# When set, the auth forms render a Turnstile challenge and pass the token to
+# Supabase. Also set the matching secret key in Supabase Dashboard ->
+# Authentication -> Bot and Abuse Protection, or tokens won't be verified.
+NEXT_PUBLIC_TURNSTILE_SITE_KEY=

--- a/__tests__/auth-form.test.tsx
+++ b/__tests__/auth-form.test.tsx
@@ -87,12 +87,18 @@ describe('AuthForm', () => {
     fireEvent.click(screen.getByRole('button', { name: /^sign up$/i }))
 
     await waitFor(() => {
-      expect(mockSignUp).toHaveBeenCalled()
+      expect(mockSignUp).toHaveBeenCalledWith({
+        email: 'new@example.com',
+        password: 'longenough123',
+        captchaToken: undefined,
+      })
     })
 
     expect(screen.getByTestId('auth-success-alert')).toBeInTheDocument()
     expect(screen.queryByTestId('auth-error-alert')).not.toBeInTheDocument()
     expect(screen.getByTestId('auth-success-alert')).toHaveTextContent(/check your email/i)
+    expect(screen.queryByPlaceholderText(/full name/i)).not.toBeInTheDocument()
+    expect(screen.queryByPlaceholderText(/username/i)).not.toBeInTheDocument()
   })
 
   it('shows a destructive alert for sign-in errors', async () => {

--- a/__tests__/auth-form.test.tsx
+++ b/__tests__/auth-form.test.tsx
@@ -75,8 +75,8 @@ describe('AuthForm', () => {
 
     render(<AuthForm mode="signup" />)
 
-    // Password form lives behind the "More options" toggle now
-    fireEvent.click(screen.getByTestId('auth-more-options-toggle'))
+    // ?mode=signup opens the password form immediately
+    expect(screen.getByTestId('password-form')).toBeInTheDocument()
 
     fireEvent.change(screen.getByPlaceholderText(/enter your email/i), {
       target: { value: 'new@example.com' },

--- a/__tests__/auth-form.test.tsx
+++ b/__tests__/auth-form.test.tsx
@@ -31,10 +31,13 @@ const mockSignUp = jest.fn()
 const mockSignIn = jest.fn()
 const mockSignInWithProvider = jest.fn()
 
+const mockSignInWithMagicLink = jest.fn()
+
 jest.mock('@/lib/supabase/auth', () => ({
   signUp: (...args: unknown[]) => mockSignUp(...args),
   signIn: (...args: unknown[]) => mockSignIn(...args),
   signInWithProvider: (...args: unknown[]) => mockSignInWithProvider(...args),
+  signInWithMagicLink: (...args: unknown[]) => mockSignInWithMagicLink(...args),
 }))
 
 import AuthForm from '@/components/auth/auth-form'
@@ -46,6 +49,25 @@ describe('AuthForm', () => {
     mockSignUp.mockReset()
     mockSignIn.mockReset()
     mockSignInWithProvider.mockReset()
+    mockSignInWithMagicLink.mockReset()
+  })
+
+  it('sends a magic link from the default email form', async () => {
+    mockSignInWithMagicLink.mockResolvedValue({ data: {}, error: null })
+
+    render(<AuthForm mode="signin" />)
+
+    fireEvent.change(screen.getByPlaceholderText(/enter your email/i), {
+      target: { value: 'new@example.com' },
+    })
+    fireEvent.click(screen.getByTestId('magic-link-submit'))
+
+    await waitFor(() => {
+      expect(mockSignInWithMagicLink).toHaveBeenCalled()
+    })
+
+    expect(screen.getByTestId('auth-success-alert')).toHaveTextContent(/check your email/i)
+    expect(screen.queryByTestId('auth-error-alert')).not.toBeInTheDocument()
   })
 
   it('shows a success alert after signup without using the destructive error alert', async () => {
@@ -53,11 +75,14 @@ describe('AuthForm', () => {
 
     render(<AuthForm mode="signup" />)
 
+    // Password form lives behind the "More options" toggle now
+    fireEvent.click(screen.getByTestId('auth-more-options-toggle'))
+
     fireEvent.change(screen.getByPlaceholderText(/enter your email/i), {
       target: { value: 'new@example.com' },
     })
     fireEvent.change(screen.getByPlaceholderText(/enter your password/i), {
-      target: { value: 'secret123' },
+      target: { value: 'longenough123' },
     })
     fireEvent.click(screen.getByRole('button', { name: /^sign up$/i }))
 
@@ -80,11 +105,14 @@ describe('AuthForm', () => {
 
     expect(screen.getByTestId('auth-error-alert')).toHaveTextContent(/oauth failed/i)
 
+    // Password form lives behind the "More options" toggle now
+    fireEvent.click(screen.getByTestId('auth-more-options-toggle'))
+
     fireEvent.change(screen.getByPlaceholderText(/enter your email/i), {
       target: { value: 'bad@example.com' },
     })
     fireEvent.change(screen.getByPlaceholderText(/enter your password/i), {
-      target: { value: 'wrong12' },
+      target: { value: 'wrongpass123' },
     })
     fireEvent.click(screen.getByRole('button', { name: /^sign in$/i }))
 

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -34,13 +34,13 @@ export async function GET(request: NextRequest) {
     const safeErrorDescription = sanitizeLogValue(errorDescription)
     console.error('[Auth Callback] OAuth error:', safeError, safeErrorDescription)
     return NextResponse.redirect(
-      `${origin}/auth/login?error=${encodeURIComponent(errorDescription || error)}`,
+      `${origin}/auth?error=${encodeURIComponent(errorDescription || error)}`,
     )
   }
 
   if (!code) {
     console.error('[Auth Callback] No code provided')
-    return NextResponse.redirect(`${origin}/auth/login?error=no_code`)
+    return NextResponse.redirect(`${origin}/auth?error=no_code`)
   }
 
   const cookieStore = await cookies()
@@ -72,7 +72,7 @@ export async function GET(request: NextRequest) {
     const safeExchangeErrorMessage = sanitizeLogValue(exchangeError.message)
     console.error('[Auth Callback] Exchange error:', safeExchangeErrorMessage)
     return NextResponse.redirect(
-      `${origin}/auth/login?error=${encodeURIComponent(exchangeError.message)}`,
+      `${origin}/auth?error=${encodeURIComponent(exchangeError.message)}`,
     )
   }
 

--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -1,4 +1,5 @@
 import AuthForm from '@/components/auth/auth-form'
+import { validateRedirectPath } from '@/lib/utils/redirect-validation'
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
@@ -15,6 +16,10 @@ export default async function LoginPage({ searchParams }: LoginPageProps) {
   const rawError = params.error
   const initialError =
     typeof rawError === 'string' && rawError.length > 0 ? rawError : undefined
+  const next =
+    typeof params.next === 'string' && params.next.length > 0
+      ? validateRedirectPath(params.next)
+      : undefined
 
-  return <AuthForm mode="signin" initialError={initialError} />
+  return <AuthForm mode="signin" initialError={initialError} next={next} />
 }

--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -1,11 +1,10 @@
-import AuthForm from '@/components/auth/auth-form'
+import { redirect } from 'next/navigation'
 import { validateRedirectPath } from '@/lib/utils/redirect-validation'
-import type { Metadata } from 'next'
 
-export const metadata: Metadata = {
-  title: 'Sign In | 16-Bit Weather',
-  description: 'Sign in to access your saved locations and weather preferences.',
-}
+/**
+ * Legacy route — auth is unified at /auth. Kept as a redirect so old links,
+ * bookmarks, and ?next=/error= params keep working.
+ */
 
 interface LoginPageProps {
   searchParams?: Promise<{ error?: string; next?: string }>
@@ -13,13 +12,15 @@ interface LoginPageProps {
 
 export default async function LoginPage({ searchParams }: LoginPageProps) {
   const params = searchParams ? await searchParams : {}
-  const rawError = params.error
-  const initialError =
-    typeof rawError === 'string' && rawError.length > 0 ? rawError : undefined
-  const next =
-    typeof params.next === 'string' && params.next.length > 0
-      ? validateRedirectPath(params.next)
-      : undefined
+  const query = new URLSearchParams()
 
-  return <AuthForm mode="signin" initialError={initialError} next={next} />
+  if (typeof params.error === 'string' && params.error.length > 0) {
+    query.set('error', params.error)
+  }
+  if (typeof params.next === 'string' && params.next.length > 0) {
+    query.set('next', validateRedirectPath(params.next))
+  }
+
+  const queryString = query.toString()
+  redirect(queryString ? `/auth?${queryString}` : '/auth')
 }

--- a/app/auth/page.tsx
+++ b/app/auth/page.tsx
@@ -1,0 +1,26 @@
+import AuthForm from '@/components/auth/auth-form'
+import { validateRedirectPath } from '@/lib/utils/redirect-validation'
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Sign In | 16-Bit Weather',
+  description: 'Sign in or create an account to save locations and customize your weather experience.',
+}
+
+interface AuthPageProps {
+  searchParams?: Promise<{ error?: string; next?: string; mode?: string }>
+}
+
+export default async function AuthPage({ searchParams }: AuthPageProps) {
+  const params = searchParams ? await searchParams : {}
+  const rawError = params.error
+  const initialError =
+    typeof rawError === 'string' && rawError.length > 0 ? rawError : undefined
+  const next =
+    typeof params.next === 'string' && params.next.length > 0
+      ? validateRedirectPath(params.next)
+      : undefined
+  const mode = params.mode === 'signup' ? 'signup' : 'signin'
+
+  return <AuthForm mode={mode} initialError={initialError} next={next} />
+}

--- a/app/auth/reset-password/page.tsx
+++ b/app/auth/reset-password/page.tsx
@@ -108,7 +108,7 @@ export default function ResetPasswordPage() {
         {/* Back to Login */}
         <div className="mt-6 text-center">
           <Link
-            href="/auth/login"
+            href="/auth"
             className={`inline-flex items-center space-x-2 text-sm font-mono hover:underline ${themeClasses.accentText}`}
           >
             <ArrowLeft className="w-4 h-4" />

--- a/app/auth/reset-password/page.tsx
+++ b/app/auth/reset-password/page.tsx
@@ -6,12 +6,15 @@ import { Mail, ArrowLeft } from 'lucide-react'
 import { resetPassword } from '@/lib/supabase/auth'
 import { useTheme } from '@/components/theme-provider'
 import { getComponentStyles, type ThemeType } from '@/lib/theme-utils'
+import TurnstileWidget, { isTurnstileEnabled } from '@/components/auth/turnstile-widget'
 
 export default function ResetPasswordPage() {
   const [email, setEmail] = useState('')
   const [loading, setLoading] = useState(false)
   const [message, setMessage] = useState('')
   const [error, setError] = useState('')
+  const [captchaToken, setCaptchaToken] = useState<string | null>(null)
+  const [captchaResetKey, setCaptchaResetKey] = useState(0)
   const { theme } = useTheme()
 
   const themeClasses = getComponentStyles(theme as ThemeType, 'auth')
@@ -22,8 +25,15 @@ export default function ResetPasswordPage() {
     setError('')
     setMessage('')
 
+    // Turnstile tokens are single-use — force a fresh challenge for any retry
+    const submittedCaptchaToken = captchaToken ?? undefined
+    if (isTurnstileEnabled()) {
+      setCaptchaToken(null)
+      setCaptchaResetKey((key) => key + 1)
+    }
+
     try {
-      const { error } = await resetPassword(email)
+      const { error } = await resetPassword(email, submittedCaptchaToken)
       if (error) {
         setError(error.message)
       } else {
@@ -84,9 +94,11 @@ export default function ResetPasswordPage() {
             </div>
           </div>
 
+          <TurnstileWidget onToken={setCaptchaToken} resetKey={captchaResetKey} />
+
           <button
             type="submit"
-            disabled={loading}
+            disabled={loading || (isTurnstileEnabled() && !captchaToken)}
             className={`w-full px-4 py-3 border-2 text-sm font-mono font-bold uppercase tracking-wider transition-all duration-200 hover:scale-105 disabled:opacity-50 disabled:cursor-not-allowed ${themeClasses.accentBg} ${themeClasses.borderColor} text-black ${themeClasses.glow}`}
           >
             {loading ? 'Sending...' : 'Send Reset Link'}

--- a/app/auth/result/page.tsx
+++ b/app/auth/result/page.tsx
@@ -35,7 +35,7 @@ function AuthResultContent() {
         } else if (error) {
             // Redirect to login after showing error
             const timer = setTimeout(() => {
-                router.push(`/auth/login?error=${encodeURIComponent(error)}`)
+                router.push(`/auth?error=${encodeURIComponent(error)}`)
             }, 3000)
 
             return () => clearTimeout(timer)

--- a/app/auth/signout/route.ts
+++ b/app/auth/signout/route.ts
@@ -3,6 +3,20 @@ import { cookies } from 'next/headers'
 import { NextResponse } from 'next/server'
 
 export async function POST(request: Request) {
+    // CSRF guard: this route is cookie-authenticated, so reject cross-site
+    // POSTs (logout CSRF). Browsers send an Origin header on cross-origin
+    // form/fetch POSTs; same-origin requests either match or omit it.
+    const origin = request.headers.get('origin')
+    if (origin) {
+        try {
+            if (new URL(origin).host !== new URL(request.url).host) {
+                return NextResponse.json({ error: 'Invalid origin' }, { status: 403 })
+            }
+        } catch {
+            return NextResponse.json({ error: 'Invalid origin' }, { status: 403 })
+        }
+    }
+
     const cookieStore = await cookies()
 
     const supabase = createServerClient(

--- a/app/auth/signup/page.tsx
+++ b/app/auth/signup/page.tsx
@@ -1,4 +1,5 @@
 import AuthForm from '@/components/auth/auth-form'
+import { validateRedirectPath } from '@/lib/utils/redirect-validation'
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
@@ -6,6 +7,16 @@ export const metadata: Metadata = {
   description: 'Create an account to save locations and customize your weather experience.',
 }
 
-export default function SignupPage() {
-  return <AuthForm mode="signup" />
+interface SignupPageProps {
+  searchParams?: Promise<{ next?: string }>
+}
+
+export default async function SignupPage({ searchParams }: SignupPageProps) {
+  const params = searchParams ? await searchParams : {}
+  const next =
+    typeof params.next === 'string' && params.next.length > 0
+      ? validateRedirectPath(params.next)
+      : undefined
+
+  return <AuthForm mode="signup" next={next} />
 }

--- a/app/auth/signup/page.tsx
+++ b/app/auth/signup/page.tsx
@@ -1,11 +1,10 @@
-import AuthForm from '@/components/auth/auth-form'
+import { redirect } from 'next/navigation'
 import { validateRedirectPath } from '@/lib/utils/redirect-validation'
-import type { Metadata } from 'next'
 
-export const metadata: Metadata = {
-  title: 'Sign Up | 16-Bit Weather',
-  description: 'Create an account to save locations and customize your weather experience.',
-}
+/**
+ * Legacy route — auth is unified at /auth. Kept as a redirect so old links,
+ * bookmarks, and ?next= params keep working.
+ */
 
 interface SignupPageProps {
   searchParams?: Promise<{ next?: string }>
@@ -13,10 +12,12 @@ interface SignupPageProps {
 
 export default async function SignupPage({ searchParams }: SignupPageProps) {
   const params = searchParams ? await searchParams : {}
-  const next =
-    typeof params.next === 'string' && params.next.length > 0
-      ? validateRedirectPath(params.next)
-      : undefined
+  const query = new URLSearchParams()
+  query.set('mode', 'signup')
 
-  return <AuthForm mode="signup" next={next} />
+  if (typeof params.next === 'string' && params.next.length > 0) {
+    query.set('next', validateRedirectPath(params.next))
+  }
+
+  redirect(`/auth?${query.toString()}`)
 }

--- a/app/auth/update-password/page.tsx
+++ b/app/auth/update-password/page.tsx
@@ -172,7 +172,7 @@ export default function UpdatePasswordPage() {
         {/* Back to Login */}
         <div className="mt-6 text-center">
           <Link
-            href="/auth/login"
+            href="/auth"
             className={`inline-flex items-center space-x-2 text-sm font-mono hover:underline ${themeClasses.accentText}`}
           >
             <ArrowLeft className="w-4 h-4" />

--- a/app/auth/update-password/page.tsx
+++ b/app/auth/update-password/page.tsx
@@ -28,9 +28,16 @@ export default function UpdatePasswordPage() {
     let cancelled = false
 
     const checkSession = async () => {
-      const { data: { session } } = await supabase.auth.getSession()
-      if (!cancelled) {
-        setHasSession(!!session)
+      try {
+        const { data: { session } } = await supabase.auth.getSession()
+        if (!cancelled) {
+          setHasSession(!!session)
+        }
+      } catch (err) {
+        console.error('[update-password]', err)
+        if (!cancelled) {
+          setHasSession(false)
+        }
       }
     }
 
@@ -70,6 +77,7 @@ export default function UpdatePasswordPage() {
         }, 1500)
       }
     } catch (err) {
+      console.error('[update-password]', err)
       setError(err instanceof Error ? err.message : 'An error occurred')
     } finally {
       setLoading(false)

--- a/app/auth/update-password/page.tsx
+++ b/app/auth/update-password/page.tsx
@@ -1,0 +1,185 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import Link from 'next/link'
+import { Lock, ArrowLeft } from 'lucide-react'
+import { supabase } from '@/lib/supabase/client'
+import { updatePassword } from '@/lib/supabase/auth'
+import { useTheme } from '@/components/theme-provider'
+import { getComponentStyles, type ThemeType } from '@/lib/theme-utils'
+
+const MIN_PASSWORD_LENGTH = 10
+
+export default function UpdatePasswordPage() {
+  const [password, setPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [message, setMessage] = useState('')
+  const [error, setError] = useState('')
+  // null = checking, true = recovery session present, false = no session
+  const [hasSession, setHasSession] = useState<boolean | null>(null)
+  const router = useRouter()
+  const { theme } = useTheme()
+
+  const themeClasses = getComponentStyles(theme as ThemeType, 'auth')
+
+  useEffect(() => {
+    let cancelled = false
+
+    const checkSession = async () => {
+      const { data: { session } } = await supabase.auth.getSession()
+      if (!cancelled) {
+        setHasSession(!!session)
+      }
+    }
+
+    checkSession()
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError('')
+    setMessage('')
+
+    if (password.length < MIN_PASSWORD_LENGTH) {
+      setError(`Password must be at least ${MIN_PASSWORD_LENGTH} characters`)
+      return
+    }
+
+    if (password !== confirmPassword) {
+      setError('Passwords do not match')
+      return
+    }
+
+    setLoading(true)
+
+    try {
+      const { error } = await updatePassword(password)
+      if (error) {
+        setError(error.message)
+      } else {
+        setMessage('Password updated. Redirecting to your dashboard...')
+        setTimeout(() => {
+          router.push('/dashboard')
+          router.refresh()
+        }, 1500)
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center px-4">
+      <div className={`w-full max-w-md p-8 border-4 ${themeClasses.background} ${themeClasses.borderColor} ${themeClasses.glow}`}>
+        {/* Header */}
+        <div className="text-center mb-8">
+          <div className={`w-12 h-12 border-2 flex items-center justify-center mx-auto mb-4 ${themeClasses.accentBg} ${themeClasses.borderColor}`}>
+            <span className="text-black font-bold text-lg">16</span>
+          </div>
+          <h1 className={`text-2xl font-bold uppercase tracking-wider font-mono mb-2 ${themeClasses.text}`}>
+            Set New Password
+          </h1>
+          <p className={`text-sm ${themeClasses.secondary || themeClasses.text}`}>
+            Choose a new password for your account
+          </p>
+        </div>
+
+        {/* Error/Success Messages */}
+        {error && (
+          <div className="p-3 mb-4 border-2 border-red-500 bg-red-100 text-red-700 text-sm font-mono" data-testid="update-password-error">
+            {error}
+          </div>
+        )}
+
+        {message && (
+          <div className="p-3 mb-4 border-2 border-green-500 bg-green-100 text-green-700 text-sm font-mono" data-testid="update-password-success">
+            {message}
+          </div>
+        )}
+
+        {hasSession === false ? (
+          <div className="space-y-6 text-center">
+            <p className={`text-sm font-mono ${themeClasses.text}`}>
+              This password reset link is invalid or has expired. Request a new
+              one to continue.
+            </p>
+            <Link
+              href="/auth/reset-password"
+              className={`inline-block w-full px-4 py-3 border-2 text-sm font-mono font-bold uppercase tracking-wider ${themeClasses.accentBg} ${themeClasses.borderColor} text-black ${themeClasses.glow}`}
+            >
+              Request New Link
+            </Link>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+              <label className={`block text-sm font-mono font-bold uppercase mb-2 ${themeClasses.text}`}>
+                New Password
+              </label>
+              <div className="relative">
+                <Lock className={`absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 ${themeClasses.mutedText}`} />
+                <input
+                  type="password"
+                  required
+                  minLength={MIN_PASSWORD_LENGTH}
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  className={`w-full pl-10 pr-4 py-3 border-2 text-sm font-mono bg-transparent focus:outline-none focus:ring-2 focus:ring-offset-2 ${themeClasses.background} ${themeClasses.borderColor} ${themeClasses.text} focus:ring-current`}
+                  placeholder={`At least ${MIN_PASSWORD_LENGTH} characters`}
+                  data-testid="update-password-input"
+                />
+              </div>
+            </div>
+
+            <div>
+              <label className={`block text-sm font-mono font-bold uppercase mb-2 ${themeClasses.text}`}>
+                Confirm Password
+              </label>
+              <div className="relative">
+                <Lock className={`absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 ${themeClasses.mutedText}`} />
+                <input
+                  type="password"
+                  required
+                  minLength={MIN_PASSWORD_LENGTH}
+                  value={confirmPassword}
+                  onChange={(e) => setConfirmPassword(e.target.value)}
+                  className={`w-full pl-10 pr-4 py-3 border-2 text-sm font-mono bg-transparent focus:outline-none focus:ring-2 focus:ring-offset-2 ${themeClasses.background} ${themeClasses.borderColor} ${themeClasses.text} focus:ring-current`}
+                  placeholder="Re-enter your new password"
+                  data-testid="update-password-confirm-input"
+                />
+              </div>
+            </div>
+
+            <button
+              type="submit"
+              disabled={loading || hasSession === null}
+              className={`w-full px-4 py-3 border-2 text-sm font-mono font-bold uppercase tracking-wider transition-all duration-200 hover:scale-105 disabled:opacity-50 disabled:cursor-not-allowed ${themeClasses.accentBg} ${themeClasses.borderColor} text-black ${themeClasses.glow}`}
+              data-testid="update-password-submit"
+            >
+              {loading ? 'Updating...' : 'Update Password'}
+            </button>
+          </form>
+        )}
+
+        {/* Back to Login */}
+        <div className="mt-6 text-center">
+          <Link
+            href="/auth/login"
+            className={`inline-flex items-center space-x-2 text-sm font-mono hover:underline ${themeClasses.accentText}`}
+          >
+            <ArrowLeft className="w-4 h-4" />
+            <span>Back to Sign In</span>
+          </Link>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -2,7 +2,8 @@
 
 import { useState, useEffect, useCallback, Suspense } from 'react'
 import { useSearchParams } from 'next/navigation'
-import { ProtectedRoute, useAuth } from '@/lib/auth'
+import { useAuth } from '@/lib/auth'
+import DashboardPreview from '@/components/dashboard/dashboard-preview'
 import { useSavedLocations } from '@/lib/supabase/hooks'
 import { useTheme } from '@/components/theme-provider'
 import { getComponentStyles, type ThemeType } from '@/lib/theme-utils'
@@ -17,18 +18,32 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { isOnboardingDismissed, getWelcomeModalSessionKey } from '@/lib/dashboard/onboarding-state'
 
 export default function DashboardPage() {
+  const { user, loading } = useAuth()
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-background flex items-center justify-center">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
+      </div>
+    )
+  }
+
+  // Logged-out visitors see a preview with a sign-in CTA instead of being
+  // redirected away (the old ProtectedRoute behavior).
+  if (!user) {
+    return <DashboardPreview />
+  }
+
   return (
-    <ProtectedRoute>
-      <Suspense
-        fallback={
-          <div className="min-h-screen bg-background flex items-center justify-center">
-            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
-          </div>
-        }
-      >
-        <DashboardContent />
-      </Suspense>
-    </ProtectedRoute>
+    <Suspense
+      fallback={
+        <div className="min-h-screen bg-background flex items-center justify-center">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
+        </div>
+      }
+    >
+      <DashboardContent />
+    </Suspense>
   )
 }
 

--- a/app/weather/[city]/client.tsx
+++ b/app/weather/[city]/client.tsx
@@ -24,6 +24,7 @@ import { Loader2 } from 'lucide-react'
 import { ResponsiveContainer } from '@/components/responsive-container'
 import { useLocationContext } from '@/components/location-context'
 import { WeatherDisplay } from '@/components/weather-display'
+import SaveLocationButton from '@/components/weather/save-location-button'
 import { locationInputToSlug } from '@/lib/city-slug'
 import { useHubLocation } from '@/hooks/use-hub-location'
 import dynamic from 'next/dynamic'
@@ -247,6 +248,13 @@ export default function CityWeatherClient({ city, citySlug, climateGuide }: City
           {/* Weather Display - Unified with homepage */}
           {weather && !loading && !error && (
             <div id="live-weather" className="scroll-mt-24">
+              <div className="flex justify-end mb-2">
+                <SaveLocationButton
+                  weather={weather}
+                  cityName={city.name}
+                  state={city.state}
+                />
+              </div>
               <WeatherDisplay
                 weather={weather}
                 theme={theme || 'nord'}

--- a/components/auth/auth-button.tsx
+++ b/components/auth/auth-button.tsx
@@ -45,7 +45,7 @@ export default function AuthButton() {
   if (!user) {
     return (
       <Link
-        href="/auth/login"
+        href="/auth"
         className={cn(
           buttonVariants({ variant: "default", size: "default" }),
           "min-w-[80px] font-bold shadow-md shadow-glow-subtle border border-primary/25"

--- a/components/auth/auth-form.tsx
+++ b/components/auth/auth-form.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
-import { Eye, EyeOff, Mail, Lock, User, Globe, Code, ChevronDown, ChevronUp } from 'lucide-react'
+import { Eye, EyeOff, Mail, Lock, Globe, Code, ChevronDown, ChevronUp } from 'lucide-react'
 import { signIn, signUp, signInWithProvider, signInWithMagicLink } from '@/lib/supabase/auth'
 import { validateRedirectPath } from '@/lib/utils/redirect-validation'
 import TurnstileWidget, { isTurnstileEnabled } from '@/components/auth/turnstile-widget'
@@ -32,8 +32,6 @@ export default function AuthForm({ mode: initialMode, initialError, next }: Auth
   const [showPasswordForm, setShowPasswordForm] = useState(false)
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
-  const [username, setUsername] = useState('')
-  const [fullName, setFullName] = useState('')
   const [showPassword, setShowPassword] = useState(false)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState(initialError ?? '')
@@ -103,12 +101,10 @@ export default function AuthForm({ mode: initialMode, initialError, next }: Auth
           router.refresh()
         }
       } else {
-        const { user, error } = await signUp({
+        const { error } = await signUp({
           email,
           password,
-          username: username || undefined,
-          full_name: fullName || undefined,
-          captchaToken: submittedCaptchaToken
+          captchaToken: submittedCaptchaToken,
         })
         if (error) {
           setError(error.message)
@@ -238,42 +234,6 @@ export default function AuthForm({ mode: initialMode, initialError, next }: Auth
           ) : (
             /* More options: password form */
             <form onSubmit={handlePasswordSubmit} className="space-y-4" data-testid="password-form">
-              {mode === 'signup' && (
-                <>
-                  <div className="space-y-2">
-                    <Label className={`font-mono font-bold uppercase ${themeClasses.text}`}>
-                      Full Name (Optional)
-                    </Label>
-                    <div className="relative">
-                      <User className={`absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 ${themeClasses.mutedText}`} />
-                      <Input
-                        type="text"
-                        value={fullName}
-                        onChange={(e) => setFullName(e.target.value)}
-                        className={`pl-10 font-mono border-2 ${themeClasses.borderColor} ${themeClasses.text} ${themeClasses.background}`}
-                        placeholder="Enter your full name"
-                      />
-                    </div>
-                  </div>
-
-                  <div className="space-y-2">
-                    <Label className={`font-mono font-bold uppercase ${themeClasses.text}`}>
-                      Username (Optional)
-                    </Label>
-                    <div className="relative">
-                      <User className={`absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 ${themeClasses.mutedText}`} />
-                      <Input
-                        type="text"
-                        value={username}
-                        onChange={(e) => setUsername(e.target.value)}
-                        className={`pl-10 font-mono border-2 ${themeClasses.borderColor} ${themeClasses.text} ${themeClasses.background}`}
-                        placeholder="Choose a username"
-                      />
-                    </div>
-                  </div>
-                </>
-              )}
-
               {emailInput}
 
               <div className="space-y-2">

--- a/components/auth/auth-form.tsx
+++ b/components/auth/auth-form.tsx
@@ -3,8 +3,8 @@
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
-import { Eye, EyeOff, Mail, Lock, User, Globe, Code } from 'lucide-react'
-import { signIn, signUp, signInWithProvider } from '@/lib/supabase/auth'
+import { Eye, EyeOff, Mail, Lock, User, Globe, Code, ChevronDown, ChevronUp } from 'lucide-react'
+import { signIn, signUp, signInWithProvider, signInWithMagicLink } from '@/lib/supabase/auth'
 import { validateRedirectPath } from '@/lib/utils/redirect-validation'
 import TurnstileWidget, { isTurnstileEnabled } from '@/components/auth/turnstile-widget'
 import { useTheme } from '@/components/theme-provider'
@@ -24,7 +24,12 @@ interface AuthFormProps {
   next?: string
 }
 
-export default function AuthForm({ mode, initialError, next }: AuthFormProps) {
+export default function AuthForm({ mode: initialMode, initialError, next }: AuthFormProps) {
+  // Google (75%+ of sign-ins) and magic link are the primary paths; the
+  // password form and GitHub live behind "More options". Magic link handles
+  // both sign-in and sign-up, so mode only matters for the password form.
+  const [mode, setMode] = useState<'signin' | 'signup'>(initialMode)
+  const [showPasswordForm, setShowPasswordForm] = useState(false)
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [username, setUsername] = useState('')
@@ -40,18 +45,51 @@ export default function AuthForm({ mode, initialError, next }: AuthFormProps) {
 
   const themeClasses = getComponentStyles(theme as ThemeType, 'auth')
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const validatedNext = next ? validateRedirectPath(next) : undefined
+
+  // Turnstile tokens are single-use — grab the current token and force a
+  // fresh challenge so retries don't submit a consumed token.
+  const consumeCaptchaToken = (): string | undefined => {
+    const token = captchaToken ?? undefined
+    if (isTurnstileEnabled()) {
+      setCaptchaToken(null)
+      setCaptchaResetKey((key) => key + 1)
+    }
+    return token
+  }
+
+  const handleMagicLink = async (e: React.FormEvent) => {
     e.preventDefault()
     setLoading(true)
     setError('')
     setSuccess('')
 
-    // Turnstile tokens are single-use — force a fresh challenge for any retry
-    const submittedCaptchaToken = captchaToken ?? undefined
-    if (isTurnstileEnabled()) {
-      setCaptchaToken(null)
-      setCaptchaResetKey((key) => key + 1)
+    const submittedCaptchaToken = consumeCaptchaToken()
+
+    try {
+      const { error } = await signInWithMagicLink(email, {
+        redirectTo: validatedNext,
+        captchaToken: submittedCaptchaToken,
+      })
+      if (error) {
+        setError(error.message)
+      } else {
+        setSuccess('Check your email for a sign-in link. It signs you in on this device and creates your account if you are new.')
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred')
+    } finally {
+      setLoading(false)
     }
+  }
+
+  const handlePasswordSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setLoading(true)
+    setError('')
+    setSuccess('')
+
+    const submittedCaptchaToken = consumeCaptchaToken()
 
     try {
       if (mode === 'signin') {
@@ -61,7 +99,7 @@ export default function AuthForm({ mode, initialError, next }: AuthFormProps) {
         } else if (user) {
           // Return the user to where they were (?next=), falling back to the
           // dashboard — consistent with the OAuth callback flow.
-          router.push(next ? validateRedirectPath(next) : '/dashboard?welcome=1')
+          router.push(validatedNext ?? '/dashboard?welcome=1')
           router.refresh()
         }
       } else {
@@ -92,7 +130,7 @@ export default function AuthForm({ mode, initialError, next }: AuthFormProps) {
       setSuccess('')
       const { error } = await signInWithProvider(
         provider,
-        next ? { redirectTo: validateRedirectPath(next) } : undefined
+        validatedNext ? { redirectTo: validatedNext } : undefined
       )
       if (error) {
         setError(error.message)
@@ -104,6 +142,25 @@ export default function AuthForm({ mode, initialError, next }: AuthFormProps) {
     }
   }
 
+  const emailInput = (
+    <div className="space-y-2">
+      <Label className={`font-mono font-bold uppercase ${themeClasses.text}`}>
+        Email Address
+      </Label>
+      <div className="relative">
+        <Mail className={`absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 ${themeClasses.mutedText}`} />
+        <Input
+          type="email"
+          required
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className={`pl-10 font-mono border-2 ${themeClasses.borderColor} ${themeClasses.text} ${themeClasses.background}`}
+          placeholder="Enter your email"
+        />
+      </div>
+    </div>
+  )
+
   return (
     <div className="min-h-screen flex items-center justify-center px-4">
       <Card className={`w-full max-w-md container-primary ${themeClasses.background}`}>
@@ -113,13 +170,10 @@ export default function AuthForm({ mode, initialError, next }: AuthFormProps) {
           </div>
           <div>
             <CardTitle className={`text-2xl font-bold uppercase tracking-wider font-mono ${themeClasses.text}`}>
-              {mode === 'signin' ? 'Sign In' : 'Sign Up'}
+              Sign In
             </CardTitle>
             <CardDescription className={`font-mono mt-2 ${themeClasses.mutedText}`}>
-              {mode === 'signin'
-                ? 'Access your weather preferences and saved locations'
-                : 'Create your account to save locations and customize your experience'
-              }
+              Save locations and customize your weather experience. New here? Same buttons — your account is created automatically.
             </CardDescription>
           </div>
         </CardHeader>
@@ -140,28 +194,16 @@ export default function AuthForm({ mode, initialError, next }: AuthFormProps) {
             </Alert>
           )}
 
-          {/* OAuth Buttons */}
-          <div className="space-y-3">
-            <Button
-              variant="outline"
-              onClick={() => handleOAuthSignIn('google')}
-              disabled={loading}
-              className={`w-full font-mono font-bold uppercase tracking-wider border-2 h-12 ${themeClasses.borderColor} ${themeClasses.text} hover:${themeClasses.accentBg} hover:text-black`}
-            >
-              <Globe className="w-4 h-4 mr-2" />
-              Continue with Google
-            </Button>
-
-            <Button
-              variant="outline"
-              onClick={() => handleOAuthSignIn('github')}
-              disabled={loading}
-              className={`w-full font-mono font-bold uppercase tracking-wider border-2 h-12 ${themeClasses.borderColor} ${themeClasses.text} hover:${themeClasses.accentBg} hover:text-black`}
-            >
-              <Code className="w-4 h-4 mr-2" />
-              Continue with GitHub
-            </Button>
-          </div>
+          {/* Primary: Google OAuth */}
+          <Button
+            onClick={() => handleOAuthSignIn('google')}
+            disabled={loading}
+            data-testid="auth-google-button"
+            className={`w-full font-mono font-bold uppercase tracking-wider h-12 text-black ${themeClasses.accentBg} hover:opacity-90`}
+          >
+            <Globe className="w-4 h-4 mr-2" />
+            Continue with Google
+          </Button>
 
           {/* Divider */}
           <div className="relative">
@@ -175,120 +217,164 @@ export default function AuthForm({ mode, initialError, next }: AuthFormProps) {
             </div>
           </div>
 
-          {/* Form */}
-          <form onSubmit={handleSubmit} className="space-y-4">
-            {mode === 'signup' && (
-              <>
-                <div className="space-y-2">
-                  <Label className={`font-mono font-bold uppercase ${themeClasses.text}`}>
-                    Full Name (Optional)
-                  </Label>
-                  <div className="relative">
-                    <User className={`absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 ${themeClasses.mutedText}`} />
-                    <Input
-                      type="text"
-                      value={fullName}
-                      onChange={(e) => setFullName(e.target.value)}
-                      className={`pl-10 font-mono border-2 ${themeClasses.borderColor} ${themeClasses.text} ${themeClasses.background}`}
-                      placeholder="Enter your full name"
-                    />
-                  </div>
-                </div>
+          {!showPasswordForm ? (
+            /* Default email path: passwordless magic link */
+            <form onSubmit={handleMagicLink} className="space-y-4" data-testid="magic-link-form">
+              {emailInput}
 
-                <div className="space-y-2">
-                  <Label className={`font-mono font-bold uppercase ${themeClasses.text}`}>
-                    Username (Optional)
-                  </Label>
-                  <div className="relative">
-                    <User className={`absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 ${themeClasses.mutedText}`} />
-                    <Input
-                      type="text"
-                      value={username}
-                      onChange={(e) => setUsername(e.target.value)}
-                      className={`pl-10 font-mono border-2 ${themeClasses.borderColor} ${themeClasses.text} ${themeClasses.background}`}
-                      placeholder="Choose a username"
-                    />
-                  </div>
-                </div>
-              </>
-            )}
+              <TurnstileWidget onToken={setCaptchaToken} resetKey={captchaResetKey} />
 
-            <div className="space-y-2">
-              <Label className={`font-mono font-bold uppercase ${themeClasses.text}`}>
-                Email Address
-              </Label>
-              <div className="relative">
-                <Mail className={`absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 ${themeClasses.mutedText}`} />
-                <Input
-                  type="email"
-                  required
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                  className={`pl-10 font-mono border-2 ${themeClasses.borderColor} ${themeClasses.text} ${themeClasses.background}`}
-                  placeholder="Enter your email"
-                />
+              <Button
+                type="submit"
+                disabled={loading || (isTurnstileEnabled() && !captchaToken)}
+                data-testid="magic-link-submit"
+                variant="outline"
+                className={`w-full font-mono font-bold uppercase tracking-wider border-2 h-12 ${themeClasses.borderColor} ${themeClasses.text} hover:${themeClasses.accentBg} hover:text-black`}
+              >
+                <Mail className="w-4 h-4 mr-2" />
+                {loading ? 'Loading...' : 'Email Me a Sign-In Link'}
+              </Button>
+            </form>
+          ) : (
+            /* More options: password form */
+            <form onSubmit={handlePasswordSubmit} className="space-y-4" data-testid="password-form">
+              {mode === 'signup' && (
+                <>
+                  <div className="space-y-2">
+                    <Label className={`font-mono font-bold uppercase ${themeClasses.text}`}>
+                      Full Name (Optional)
+                    </Label>
+                    <div className="relative">
+                      <User className={`absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 ${themeClasses.mutedText}`} />
+                      <Input
+                        type="text"
+                        value={fullName}
+                        onChange={(e) => setFullName(e.target.value)}
+                        className={`pl-10 font-mono border-2 ${themeClasses.borderColor} ${themeClasses.text} ${themeClasses.background}`}
+                        placeholder="Enter your full name"
+                      />
+                    </div>
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label className={`font-mono font-bold uppercase ${themeClasses.text}`}>
+                      Username (Optional)
+                    </Label>
+                    <div className="relative">
+                      <User className={`absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 ${themeClasses.mutedText}`} />
+                      <Input
+                        type="text"
+                        value={username}
+                        onChange={(e) => setUsername(e.target.value)}
+                        className={`pl-10 font-mono border-2 ${themeClasses.borderColor} ${themeClasses.text} ${themeClasses.background}`}
+                        placeholder="Choose a username"
+                      />
+                    </div>
+                  </div>
+                </>
+              )}
+
+              {emailInput}
+
+              <div className="space-y-2">
+                <Label className={`font-mono font-bold uppercase ${themeClasses.text}`}>
+                  Password
+                </Label>
+                <div className="relative">
+                  <Lock className={`absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 ${themeClasses.mutedText}`} />
+                  <Input
+                    type={showPassword ? 'text' : 'password'}
+                    required
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    className={`pl-10 pr-12 font-mono border-2 ${themeClasses.borderColor} ${themeClasses.text} ${themeClasses.background}`}
+                    placeholder="Enter your password"
+                    minLength={10}
+                  />
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => setShowPassword(!showPassword)}
+                    className={`absolute right-0 top-0 h-full px-3 hover:bg-transparent`}
+                  >
+                    {showPassword ? <EyeOff className={`w-4 h-4 ${themeClasses.mutedText}`} /> : <Eye className={`w-4 h-4 ${themeClasses.mutedText}`} />}
+                  </Button>
+                </div>
               </div>
-            </div>
 
-            <div className="space-y-2">
-              <Label className={`font-mono font-bold uppercase ${themeClasses.text}`}>
-                Password
-              </Label>
-              <div className="relative">
-                <Lock className={`absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 ${themeClasses.mutedText}`} />
-                <Input
-                  type={showPassword ? 'text' : 'password'}
-                  required
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  className={`pl-10 pr-12 font-mono border-2 ${themeClasses.borderColor} ${themeClasses.text} ${themeClasses.background}`}
-                  placeholder="Enter your password"
-                  minLength={6}
-                />
-                <Button
+              {mode === 'signin' && (
+                <div className="text-right">
+                  <Link
+                    href="/auth/reset-password"
+                    className={`text-xs font-mono hover:underline ${themeClasses.accentText}`}
+                  >
+                    Forgot password?
+                  </Link>
+                </div>
+              )}
+
+              <TurnstileWidget onToken={setCaptchaToken} resetKey={captchaResetKey} />
+
+              <Button
+                type="submit"
+                disabled={loading || (isTurnstileEnabled() && !captchaToken)}
+                className={`w-full font-mono font-bold uppercase tracking-wider h-12 text-black ${themeClasses.accentBg} hover:opacity-90`}
+              >
+                {loading ? 'Loading...' : mode === 'signin' ? 'Sign In' : 'Sign Up'}
+              </Button>
+
+              <p className={`text-sm font-mono text-center ${themeClasses.mutedText}`}>
+                {mode === 'signin' ? "Don't have an account? " : "Already have an account? "}
+                <button
                   type="button"
-                  variant="ghost"
-                  size="icon"
-                  onClick={() => setShowPassword(!showPassword)}
-                  className={`absolute right-0 top-0 h-full px-3 hover:bg-transparent`}
+                  onClick={() => setMode(mode === 'signin' ? 'signup' : 'signin')}
+                  className={`font-bold hover:underline ${themeClasses.accentText}`}
                 >
-                  {showPassword ? <EyeOff className={`w-4 h-4 ${themeClasses.mutedText}`} /> : <Eye className={`w-4 h-4 ${themeClasses.mutedText}`} />}
-                </Button>
-              </div>
-            </div>
+                  {mode === 'signin' ? 'Sign Up' : 'Sign In'}
+                </button>
+              </p>
+            </form>
+          )}
 
-            {mode === 'signin' && (
-              <div className="text-right">
-                <Link
-                  href="/auth/reset-password"
-                  className={`text-xs font-mono hover:underline ${themeClasses.accentText}`}
-                >
-                  Forgot password?
-                </Link>
-              </div>
-            )}
-
-            <TurnstileWidget onToken={setCaptchaToken} resetKey={captchaResetKey} />
-
-            <Button
-              type="submit"
-              disabled={loading || (isTurnstileEnabled() && !captchaToken)}
-              className={`w-full font-mono font-bold uppercase tracking-wider h-12 text-black ${themeClasses.accentBg} hover:opacity-90`}
+          {/* More options toggle: GitHub + password */}
+          <div className="space-y-3">
+            <button
+              type="button"
+              onClick={() => setShowPasswordForm(!showPasswordForm)}
+              data-testid="auth-more-options-toggle"
+              className={`w-full inline-flex items-center justify-center gap-1 text-xs font-mono uppercase tracking-wider hover:underline ${themeClasses.mutedText}`}
             >
-              {loading ? 'Loading...' : mode === 'signin' ? 'Sign In' : 'Sign Up'}
-            </Button>
-          </form>
+              {showPasswordForm ? (
+                <>
+                  <ChevronUp className="w-3 h-3" />
+                  Back to sign-in link
+                </>
+              ) : (
+                <>
+                  <ChevronDown className="w-3 h-3" />
+                  More options (password, GitHub)
+                </>
+              )}
+            </button>
+
+            {showPasswordForm && (
+              <Button
+                variant="outline"
+                onClick={() => handleOAuthSignIn('github')}
+                disabled={loading}
+                className={`w-full font-mono font-bold uppercase tracking-wider border-2 h-12 ${themeClasses.borderColor} ${themeClasses.text} hover:${themeClasses.accentBg} hover:text-black`}
+              >
+                <Code className="w-4 h-4 mr-2" />
+                Continue with GitHub
+              </Button>
+            )}
+          </div>
         </CardContent>
 
         <CardFooter className="justify-center">
-          <p className={`text-sm font-mono ${themeClasses.mutedText}`}>
-            {mode === 'signin' ? "Don't have an account? " : "Already have an account? "}
-            <Link
-              href={`${mode === 'signin' ? '/auth/signup' : '/auth/login'}${next ? `?next=${encodeURIComponent(next)}` : ''}`}
-              className={`font-bold hover:underline ${themeClasses.accentText}`}
-            >
-              {mode === 'signin' ? 'Sign Up' : 'Sign In'}
-            </Link>
+          <p className={`text-xs font-mono text-center ${themeClasses.mutedText}`}>
+            One account for saved locations, themes, and severe weather alerts.
           </p>
         </CardFooter>
       </Card>

--- a/components/auth/auth-form.tsx
+++ b/components/auth/auth-form.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link'
 import { Eye, EyeOff, Mail, Lock, User, Globe, Code } from 'lucide-react'
 import { signIn, signUp, signInWithProvider } from '@/lib/supabase/auth'
 import { validateRedirectPath } from '@/lib/utils/redirect-validation'
+import TurnstileWidget, { isTurnstileEnabled } from '@/components/auth/turnstile-widget'
 import { useTheme } from '@/components/theme-provider'
 import { getComponentStyles, type ThemeType } from '@/lib/theme-utils'
 
@@ -32,6 +33,8 @@ export default function AuthForm({ mode, initialError, next }: AuthFormProps) {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState(initialError ?? '')
   const [success, setSuccess] = useState('')
+  const [captchaToken, setCaptchaToken] = useState<string | null>(null)
+  const [captchaResetKey, setCaptchaResetKey] = useState(0)
   const router = useRouter()
   const { theme } = useTheme()
 
@@ -43,9 +46,16 @@ export default function AuthForm({ mode, initialError, next }: AuthFormProps) {
     setError('')
     setSuccess('')
 
+    // Turnstile tokens are single-use — force a fresh challenge for any retry
+    const submittedCaptchaToken = captchaToken ?? undefined
+    if (isTurnstileEnabled()) {
+      setCaptchaToken(null)
+      setCaptchaResetKey((key) => key + 1)
+    }
+
     try {
       if (mode === 'signin') {
-        const { user, error } = await signIn({ email, password })
+        const { user, error } = await signIn({ email, password, captchaToken: submittedCaptchaToken })
         if (error) {
           setError(error.message)
         } else if (user) {
@@ -59,7 +69,8 @@ export default function AuthForm({ mode, initialError, next }: AuthFormProps) {
           email,
           password,
           username: username || undefined,
-          full_name: fullName || undefined
+          full_name: fullName || undefined,
+          captchaToken: submittedCaptchaToken
         })
         if (error) {
           setError(error.message)
@@ -257,9 +268,11 @@ export default function AuthForm({ mode, initialError, next }: AuthFormProps) {
               </div>
             )}
 
+            <TurnstileWidget onToken={setCaptchaToken} resetKey={captchaResetKey} />
+
             <Button
               type="submit"
-              disabled={loading}
+              disabled={loading || (isTurnstileEnabled() && !captchaToken)}
               className={`w-full font-mono font-bold uppercase tracking-wider h-12 text-black ${themeClasses.accentBg} hover:opacity-90`}
             >
               {loading ? 'Loading...' : mode === 'signin' ? 'Sign In' : 'Sign Up'}

--- a/components/auth/auth-form.tsx
+++ b/components/auth/auth-form.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { Eye, EyeOff, Mail, Lock, User, Globe, Code } from 'lucide-react'
 import { signIn, signUp, signInWithProvider } from '@/lib/supabase/auth'
+import { validateRedirectPath } from '@/lib/utils/redirect-validation'
 import { useTheme } from '@/components/theme-provider'
 import { getComponentStyles, type ThemeType } from '@/lib/theme-utils'
 
@@ -18,9 +19,11 @@ import { Alert, AlertDescription } from "@/components/ui/alert"
 interface AuthFormProps {
   mode: 'signin' | 'signup'
   initialError?: string
+  /** Validated internal path to return to after auth (from ?next=). */
+  next?: string
 }
 
-export default function AuthForm({ mode, initialError }: AuthFormProps) {
+export default function AuthForm({ mode, initialError, next }: AuthFormProps) {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [username, setUsername] = useState('')
@@ -46,8 +49,9 @@ export default function AuthForm({ mode, initialError }: AuthFormProps) {
         if (error) {
           setError(error.message)
         } else if (user) {
-          // Redirect to dashboard for better UX (consistent with OAuth flow)
-          router.push('/dashboard?welcome=1')
+          // Return the user to where they were (?next=), falling back to the
+          // dashboard — consistent with the OAuth callback flow.
+          router.push(next ? validateRedirectPath(next) : '/dashboard?welcome=1')
           router.refresh()
         }
       } else {
@@ -75,7 +79,10 @@ export default function AuthForm({ mode, initialError }: AuthFormProps) {
       setLoading(true)
       setError('')
       setSuccess('')
-      const { error } = await signInWithProvider(provider)
+      const { error } = await signInWithProvider(
+        provider,
+        next ? { redirectTo: validateRedirectPath(next) } : undefined
+      )
       if (error) {
         setError(error.message)
       }
@@ -264,7 +271,7 @@ export default function AuthForm({ mode, initialError }: AuthFormProps) {
           <p className={`text-sm font-mono ${themeClasses.mutedText}`}>
             {mode === 'signin' ? "Don't have an account? " : "Already have an account? "}
             <Link
-              href={mode === 'signin' ? '/auth/signup' : '/auth/login'}
+              href={`${mode === 'signin' ? '/auth/signup' : '/auth/login'}${next ? `?next=${encodeURIComponent(next)}` : ''}`}
               className={`font-bold hover:underline ${themeClasses.accentText}`}
             >
               {mode === 'signin' ? 'Sign Up' : 'Sign In'}

--- a/components/auth/auth-form.tsx
+++ b/components/auth/auth-form.tsx
@@ -28,8 +28,10 @@ export default function AuthForm({ mode: initialMode, initialError, next }: Auth
   // Google (75%+ of sign-ins) and magic link are the primary paths; the
   // password form and GitHub live behind "More options". Magic link handles
   // both sign-in and sign-up, so mode only matters for the password form.
+  // Deep links to ?mode=signup (and legacy /auth/signup) open the password
+  // form so the Sign Up CTA is immediately reachable.
   const [mode, setMode] = useState<'signin' | 'signup'>(initialMode)
-  const [showPasswordForm, setShowPasswordForm] = useState(false)
+  const [showPasswordForm, setShowPasswordForm] = useState(initialMode === 'signup')
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [showPassword, setShowPassword] = useState(false)

--- a/components/auth/auth-form.tsx
+++ b/components/auth/auth-form.tsx
@@ -251,7 +251,7 @@ export default function AuthForm({ mode: initialMode, initialError, next }: Auth
                     onChange={(e) => setPassword(e.target.value)}
                     className={`pl-10 pr-12 font-mono border-2 ${themeClasses.borderColor} ${themeClasses.text} ${themeClasses.background}`}
                     placeholder="Enter your password"
-                    minLength={10}
+                    minLength={mode === 'signup' ? 10 : undefined}
                   />
                   <Button
                     type="button"

--- a/components/auth/auth-gate-modal.tsx
+++ b/components/auth/auth-gate-modal.tsx
@@ -1,0 +1,170 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { Globe, Mail } from 'lucide-react'
+import { signInWithProvider, signInWithMagicLink } from '@/lib/supabase/auth'
+import { validateRedirectPath } from '@/lib/utils/redirect-validation'
+import TurnstileWidget, { isTurnstileEnabled } from '@/components/auth/turnstile-widget'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+
+interface AuthGateModalProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** What the user was trying to do, e.g. "Save this location". */
+  title?: string
+  description?: string
+  /** Internal path to return to after sign-in (validated). */
+  next?: string
+}
+
+/**
+ * Lightweight sign-in prompt for protected actions (saving a location,
+ * subscribing to alerts). Keeps the user on the page instead of bouncing
+ * them to /auth; after sign-in they return here via ?next=.
+ */
+export default function AuthGateModal({
+  open,
+  onOpenChange,
+  title = 'Sign in to continue',
+  description = 'One account for saved locations, themes, and severe weather alerts.',
+  next,
+}: AuthGateModalProps) {
+  const [email, setEmail] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [success, setSuccess] = useState('')
+  const [captchaToken, setCaptchaToken] = useState<string | null>(null)
+  const [captchaResetKey, setCaptchaResetKey] = useState(0)
+
+  const validatedNext = next ? validateRedirectPath(next) : undefined
+
+  const handleGoogle = async () => {
+    setLoading(true)
+    setError('')
+    try {
+      const { error } = await signInWithProvider(
+        'google',
+        validatedNext ? { redirectTo: validatedNext } : undefined
+      )
+      if (error) setError(error.message)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'OAuth error occurred')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleMagicLink = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setLoading(true)
+    setError('')
+    setSuccess('')
+
+    // Turnstile tokens are single-use — force a fresh challenge for retries
+    const submittedCaptchaToken = captchaToken ?? undefined
+    if (isTurnstileEnabled()) {
+      setCaptchaToken(null)
+      setCaptchaResetKey((key) => key + 1)
+    }
+
+    try {
+      const { error } = await signInWithMagicLink(email, {
+        redirectTo: validatedNext,
+        captchaToken: submittedCaptchaToken,
+      })
+      if (error) {
+        setError(error.message)
+      } else {
+        setSuccess('Check your email for a sign-in link — it will bring you right back here.')
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-sm font-mono" data-testid="auth-gate-modal">
+        <DialogHeader>
+          <DialogTitle className="uppercase tracking-wider">{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          {success ? (
+            <Alert className="border-2 border-green-500/50 bg-green-950/30 text-green-400" data-testid="auth-gate-success">
+              <AlertDescription>{success}</AlertDescription>
+            </Alert>
+          ) : (
+            <>
+              {error && (
+                <Alert variant="destructive" className="border-2" data-testid="auth-gate-error">
+                  <AlertDescription>{error}</AlertDescription>
+                </Alert>
+              )}
+
+              <Button
+                onClick={handleGoogle}
+                disabled={loading}
+                className="w-full font-bold uppercase tracking-wider h-11"
+                data-testid="auth-gate-google"
+              >
+                <Globe className="w-4 h-4 mr-2" />
+                Continue with Google
+              </Button>
+
+              <div className="text-center text-xs uppercase text-muted-foreground">
+                Or get a sign-in link
+              </div>
+
+              <form onSubmit={handleMagicLink} className="space-y-3">
+                <Input
+                  type="email"
+                  required
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  placeholder="Enter your email"
+                  className="border-2"
+                />
+
+                <TurnstileWidget onToken={setCaptchaToken} resetKey={captchaResetKey} />
+
+                <Button
+                  type="submit"
+                  variant="outline"
+                  disabled={loading || (isTurnstileEnabled() && !captchaToken)}
+                  className="w-full font-bold uppercase tracking-wider h-11 border-2"
+                  data-testid="auth-gate-magic-link"
+                >
+                  <Mail className="w-4 h-4 mr-2" />
+                  {loading ? 'Loading...' : 'Email Me a Sign-In Link'}
+                </Button>
+              </form>
+            </>
+          )}
+
+          <p className="text-center text-xs text-muted-foreground">
+            <Link
+              href={`/auth${validatedNext ? `?next=${encodeURIComponent(validatedNext)}` : ''}`}
+              className="hover:underline"
+            >
+              All sign-in options
+            </Link>
+          </p>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/auth/auth-gate-modal.tsx
+++ b/components/auth/auth-gate-modal.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import Link from 'next/link'
 import { Globe, Mail } from 'lucide-react'
 import { signInWithProvider, signInWithMagicLink } from '@/lib/supabase/auth'
@@ -45,6 +45,17 @@ export default function AuthGateModal({
   const [success, setSuccess] = useState('')
   const [captchaToken, setCaptchaToken] = useState<string | null>(null)
   const [captchaResetKey, setCaptchaResetKey] = useState(0)
+
+  useEffect(() => {
+    if (!open) {
+      setEmail('')
+      setError('')
+      setSuccess('')
+      setLoading(false)
+      setCaptchaToken(null)
+      setCaptchaResetKey((key) => key + 1)
+    }
+  }, [open])
 
   const validatedNext = next ? validateRedirectPath(next) : undefined
 

--- a/components/auth/turnstile-widget.tsx
+++ b/components/auth/turnstile-widget.tsx
@@ -1,0 +1,101 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+
+/**
+ * Cloudflare Turnstile CAPTCHA widget.
+ *
+ * Renders nothing unless NEXT_PUBLIC_TURNSTILE_SITE_KEY is set, so the auth
+ * forms work unchanged until CAPTCHA is enabled. When enabling, also set the
+ * secret key in Supabase Dashboard -> Authentication -> Bot and Abuse
+ * Protection, otherwise Supabase will not verify the tokens.
+ */
+
+declare global {
+  interface Window {
+    turnstile?: {
+      render: (el: HTMLElement, opts: Record<string, unknown>) => string
+      reset: (id?: string) => void
+      remove: (id: string) => void
+    }
+  }
+}
+
+const SCRIPT_SRC = 'https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit'
+
+const TURNSTILE_SITE_KEY = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY
+
+export function isTurnstileEnabled(): boolean {
+  return typeof TURNSTILE_SITE_KEY === 'string' && TURNSTILE_SITE_KEY.length > 0
+}
+
+interface TurnstileWidgetProps {
+  /** Called with a fresh token, or null when the token expires/errors. */
+  onToken: (token: string | null) => void
+  /** Bump to force a re-render of the widget (tokens are single-use). */
+  resetKey?: number
+}
+
+export default function TurnstileWidget({ onToken, resetKey = 0 }: TurnstileWidgetProps) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const widgetIdRef = useRef<string | null>(null)
+  const onTokenRef = useRef(onToken)
+  onTokenRef.current = onToken
+
+  useEffect(() => {
+    if (!isTurnstileEnabled() || !containerRef.current) return
+
+    let cancelled = false
+
+    const ensureScript = () =>
+      new Promise<void>((resolve, reject) => {
+        if (window.turnstile) {
+          resolve()
+          return
+        }
+        let script = document.querySelector<HTMLScriptElement>(`script[src="${SCRIPT_SRC}"]`)
+        if (!script) {
+          script = document.createElement('script')
+          script.src = SCRIPT_SRC
+          script.async = true
+          document.head.appendChild(script)
+        }
+        script.addEventListener('load', () => resolve(), { once: true })
+        script.addEventListener(
+          'error',
+          () => reject(new Error('Failed to load Turnstile script')),
+          { once: true },
+        )
+      })
+
+    ensureScript()
+      .then(() => {
+        if (cancelled || !window.turnstile || !containerRef.current) return
+        widgetIdRef.current = window.turnstile.render(containerRef.current, {
+          sitekey: TURNSTILE_SITE_KEY,
+          theme: 'auto',
+          callback: (token: string) => onTokenRef.current(token),
+          'expired-callback': () => onTokenRef.current(null),
+          'error-callback': () => onTokenRef.current(null),
+        })
+      })
+      .catch((err) => {
+        console.error('[turnstile]', err)
+        onTokenRef.current(null)
+      })
+
+    return () => {
+      cancelled = true
+      if (widgetIdRef.current && window.turnstile) {
+        window.turnstile.remove(widgetIdRef.current)
+        widgetIdRef.current = null
+      }
+    }
+  }, [resetKey])
+
+  if (!isTurnstileEnabled()) {
+    return null
+  }
+
+  return <div ref={containerRef} className="flex justify-center" data-testid="turnstile-widget" />
+}

--- a/components/auth/turnstile-widget.tsx
+++ b/components/auth/turnstile-widget.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 /**
  * Cloudflare Turnstile CAPTCHA widget.
@@ -22,6 +22,7 @@ declare global {
 }
 
 const SCRIPT_SRC = 'https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit'
+const SCRIPT_LOAD_TIMEOUT_MS = 10_000
 
 const TURNSTILE_SITE_KEY = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY
 
@@ -36,37 +37,67 @@ interface TurnstileWidgetProps {
   resetKey?: number
 }
 
+function ensureScript(): Promise<void> {
+  if (typeof window === 'undefined') {
+    return Promise.reject(new Error('Turnstile requires a browser environment'))
+  }
+  if (window.turnstile) {
+    return Promise.resolve()
+  }
+
+  return new Promise<void>((resolve, reject) => {
+    let settled = false
+    const settle = (fn: () => void) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timeoutId)
+      fn()
+    }
+
+    let script = document.querySelector<HTMLScriptElement>(`script[src="${SCRIPT_SRC}"]`)
+    if (!script) {
+      script = document.createElement('script')
+      script.src = SCRIPT_SRC
+      script.async = true
+      document.head.appendChild(script)
+    }
+
+    const onLoad = () => settle(() => resolve())
+    const onError = () =>
+      settle(() => {
+        script?.remove()
+        reject(new Error('Failed to load Turnstile script'))
+      })
+
+    script.addEventListener('load', onLoad, { once: true })
+    script.addEventListener('error', onError, { once: true })
+
+    const timeoutId = window.setTimeout(() => {
+      settle(() => {
+        script?.remove()
+        reject(new Error('Timed out loading Turnstile script'))
+      })
+    }, SCRIPT_LOAD_TIMEOUT_MS)
+
+    // Script may already be loaded (or failed) before listeners attached.
+    if (window.turnstile) {
+      settle(() => resolve())
+    }
+  })
+}
+
 export default function TurnstileWidget({ onToken, resetKey = 0 }: TurnstileWidgetProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const widgetIdRef = useRef<string | null>(null)
   const onTokenRef = useRef(onToken)
   onTokenRef.current = onToken
+  const [loadError, setLoadError] = useState<string | null>(null)
 
   useEffect(() => {
     if (!isTurnstileEnabled() || !containerRef.current) return
 
     let cancelled = false
-
-    const ensureScript = () =>
-      new Promise<void>((resolve, reject) => {
-        if (window.turnstile) {
-          resolve()
-          return
-        }
-        let script = document.querySelector<HTMLScriptElement>(`script[src="${SCRIPT_SRC}"]`)
-        if (!script) {
-          script = document.createElement('script')
-          script.src = SCRIPT_SRC
-          script.async = true
-          document.head.appendChild(script)
-        }
-        script.addEventListener('load', () => resolve(), { once: true })
-        script.addEventListener(
-          'error',
-          () => reject(new Error('Failed to load Turnstile script')),
-          { once: true },
-        )
-      })
+    setLoadError(null)
 
     ensureScript()
       .then(() => {
@@ -82,6 +113,11 @@ export default function TurnstileWidget({ onToken, resetKey = 0 }: TurnstileWidg
       .catch((err) => {
         console.error('[turnstile]', err)
         onTokenRef.current(null)
+        if (!cancelled) {
+          setLoadError(
+            'Security check failed to load. Disable ad blockers for this site, or refresh and try again.',
+          )
+        }
       })
 
     return () => {
@@ -97,5 +133,14 @@ export default function TurnstileWidget({ onToken, resetKey = 0 }: TurnstileWidg
     return null
   }
 
-  return <div ref={containerRef} className="flex justify-center" data-testid="turnstile-widget" />
+  return (
+    <div className="space-y-2">
+      <div ref={containerRef} className="flex justify-center" data-testid="turnstile-widget" />
+      {loadError && (
+        <p className="text-center text-xs font-mono text-red-500" data-testid="turnstile-load-error" role="alert">
+          {loadError}
+        </p>
+      )}
+    </div>
+  )
 }

--- a/components/dashboard/dashboard-preview.tsx
+++ b/components/dashboard/dashboard-preview.tsx
@@ -6,7 +6,7 @@ import { MapPin, Palette, Siren, Settings } from 'lucide-react'
 import Navigation from '@/components/navigation'
 import AuthGateModal from '@/components/auth/auth-gate-modal'
 import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Card, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { useTheme } from '@/components/theme-provider'
 import { getComponentStyles, type ThemeType } from '@/lib/theme-utils'
 

--- a/components/dashboard/dashboard-preview.tsx
+++ b/components/dashboard/dashboard-preview.tsx
@@ -1,0 +1,109 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { MapPin, Palette, Siren, Settings } from 'lucide-react'
+import Navigation from '@/components/navigation'
+import AuthGateModal from '@/components/auth/auth-gate-modal'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { useTheme } from '@/components/theme-provider'
+import { getComponentStyles, type ThemeType } from '@/lib/theme-utils'
+
+const FEATURES = [
+  {
+    icon: MapPin,
+    title: 'Saved Locations',
+    description: 'Pin your cities and see current conditions for all of them at a glance.',
+  },
+  {
+    icon: Siren,
+    title: 'Severe Weather Alerts',
+    description: 'Get notified when watches and warnings are issued for your saved locations.',
+  },
+  {
+    icon: Palette,
+    title: 'All Six Themes',
+    description: 'Unlock every retro terminal theme and keep your pick across devices.',
+  },
+  {
+    icon: Settings,
+    title: 'Preferences',
+    description: 'Units, forecast defaults, and dashboard layout — saved to your account.',
+  },
+] as const
+
+/**
+ * Logged-out view of /dashboard. Shows what the dashboard offers instead of
+ * bouncing anonymous visitors to the auth page.
+ */
+export default function DashboardPreview() {
+  const { theme } = useTheme()
+  const themeClasses = getComponentStyles(theme as ThemeType, 'dashboard')
+  const [gateOpen, setGateOpen] = useState(false)
+
+  return (
+    <div className={`min-h-screen ${themeClasses.background}`}>
+      <Navigation />
+
+      <div className="container mx-auto px-4 py-8 space-y-8" data-testid="dashboard-preview">
+        <header className="text-center">
+          <h1
+            className={`text-3xl font-bold uppercase tracking-wider font-mono mb-3 ${themeClasses.text} ${themeClasses.glow}`}
+            style={{ fontFamily: 'monospace', fontSize: 'clamp(24px, 5vw, 40px)' }}
+          >
+            Weather Dashboard
+          </h1>
+          <p className={`text-base font-mono ${themeClasses.secondary || themeClasses.text} max-w-2xl mx-auto`}>
+            Your cities, your themes, your alerts — sign in to set it up in under a minute.
+          </p>
+        </header>
+
+        <div className="grid gap-4 sm:grid-cols-2 max-w-3xl mx-auto">
+          {FEATURES.map(({ icon: Icon, title, description }) => (
+            <Card
+              key={title}
+              className={`${themeClasses.background} border-2 ${themeClasses.borderColor}`}
+            >
+              <CardHeader>
+                <CardTitle
+                  className={`font-mono font-bold text-base uppercase tracking-wider ${themeClasses.text}`}
+                >
+                  <Icon className="w-4 h-4 inline mr-2" aria-hidden="true" />
+                  {title}
+                </CardTitle>
+                <CardDescription className={`font-mono ${themeClasses.mutedText}`}>
+                  {description}
+                </CardDescription>
+              </CardHeader>
+            </Card>
+          ))}
+        </div>
+
+        <div className="flex flex-col items-center gap-3">
+          <Button
+            onClick={() => setGateOpen(true)}
+            data-testid="dashboard-preview-signin"
+            className="font-mono font-bold uppercase tracking-wider h-12 px-8"
+          >
+            Sign In to Get Started
+          </Button>
+          <Link
+            href="/auth?next=%2Fdashboard"
+            className={`text-xs font-mono hover:underline ${themeClasses.mutedText}`}
+          >
+            All sign-in options
+          </Link>
+        </div>
+      </div>
+
+      <AuthGateModal
+        open={gateOpen}
+        onOpenChange={setGateOpen}
+        title="Set up your dashboard"
+        description="One account for saved locations, themes, and severe weather alerts."
+        next="/dashboard"
+      />
+    </div>
+  )
+}

--- a/components/warnings/storm-report-form.tsx
+++ b/components/warnings/storm-report-form.tsx
@@ -88,7 +88,7 @@ export default function StormReportForm({
       <div className={cn('rounded-lg border border-border bg-card/50 p-4 font-mono text-sm', className)}>
         <p className="text-muted-foreground mb-2">Sign in to submit a ground-truth observation.</p>
         <Button asChild size="sm" variant="secondary">
-          <Link href="/auth/login">Log in</Link>
+          <Link href="/auth">Log in</Link>
         </Button>
       </div>
     )

--- a/components/weather/save-location-button.tsx
+++ b/components/weather/save-location-button.tsx
@@ -1,0 +1,105 @@
+'use client'
+
+import { useState } from 'react'
+import { usePathname } from 'next/navigation'
+import { BookmarkPlus, Check, Loader2 } from 'lucide-react'
+import { useAuth } from '@/lib/auth'
+import { saveUserLocation } from '@/lib/dashboard/save-user-location'
+import AuthGateModal from '@/components/auth/auth-gate-modal'
+import { Button } from '@/components/ui/button'
+import type { WeatherData } from '@/lib/types'
+
+interface SaveLocationButtonProps {
+  weather: WeatherData
+  cityName: string
+  state?: string
+}
+
+/**
+ * "Save to Dashboard" on public weather pages. Logged-out visitors get the
+ * auth gate modal and return here after signing in (?next=); logged-in
+ * users save directly.
+ */
+export default function SaveLocationButton({ weather, cityName, state }: SaveLocationButtonProps) {
+  const { user } = useAuth()
+  const pathname = usePathname()
+  const [status, setStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle')
+  const [message, setMessage] = useState('')
+  const [gateOpen, setGateOpen] = useState(false)
+
+  const latitude = weather.coordinates?.lat
+  const longitude = weather.coordinates?.lon
+
+  if (latitude == null || longitude == null) {
+    return null
+  }
+
+  const handleClick = async () => {
+    if (!user) {
+      setGateOpen(true)
+      return
+    }
+
+    setStatus('saving')
+    setMessage('')
+
+    try {
+      await saveUserLocation({
+        location_name: weather.location || cityName,
+        city: cityName,
+        state: state || null,
+        country: weather.country || 'Unknown',
+        latitude,
+        longitude,
+      })
+      setStatus('saved')
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : 'Failed to save location'
+      if (errorMessage.includes('already in your saved locations')) {
+        setStatus('saved')
+        setMessage('Already saved to your dashboard')
+      } else {
+        setStatus('error')
+        setMessage(errorMessage)
+      }
+    }
+  }
+
+  return (
+    <div className="flex flex-col items-end gap-1">
+      <Button
+        onClick={handleClick}
+        disabled={status === 'saving' || status === 'saved'}
+        variant="outline"
+        size="sm"
+        className="font-mono font-bold uppercase tracking-wider border-2"
+        data-testid="save-location-button"
+      >
+        {status === 'saving' ? (
+          <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+        ) : status === 'saved' ? (
+          <Check className="w-4 h-4 mr-2" />
+        ) : (
+          <BookmarkPlus className="w-4 h-4 mr-2" />
+        )}
+        {status === 'saved' ? 'Saved' : 'Save to Dashboard'}
+      </Button>
+      {message && (
+        <span
+          className={`text-xs font-mono ${status === 'error' ? 'text-red-500' : 'text-muted-foreground'}`}
+          data-testid="save-location-message"
+        >
+          {message}
+        </span>
+      )}
+
+      <AuthGateModal
+        open={gateOpen}
+        onOpenChange={setGateOpen}
+        title="Save this location"
+        description="Sign in to pin this city to your dashboard and get severe weather alerts for it."
+        next={pathname ?? undefined}
+      />
+    </div>
+  )
+}

--- a/hooks/use-theme-preview.ts
+++ b/hooks/use-theme-preview.ts
@@ -114,7 +114,7 @@ export function useThemePreview() {
   // Upgrade to premium (redirect to signup)
   const upgradeAccount = () => {
     clearTimers()
-    router.push('/auth/signup')
+    router.push('/auth?mode=signup')
   }
 
   // Cleanup on unmount

--- a/lib/auth/protected-route.tsx
+++ b/lib/auth/protected-route.tsx
@@ -9,7 +9,7 @@ interface ProtectedRouteProps {
   redirectTo?: string
 }
 
-export function ProtectedRoute({ children, redirectTo = '/auth/login' }: ProtectedRouteProps) {
+export function ProtectedRoute({ children, redirectTo = '/auth' }: ProtectedRouteProps) {
   // Hooks must be called unconditionally at the top
   const { user, loading } = useAuth()
   const router = useRouter()

--- a/lib/auth/protected-route.tsx
+++ b/lib/auth/protected-route.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect } from 'react'
-import { useRouter } from 'next/navigation'
+import { usePathname, useRouter } from 'next/navigation'
 import { useAuth } from './auth-context'
 
 interface ProtectedRouteProps {
@@ -13,6 +13,7 @@ export function ProtectedRoute({ children, redirectTo = '/auth/login' }: Protect
   // Hooks must be called unconditionally at the top
   const { user, loading } = useAuth()
   const router = useRouter()
+  const pathname = usePathname()
 
   // The previous Playwright test-mode bypass that rendered children
   // unconditionally lived here. Removed in Phase 4 cleanup (Phase 1 M2):
@@ -22,9 +23,15 @@ export function ProtectedRoute({ children, redirectTo = '/auth/login' }: Protect
   // sessions seeded by Playwright fixtures, not a render-layer bypass.
   useEffect(() => {
     if (!loading && !user) {
-      router.push(redirectTo)
+      // Preserve the attempted path so auth returns the user here afterwards
+      // (mirrors the ?next= behavior of the middleware redirect).
+      const target =
+        pathname && pathname !== '/'
+          ? `${redirectTo}?next=${encodeURIComponent(pathname)}`
+          : redirectTo
+      router.push(target)
     }
-  }, [user, loading, router, redirectTo])
+  }, [user, loading, router, redirectTo, pathname])
 
   if (loading) {
     return (

--- a/lib/supabase/auth.ts
+++ b/lib/supabase/auth.ts
@@ -79,10 +79,20 @@ export const signInWithProvider = async (
 
 
 // Reset password (used by app/auth/reset-password/page.tsx)
+// The recovery link goes through /auth/callback (PKCE code exchange) and then
+// lands on /auth/update-password, where the user actually sets the new password.
 export const resetPassword = async (email: string) => {
   const { data, error } = await supabase.auth.resetPasswordForEmail(email, {
-    redirectTo: `${window.location.origin}/auth/reset-password`
+    redirectTo: `${window.location.origin}/auth/callback?next=${encodeURIComponent('/auth/update-password')}`
   })
 
   return { data, error }
+}
+
+// Complete the password-recovery flow (used by app/auth/update-password/page.tsx).
+// Requires an active session, which the recovery-link callback establishes.
+export const updatePassword = async (password: string) => {
+  const { data, error } = await supabase.auth.updateUser({ password })
+
+  return { user: data.user, error }
 }

--- a/lib/supabase/auth.ts
+++ b/lib/supabase/auth.ts
@@ -11,8 +11,6 @@ export interface AuthResponse {
 export interface SignUpData {
   email: string
   password: string
-  username?: string
-  full_name?: string
   captchaToken?: string
 }
 
@@ -22,16 +20,13 @@ export interface SignInData {
   captchaToken?: string
 }
 
-// Sign up new user
-export const signUp = async ({ email, password, username, full_name, captchaToken }: SignUpData): Promise<AuthResponse> => {
+// Sign up new user. Profile fields (username / full name) are collected later
+// on /profile — keep the first-run form to email + password only.
+export const signUp = async ({ email, password, captchaToken }: SignUpData): Promise<AuthResponse> => {
   const { data, error } = await supabase.auth.signUp({
     email,
     password,
     options: {
-      data: {
-        username,
-        full_name,
-      },
       captchaToken,
     }
   })
@@ -82,7 +77,7 @@ export const signInWithMagicLink = async (
 
 // Sign in with OAuth providers
 export const signInWithProvider = async (
-  provider: 'google' | 'github' | 'discord',
+  provider: 'google' | 'github',
   options?: { redirectTo?: string }
 ) => {
   // Build callback URL with optional next parameter

--- a/lib/supabase/auth.ts
+++ b/lib/supabase/auth.ts
@@ -58,6 +58,28 @@ export const signIn = async ({ email, password, captchaToken }: SignInData): Pro
   }
 }
 
+// Passwordless sign-in: emails a magic link that signs the user in (and
+// creates the account on first use — one flow for sign-in and sign-up).
+// The link goes through /auth/callback (PKCE code exchange) like OAuth does.
+export const signInWithMagicLink = async (
+  email: string,
+  options?: { redirectTo?: string; captchaToken?: string }
+) => {
+  const finalDestination = options?.redirectTo || '/dashboard?welcome=1'
+  const emailRedirectTo = `${window.location.origin}/auth/callback?next=${encodeURIComponent(finalDestination)}`
+
+  const { data, error } = await supabase.auth.signInWithOtp({
+    email,
+    options: {
+      emailRedirectTo,
+      shouldCreateUser: true,
+      captchaToken: options?.captchaToken,
+    },
+  })
+
+  return { data, error }
+}
+
 // Sign in with OAuth providers
 export const signInWithProvider = async (
   provider: 'google' | 'github' | 'discord',

--- a/lib/supabase/auth.ts
+++ b/lib/supabase/auth.ts
@@ -115,7 +115,7 @@ export const resetPassword = async (email: string, captchaToken?: string) => {
 
 // Complete the password-recovery flow (used by app/auth/update-password/page.tsx).
 // Requires an active session, which the recovery-link callback establishes.
-export const updatePassword = async (password: string) => {
+export const updatePassword = async (password: string): Promise<AuthResponse> => {
   const { data, error } = await supabase.auth.updateUser({ password })
 
   return { user: data.user, error }

--- a/lib/supabase/auth.ts
+++ b/lib/supabase/auth.ts
@@ -13,15 +13,17 @@ export interface SignUpData {
   password: string
   username?: string
   full_name?: string
+  captchaToken?: string
 }
 
 export interface SignInData {
   email: string
   password: string
+  captchaToken?: string
 }
 
 // Sign up new user
-export const signUp = async ({ email, password, username, full_name }: SignUpData): Promise<AuthResponse> => {
+export const signUp = async ({ email, password, username, full_name, captchaToken }: SignUpData): Promise<AuthResponse> => {
   const { data, error } = await supabase.auth.signUp({
     email,
     password,
@@ -29,7 +31,8 @@ export const signUp = async ({ email, password, username, full_name }: SignUpDat
       data: {
         username,
         full_name,
-      }
+      },
+      captchaToken,
     }
   })
 
@@ -40,10 +43,13 @@ export const signUp = async ({ email, password, username, full_name }: SignUpDat
 }
 
 // Sign in existing user
-export const signIn = async ({ email, password }: SignInData): Promise<AuthResponse> => {
+export const signIn = async ({ email, password, captchaToken }: SignInData): Promise<AuthResponse> => {
   const { data, error } = await supabase.auth.signInWithPassword({
     email,
-    password
+    password,
+    options: {
+      captchaToken,
+    }
   })
 
   return {
@@ -81,9 +87,10 @@ export const signInWithProvider = async (
 // Reset password (used by app/auth/reset-password/page.tsx)
 // The recovery link goes through /auth/callback (PKCE code exchange) and then
 // lands on /auth/update-password, where the user actually sets the new password.
-export const resetPassword = async (email: string) => {
+export const resetPassword = async (email: string, captchaToken?: string) => {
   const { data, error } = await supabase.auth.resetPasswordForEmail(email, {
-    redirectTo: `${window.location.origin}/auth/callback?next=${encodeURIComponent('/auth/update-password')}`
+    redirectTo: `${window.location.origin}/auth/callback?next=${encodeURIComponent('/auth/update-password')}`,
+    captchaToken,
   })
 
   return { data, error }

--- a/lib/supabase/hooks.ts
+++ b/lib/supabase/hooks.ts
@@ -1,95 +1,12 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import type { User, Session } from '@supabase/supabase-js'
-import { supabase } from './client'
-import type { Profile, SavedLocation, UserPreferences } from './types'
-import { getProfile, getSavedLocations, getUserPreferences } from './database'
-
-// Hook to get current user and session
-export const useAuth = () => {
-  const [user, setUser] = useState<User | null>(null)
-  const [session, setSession] = useState<Session | null>(null)
-  const [loading, setLoading] = useState(true)
-
-  useEffect(() => {
-    // Get initial session
-    const getInitialSession = async () => {
-      const { data: { session } } = await supabase.auth.getSession()
-      setSession(session)
-      setUser(session?.user ?? null)
-      setLoading(false)
-    }
-
-    getInitialSession()
-
-    // Listen for auth changes
-    const {
-      data: { subscription },
-    } = supabase.auth.onAuthStateChange((_event, session) => {
-      setSession(session)
-      setUser(session?.user ?? null)
-      setLoading(false)
-    })
-
-    return () => subscription.unsubscribe()
-  }, [])
-
-  return {
-    user,
-    session,
-    loading,
-    isAuthenticated: !!user
-  }
-}
-
-// Hook to get user profile
-const useProfile = () => {
-  const { user, loading: authLoading } = useAuth()
-  const [profile, setProfile] = useState<Profile | null>(null)
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-
-  useEffect(() => {
-    const fetchProfile = async () => {
-      if (!user) {
-        setProfile(null)
-        setLoading(false)
-        return
-      }
-
-      try {
-        setLoading(true)
-        const profileData = await getProfile(user.id)
-        setProfile(profileData)
-        setError(null)
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to fetch profile')
-      } finally {
-        setLoading(false)
-      }
-    }
-
-    if (!authLoading) {
-      fetchProfile()
-    }
-  }, [user, authLoading])
-
-  return {
-    profile,
-    loading: loading || authLoading,
-    error,
-    refetch: () => {
-      if (user) {
-        const fetchProfile = async () => {
-          const profileData = await getProfile(user.id)
-          setProfile(profileData)
-        }
-        fetchProfile()
-      }
-    }
-  }
-}
+// Single source of truth for auth state. This module previously had its own
+// getSession()-based useAuth, which could diverge from the app-wide
+// AuthProvider — everything now reads the shared context.
+import { useAuth } from '@/lib/auth/auth-context'
+import type { SavedLocation } from './types'
+import { getSavedLocations } from './database'
 
 // Hook to get saved locations
 export const useSavedLocations = () => {
@@ -134,54 +51,6 @@ export const useSavedLocations = () => {
           setLocations(locationsData)
         }
         fetchLocations()
-      }
-    }
-  }
-}
-
-// Hook to get user preferences
-const useUserPreferences = () => {
-  const { user, loading: authLoading } = useAuth()
-  const [preferences, setPreferences] = useState<UserPreferences | null>(null)
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-
-  useEffect(() => {
-    const fetchPreferences = async () => {
-      if (!user) {
-        setPreferences(null)
-        setLoading(false)
-        return
-      }
-
-      try {
-        setLoading(true)
-        const preferencesData = await getUserPreferences(user.id)
-        setPreferences(preferencesData)
-        setError(null)
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to fetch user preferences')
-      } finally {
-        setLoading(false)
-      }
-    }
-
-    if (!authLoading) {
-      fetchPreferences()
-    }
-  }, [user, authLoading])
-
-  return {
-    preferences,
-    loading: loading || authLoading,
-    error,
-    refetch: () => {
-      if (user) {
-        const fetchPreferences = async () => {
-          const preferencesData = await getUserPreferences(user.id)
-          setPreferences(preferencesData)
-        }
-        fetchPreferences()
       }
     }
   }

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -42,7 +42,12 @@ export const getServerUser = async () => {
   const { data: { user }, error } = await supabase.auth.getUser()
 
   if (error) {
-    console.error('Error getting server user:', error)
+    // "Auth session missing" is the normal state for anonymous visitors —
+    // logging it as an error floods Vercel/Sentry (it was the top runtime
+    // error cluster in production). Only log unexpected auth failures.
+    if (error.name !== 'AuthSessionMissingError') {
+      console.error('[supabase] Error getting server user:', error)
+    }
     return null
   }
 

--- a/lib/utils/redirect-validation.ts
+++ b/lib/utils/redirect-validation.ts
@@ -18,6 +18,7 @@ const ALLOWED_REDIRECT_PATHS = [
   '/news',
   '/radar',
   '/education',
+  '/auth/update-password',
   '/',
 ] as const
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -14,8 +14,8 @@ import { resolveAuthenticatedAuthRouteRedirect } from '@/lib/auth/middleware-red
  */
 function buildCspHeader(isProd: boolean): string {
   const scriptSrc = isProd
-    ? `script-src 'self' 'unsafe-inline' https://vercel.live https://vercel.com https://va.vercel-scripts.com`
-    : `script-src 'self' 'unsafe-inline' 'unsafe-eval' https://vercel.live https://vercel.com https://va.vercel-scripts.com`
+    ? `script-src 'self' 'unsafe-inline' https://vercel.live https://vercel.com https://va.vercel-scripts.com https://challenges.cloudflare.com`
+    : `script-src 'self' 'unsafe-inline' 'unsafe-eval' https://vercel.live https://vercel.com https://va.vercel-scripts.com https://challenges.cloudflare.com`
 
   return [
     "default-src 'self'",
@@ -29,7 +29,7 @@ function buildCspHeader(isProd: boolean): string {
     // skeleton never resolves.
     "connect-src 'self' https://api.openweathermap.org https://pollen.googleapis.com https://www.google.com https://*.supabase.co https://*.sentry.io https://vitals.vercel-insights.com https://mesonet.agron.iastate.edu https://tile.openstreetmap.org https://vercel.live https://vercel.com https://ipapi.co https://ipinfo.io https://api.ipgeolocation.io",
     "worker-src 'self' blob:",
-    "frame-src 'self' https://vercel.live",
+    "frame-src 'self' https://vercel.live https://challenges.cloudflare.com",
     "object-src 'none'",
     "base-uri 'self'",
     "form-action 'self'",

--- a/middleware.ts
+++ b/middleware.ts
@@ -106,15 +106,19 @@ export async function middleware(request: NextRequest) {
   )
 
   if (isProtectedRoute && !user) {
-    const redirectUrl = new URL('/auth/login', request.url)
+    const redirectUrl = new URL('/auth', request.url)
     redirectUrl.searchParams.set('next', request.nextUrl.pathname)
     return NextResponse.redirect(redirectUrl)
   }
 
+  // Exact match for the unified /auth page; prefix match for the legacy
+  // login/signup aliases. Deliberately NOT a bare startsWith('/auth') —
+  // that would swallow /auth/callback, /auth/signout, /auth/reset-password,
+  // and /auth/update-password.
   const authRoutes = ['/auth/login', '/auth/signup']
-  const isAuthRoute = authRoutes.some((route) =>
-    request.nextUrl.pathname.startsWith(route)
-  )
+  const isAuthRoute =
+    request.nextUrl.pathname === '/auth' ||
+    authRoutes.some((route) => request.nextUrl.pathname.startsWith(route))
 
   if (isAuthRoute && user) {
     const next = resolveAuthenticatedAuthRouteRedirect(request.nextUrl.searchParams.get('next'))

--- a/middleware.ts
+++ b/middleware.ts
@@ -123,6 +123,9 @@ export async function middleware(request: NextRequest) {
     request.nextUrl.pathname === '/auth' ||
     authRoutes.some((route) => request.nextUrl.pathname.startsWith(route))
 
+  // Auth-route redirect is UX (skip login when already signed in), not an
+  // authorization gate. Destination is allowlisted via validateRedirectPath.
+  // codeql[js/user-controlled-bypass]: pathname selects auth UX routes only; redirect target is allowlisted
   if (isAuthRoute && user) {
     const next = resolveAuthenticatedAuthRouteRedirect(request.nextUrl.searchParams.get('next'))
     return NextResponse.redirect(new URL(next, request.url))

--- a/middleware.ts
+++ b/middleware.ts
@@ -56,6 +56,16 @@ export async function middleware(request: NextRequest) {
     return NextResponse.redirect(new URL('/dashboard', request.url))
   }
 
+  // API routes authenticate themselves (cookie session or Bearer token) and
+  // are never in `protectedRoutes`/`authRoutes` below. Skip the per-request
+  // `getUser()` network round-trip for them — it added latency to every
+  // public API call and logged AuthSessionMissingError noise for anonymous
+  // traffic. Session cookie refresh for browser clients still happens on
+  // page navigations, which always pass through the block below.
+  if (request.nextUrl.pathname.startsWith('/api/')) {
+    return response
+  }
+
   // TEST MODE: Skip auth checks during E2E (same rules as API routes — see lib/playwright-test-mode.ts)
 
   if (isPlaywrightTestModeRequest(request)) {

--- a/middleware.ts
+++ b/middleware.ts
@@ -100,7 +100,10 @@ export async function middleware(request: NextRequest) {
   } = await supabase.auth.getUser()
 
 
-  const protectedRoutes = ['/dashboard', '/profile', '/saved-locations']
+  // /dashboard is intentionally NOT protected: anonymous visitors get a
+  // preview state with a sign-in CTA (app/dashboard/page.tsx) instead of a
+  // redirect. Authenticated-only data stays safe behind RLS + API auth.
+  const protectedRoutes = ['/profile', '/saved-locations']
   const isProtectedRoute = protectedRoutes.some((route) =>
     request.nextUrl.pathname.startsWith(route)
   )

--- a/planning/auth-security-improvement-plan.md
+++ b/planning/auth-security-improvement-plan.md
@@ -83,15 +83,16 @@ GitHub OAuth has zero sign-ups in your data. Fold it under "More options" or rem
 4. Thread `next` end-to-end: login page → `AuthForm` → email sign-in redirect + `signInWithProvider({ redirectTo })`; make `ProtectedRoute` preserve the attempted path (F6).
 5. Origin check on `/auth/signout` (F8). De-duplicate headers in `vercel.json` (F9).
 
-### Phase 2 — Auth UX overhaul (one PR, ~1-2 days)
+### Phase 2 — Auth UX overhaul (shipped on `auth/security-and-ux-overhaul`)
 1. **Reorder the form:** Google button alone above the fold; "Continue with email" (magic link via `signInWithOtp`) below; password + GitHub under "More options."
-2. **Unify `/auth`** — login/signup already share `AuthForm` via a `mode` prop; collapse to one route.
+2. **Unify `/auth`** — login/signup redirect to one route.
 3. **Consolidate `useAuth`** on `lib/auth/auth-context.tsx`; retire the `lib/supabase/hooks.ts` variant (F7).
+4. **Slim password signup** — email + password only; username/full name stay on `/profile`.
 
-### Phase 3 — Conversion features (after Phase 2)
-1. Add "Save to dashboard" buttons on public weather pages (none exist today — the auth-gate modal from the earlier plan has nothing to gate until this ships).
-2. Auth-gate modal using the consolidated `useAuth` + `next` plumbing.
-3. Dashboard preview for logged-out users (requires relaxing both `middleware.ts` protectedRoutes and `<ProtectedRoute>`).
+### Phase 3 — Conversion features (shipped on `auth/security-and-ux-overhaul`)
+1. "Save to dashboard" on public weather pages.
+2. Auth-gate modal using consolidated `useAuth` + `next` plumbing.
+3. Dashboard preview for logged-out users (middleware + `<ProtectedRoute>` relaxed).
 
 ### Phase 4 — Later / watchlist
 - Passkeys when Supabase support goes GA.

--- a/planning/auth-security-improvement-plan.md
+++ b/planning/auth-security-improvement-plan.md
@@ -1,0 +1,118 @@
+# Auth Workflow & Security Posture — Audit and Improvement Plan
+
+**Date:** 2026-07-08
+**Scope:** Full review of authentication workflow (code), Supabase project security (advisors, RLS, auth config, live user data), and Vercel production posture (runtime errors, headers).
+**Verdict:** Security fundamentals are strong. The gaps are bot/abuse protection, password policy enforcement, a broken password-recovery flow, and auth UX friction. A plan is warranted — prioritized below.
+
+---
+
+## 1. Recommended auth method (the direct answer)
+
+For a consumer app like 16-Bit Weather, the optimal stack in 2026 is:
+
+1. **Google OAuth as the primary, above-the-fold method.** Your live data confirms it: 6 of 8 users (75%) signed up with Google, and all 3 users active in the last 30 days are Google users. OAuth is both the most user-friendly (one click, no password) and the most secure option you offer (no credential to phish or stuff; Google enforces its own MFA).
+2. **Magic link (email OTP) as the fallback**, replacing the password form as the default email path. Passwordless removes your two biggest email-auth problems at once: weak passwords (your only guard is a client-side `minLength=6`) and confirmation-flow drop-off (1 of your 2 email users never confirmed — a 50% loss on that path). Supabase supports this natively via `signInWithOtp`; magic links and 6-digit OTP codes share one implementation.
+3. **Keep password sign-in available but demoted** ("More options") for existing password users; don't force-migrate.
+4. **Passkeys (WebAuthn): adopt later, not now.** Supabase passkey support exists but is **experimental** (opt-in, API may change). Right long-term destination — phishing-resistant, no shared secret — wrong quarter for a solo project. Revisit when Supabase marks it GA.
+
+GitHub OAuth has zero sign-ups in your data. Fold it under "More options" or remove it.
+
+---
+
+## 2. What is already GOOD (verified — do not re-fix)
+
+- **Middleware uses `supabase.auth.getUser()`** (server-verified), not `getSession()` — correct trust boundary (`middleware.ts:88-90`), with correct SSR cookie-refresh pattern.
+- **Redirect validation is sound.** `lib/utils/redirect-validation.ts` blocks `//`, schemes, backslashes, and percent-encoding bypasses via a strict allowlist. No open redirect found, including in the OAuth callback (PKCE, sanitized error logging, 303 redirects).
+- **RLS posture is solid.** `profiles`, `saved_locations`, `user_preferences`, `alert_subscriptions`, `user_alerts` all have owner-scoped policies on `auth.uid()`. The `weather_cache` `USING(true)` policy was removed; `handle_new_user()` is `SECURITY DEFINER` with pinned `search_path` and revoked from anon/authenticated.
+- **No IDOR.** `api/user/preferences`, `api/user/alerts`, `api/locations` all derive the user id from a verified session, never from client input; Zod strips client-sent `user_id`.
+- **Service-role key confined to server-only modules**; cron and webhook endpoints use constant-time secret comparison; Playwright bypass is disabled in production.
+- **Secrets hygiene clean.** No hardcoded keys; `NEXT_PUBLIC_*` limited to safe values; gitleaks hooks in place.
+- **Headers:** HSTS with preload, nosniff, X-Frame-Options, Referrer-Policy, Permissions-Policy; per-request CSP in middleware.
+
+---
+
+## 3. Findings (prioritized)
+
+### HIGH-leverage, low-effort
+
+**F1. No bot/abuse protection on auth (MED severity).** Sign-in/sign-up/reset call `supabase.auth.*` directly from the browser — there is no server route to throttle, no CAPTCHA anywhere. Your in-house rate limiter covers only weather/user APIs, is in-memory (doesn't hold across Vercel serverless instances), and fails open. Credential stuffing and signup abuse are currently held off only by Supabase's default limits.
+→ Enable **CAPTCHA (Cloudflare Turnstile)** in Supabase Dashboard: Settings → Authentication → Bot and Abuse Protection. Turnstile is free and privacy-friendly. Add the widget token to `AuthForm` (`options.captchaToken`).
+
+**F2. Leaked-password protection disabled (Supabase advisor: WARN).** HaveIBeenPwned checking is off; password min length is effectively 6, enforced client-side only (`components/auth/auth-form.tsx:228`) and trivially bypassed.
+→ Dashboard: enable leaked-password protection; raise minimum length to 10+ with character requirements. Zero code.
+
+**F3. Postgres has outstanding security patches (Supabase advisor: WARN).** Running `supabase-postgres-17.4.1.075`.
+→ Dashboard: upgrade database. Zero code. ([remediation](https://supabase.com/docs/guides/platform/upgrading))
+
+**F4. Production error noise: `AuthSessionMissingError` — 443 occurrences / 250 users (top runtime error).** `getServerUser` logs every anonymous visitor as a `console.error` (`lib/supabase/server.ts:45`), polluting Vercel logs and Sentry across 9 routes + middleware. An anonymous session is not an error.
+→ Filter `AuthSessionMissingError` before logging. Also consider skipping the `getUser()` round-trip in middleware for public `/api/*` routes (perf).
+
+**F5. Password-recovery flow appears broken (functional).** `resetPassword` redirects the recovery link back to `/auth/reset-password`, but that page only renders the "request email" form — there's no step to consume the recovery token and set a new password.
+→ Add an update-password handler/page. Test end-to-end.
+
+### MEDIUM
+
+**F6. `next` redirect param is dropped by the form.** Middleware sets `?next=` and the OAuth callback honors it, but `AuthForm` hardcodes `/dashboard?welcome=1` for email sign-in, never passes `redirectTo` to `signInWithProvider`, and `ProtectedRoute` redirects to bare `/auth/login`. Users never return to where they were.
+
+**F7. Two competing `useAuth` implementations.** `lib/auth/auth-context.tsx` (full) vs `lib/supabase/hooks.ts` (session-only, used by `useSavedLocations`). Risk of divergent auth state; consolidate on the context before building modal UX on top.
+
+**F8. Logout CSRF (LOW).** `/auth/signout` is a cookie-authenticated POST with no origin check. Impact limited to forced logout. → Add an Origin/Referer check.
+
+**F9. Header config drift (LOW).** `vercel.json` re-declares some headers but omits HSTS/CSP — two sources of truth. → Remove header duplication from `vercel.json`; keep `next.config.mjs` + middleware CSP canonical.
+
+**F10. CSP allows `'unsafe-inline'` scripts (documented accepted risk).** Required for SSG hydration without nonces. Acceptable while the no-untrusted-HTML invariant holds; revisit if you ever render user-generated HTML.
+
+### INFO (intentional, leave alone)
+
+- `aeroapi_usage` and `alert_monitor_state` have RLS enabled with no policies — deny-all by design (service-role/cron writes only). Advisor flags are expected. ([lint reference](https://supabase.com/docs/guides/database/database-linter?lint=0008_rls_enabled_no_policy))
+
+---
+
+## 4. Improvement plan
+
+### Phase 0 — Dashboard-only, do today (no code, ~15 min)
+1. Enable leaked-password protection (F2).
+2. Set password min length ≥ 10 (F2).
+3. Enable Turnstile CAPTCHA in Supabase (F1) — code hookup lands in Phase 1.
+4. Schedule the Postgres upgrade (F3).
+
+### Phase 1 — Security & correctness fixes (one PR, ~half day)
+1. Wire Turnstile token into `AuthForm` (`captchaToken` on signUp/signIn/reset) (F1).
+2. Stop logging `AuthSessionMissingError` as an error; skip middleware `getUser()` for public API routes (F4).
+3. Fix the password-recovery completion flow (F5).
+4. Thread `next` end-to-end: login page → `AuthForm` → email sign-in redirect + `signInWithProvider({ redirectTo })`; make `ProtectedRoute` preserve the attempted path (F6).
+5. Origin check on `/auth/signout` (F8). De-duplicate headers in `vercel.json` (F9).
+
+### Phase 2 — Auth UX overhaul (one PR, ~1-2 days)
+1. **Reorder the form:** Google button alone above the fold; "Continue with email" (magic link via `signInWithOtp`) below; password + GitHub under "More options."
+2. **Unify `/auth`** — login/signup already share `AuthForm` via a `mode` prop; collapse to one route.
+3. **Consolidate `useAuth`** on `lib/auth/auth-context.tsx`; retire the `lib/supabase/hooks.ts` variant (F7).
+
+### Phase 3 — Conversion features (after Phase 2)
+1. Add "Save to dashboard" buttons on public weather pages (none exist today — the auth-gate modal from the earlier plan has nothing to gate until this ships).
+2. Auth-gate modal using the consolidated `useAuth` + `next` plumbing.
+3. Dashboard preview for logged-out users (requires relaxing both `middleware.ts` protectedRoutes and `<ProtectedRoute>`).
+
+### Phase 4 — Later / watchlist
+- Passkeys when Supabase support goes GA.
+- Move the in-house rate limiter to a shared store (Upstash Redis / Vercel KV) — matters more as traffic grows.
+- Optional MFA (TOTP) for accounts — low priority for a weather app.
+
+---
+
+## 5. Success metrics (solo-friendly)
+
+- % OAuth vs magic link vs password (query `auth.users.raw_app_meta_data->>'provider'` — baseline today: google 6, email 2).
+- Email-path completion rate (baseline: 50% — 1 of 2 email users unconfirmed).
+- `AuthSessionMissingError` count in Vercel runtime errors → should drop to ~0 after Phase 1 (baseline: 443).
+- Supabase security advisors → 2 WARNs today, target 0 (INFO lints excepted).
+- After Phase 3: logged-out save attempts → completed sign-ins.
+
+## 6. References
+
+- [Supabase: Enable CAPTCHA protection](https://supabase.com/docs/guides/auth/auth-captcha)
+- [Supabase: Passwordless email logins (magic link / OTP)](https://supabase.com/docs/guides/auth/auth-email-passwordless)
+- [Supabase: `signInWithOtp`](https://supabase.com/docs/reference/javascript/auth-signinwithotp)
+- [Supabase: Passkey authentication (experimental)](https://supabase.com/docs/guides/auth/passkeys)
+- [Supabase: Password strength & leaked-password protection](https://supabase.com/docs/guides/auth/password-security#password-strength-and-leaked-password-protection)
+- [Supabase: Upgrading Postgres](https://supabase.com/docs/guides/platform/upgrading)

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -20,8 +20,10 @@ test.describe('Auth flow', () => {
   test('legacy signup route redirects and password form is reachable via more options', async ({ page }) => {
     await page.goto('/auth/signup', { waitUntil: 'domcontentloaded' });
     await expect(page).toHaveURL(/\/auth\?mode=signup/, { timeout: 15000 });
-    await page.getByTestId('auth-more-options-toggle').click();
-    await expect(page.getByRole('button', { name: /^sign up$/i })).toBeVisible({ timeout: 15000 });
+    // ?mode=signup opens the password form so Sign Up is immediately available
+    await expect(page.getByTestId('password-form')).toBeVisible({ timeout: 15000 });
+    await expect(page.getByRole('button', { name: /^sign up$/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /continue with github/i })).toBeVisible();
   });
 
   test('auth page displays OAuth callback errors from query string', async ({ page }) => {

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -10,18 +10,21 @@ test.describe('Auth flow', () => {
     await setupStableApp(page);
   });
 
-  test('login page loads and shows sign-in form', async ({ page }) => {
+  test('legacy login route redirects to unified auth page with Google and magic link', async ({ page }) => {
     await page.goto('/auth/login', { waitUntil: 'domcontentloaded' });
-    await expect(page.getByRole('button', { name: /sign in/i }).first()).toBeVisible({ timeout: 15000 });
-    await expect(page.getByText(/continue with google/i)).toBeVisible();
+    await expect(page).toHaveURL(/\/auth(\?|$)/, { timeout: 15000 });
+    await expect(page.getByText(/continue with google/i)).toBeVisible({ timeout: 15000 });
+    await expect(page.getByTestId('magic-link-submit')).toBeVisible();
   });
 
-  test('signup page loads', async ({ page }) => {
+  test('legacy signup route redirects and password form is reachable via more options', async ({ page }) => {
     await page.goto('/auth/signup', { waitUntil: 'domcontentloaded' });
-    await expect(page.getByRole('button', { name: /sign up/i }).first()).toBeVisible({ timeout: 15000 });
+    await expect(page).toHaveURL(/\/auth\?mode=signup/, { timeout: 15000 });
+    await page.getByTestId('auth-more-options-toggle').click();
+    await expect(page.getByRole('button', { name: /^sign up$/i })).toBeVisible({ timeout: 15000 });
   });
 
-  test('login page displays OAuth callback errors from query string', async ({ page }) => {
+  test('auth page displays OAuth callback errors from query string', async ({ page }) => {
     await page.goto('/auth/login?error=access_denied', { waitUntil: 'domcontentloaded' });
     await expect(page.getByTestId('auth-error-alert')).toBeVisible({ timeout: 15000 });
     await expect(page.getByTestId('auth-error-alert')).toContainText(/access_denied/i);

--- a/tests/e2e/weather-app.spec.ts
+++ b/tests/e2e/weather-app.spec.ts
@@ -1,8 +1,9 @@
 import { test, expect } from './fixtures';
-import { stubWeatherApis } from '../fixtures/utils';
+import { stubHomeHubApis, stubWeatherApis } from '../fixtures/utils';
 
 test.beforeEach(async ({ page }) => {
   await stubWeatherApis(page);
+  await stubHomeHubApis(page);
   await page.goto('/');
 
   // Force a deterministic baseline: seeded cache + no rate limit.

--- a/tests/fixtures/utils.ts
+++ b/tests/fixtures/utils.ts
@@ -720,92 +720,8 @@ const transparentPng = Buffer.from(
   'base64'
 );
 
-export async function stubRadarApis(page: Page): Promise<void> {
-  const metadataFrames = Array.from({ length: 13 }, (_, index) => {
-    const epochSeconds = 1718841600 - (12 - index) * 600
-    return {
-      timestamp: epochSeconds * 1000,
-      isoTime: new Date(epochSeconds * 1000).toISOString(),
-      epochSeconds,
-      offsetMinutes: index === 12 ? 0 : -((12 - index) * 10),
-      isLive: index === 12,
-      tilePath: `/v2/radar/${epochSeconds}`,
-    }
-  })
-
-  await page.route('**/api/radar/metadata**', (route) => route.fulfill({
-    status: 200,
-    contentType: 'application/json',
-    body: JSON.stringify({
-      location: { lat: 40.7128, lon: -74.006 },
-      generatedAt: new Date(1718841600 * 1000).toISOString(),
-      selectedProvider: {
-        id: 'rainviewer',
-        displayName: 'RainViewer Radar',
-        shortName: 'RainViewer',
-        coverage: 'global',
-        protocol: 'xyz',
-        attribution: 'RainViewer',
-        refreshIntervalSeconds: 300,
-        frameStepMinutes: 10,
-        pastMinutes: 120,
-        supportsAnimation: true,
-        qualityTier: 'community',
-        notes: [],
-      },
-      frames: metadataFrames,
-      refreshIntervalSeconds: 300,
-      legend: [],
-      selectionReason: 'RainViewer global composite selected for test coverage region.',
-      coverageRegion: 'us',
-      rainviewer: {
-        host: 'https://tilecache.rainviewer.com',
-        generated: 1718841600,
-        version: '2.0',
-        colorScheme: 6,
-        smooth: true,
-        snow: true,
-        tileSize: 512,
-      },
-    }),
-  }))
-
-  await page.route('**/api/radar/tile/**', (route) => route.fulfill({
-    status: 200,
-    contentType: 'image/png',
-    body: transparentPng,
-  }));
-
-  await page.route('**/api/weather/noaa-wms**', (route) => route.fulfill({
-    status: 200,
-    contentType: 'image/png',
-    body: transparentPng,
-  }));
-
-  await page.route('**/mesonet.agron.iastate.edu/cgi-bin/wms/nexrad/**', (route) => route.fulfill({
-    status: 200,
-    contentType: 'image/png',
-    body: transparentPng,
-  }));
-
-  await page.route('**/geo.weather.gc.ca/geomet/**', (route) => route.fulfill({
-    status: 200,
-    contentType: 'image/png',
-    body: transparentPng,
-  }));
-
-  await page.route('**/tilecache.rainviewer.com/**', (route) => route.fulfill({
-    status: 200,
-    contentType: 'image/png',
-    body: transparentPng,
-  }));
-
-  await page.route('**/basemaps.cartocdn.com/**', (route) => route.fulfill({
-    status: 200,
-    contentType: 'image/png',
-    body: transparentPng,
-  }));
-
+/** Deterministic stubs for the home hub discovery row (alerts, SPC, news, stargazer). */
+export async function stubHomeHubApis(page: Page): Promise<void> {
   await page.route('**/api/weather/alerts**', (route) => {
     const url = new URL(route.request().url());
     if (url.searchParams.get('detail') === '1') {
@@ -914,6 +830,7 @@ export async function stubRadarApis(page: Page): Promise<void> {
         source: 'USGS',
         category: 'earthquakes',
         priority: 'high',
+        magnitude: 6.2,
         timestamp: new Date().toISOString(),
       }],
       featured: null,
@@ -928,6 +845,95 @@ export async function stubRadarApis(page: Page): Promise<void> {
     contentType: 'application/json',
     body: JSON.stringify(stargazerE2eFixture()),
   }));
+}
+
+export async function stubRadarApis(page: Page): Promise<void> {
+  const metadataFrames = Array.from({ length: 13 }, (_, index) => {
+    const epochSeconds = 1718841600 - (12 - index) * 600
+    return {
+      timestamp: epochSeconds * 1000,
+      isoTime: new Date(epochSeconds * 1000).toISOString(),
+      epochSeconds,
+      offsetMinutes: index === 12 ? 0 : -((12 - index) * 10),
+      isLive: index === 12,
+      tilePath: `/v2/radar/${epochSeconds}`,
+    }
+  })
+
+  await page.route('**/api/radar/metadata**', (route) => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({
+      location: { lat: 40.7128, lon: -74.006 },
+      generatedAt: new Date(1718841600 * 1000).toISOString(),
+      selectedProvider: {
+        id: 'rainviewer',
+        displayName: 'RainViewer Radar',
+        shortName: 'RainViewer',
+        coverage: 'global',
+        protocol: 'xyz',
+        attribution: 'RainViewer',
+        refreshIntervalSeconds: 300,
+        frameStepMinutes: 10,
+        pastMinutes: 120,
+        supportsAnimation: true,
+        qualityTier: 'community',
+        notes: [],
+      },
+      frames: metadataFrames,
+      refreshIntervalSeconds: 300,
+      legend: [],
+      selectionReason: 'RainViewer global composite selected for test coverage region.',
+      coverageRegion: 'us',
+      rainviewer: {
+        host: 'https://tilecache.rainviewer.com',
+        generated: 1718841600,
+        version: '2.0',
+        colorScheme: 6,
+        smooth: true,
+        snow: true,
+        tileSize: 512,
+      },
+    }),
+  }))
+
+  await page.route('**/api/radar/tile/**', (route) => route.fulfill({
+    status: 200,
+    contentType: 'image/png',
+    body: transparentPng,
+  }));
+
+  await page.route('**/api/weather/noaa-wms**', (route) => route.fulfill({
+    status: 200,
+    contentType: 'image/png',
+    body: transparentPng,
+  }));
+
+  await page.route('**/mesonet.agron.iastate.edu/cgi-bin/wms/nexrad/**', (route) => route.fulfill({
+    status: 200,
+    contentType: 'image/png',
+    body: transparentPng,
+  }));
+
+  await page.route('**/geo.weather.gc.ca/geomet/**', (route) => route.fulfill({
+    status: 200,
+    contentType: 'image/png',
+    body: transparentPng,
+  }));
+
+  await page.route('**/tilecache.rainviewer.com/**', (route) => route.fulfill({
+    status: 200,
+    contentType: 'image/png',
+    body: transparentPng,
+  }));
+
+  await page.route('**/basemaps.cartocdn.com/**', (route) => route.fulfill({
+    status: 200,
+    contentType: 'image/png',
+    body: transparentPng,
+  }));
+
+  await stubHomeHubApis(page);
 
   await page.route('**/api/weather/storm-reports**', (route) => route.fulfill({
     status: 200,

--- a/vercel.json
+++ b/vercel.json
@@ -1,36 +1,4 @@
 {
-  "headers": [
-    {
-      "source": "/(.*)",
-      "headers": [
-        {
-          "key": "X-DNS-Prefetch-Control",
-          "value": "on"
-        },
-        {
-          "key": "X-Content-Type-Options",
-          "value": "nosniff"
-        },
-        {
-          "key": "X-Frame-Options",
-          "value": "SAMEORIGIN"
-        },
-        {
-          "key": "Referrer-Policy",
-          "value": "strict-origin-when-cross-origin"
-        }
-      ]
-    },
-    {
-      "source": "/static/(.*)",
-      "headers": [
-        {
-          "key": "Cache-Control",
-          "value": "public, max-age=31536000, immutable"
-        }
-      ]
-    }
-  ],
   "rewrites": [
     {
       "source": "/sitemap.xml",


### PR DESCRIPTION
## Summary
- Harden auth: Turnstile (env-gated), password recovery completion, signout CSRF origin check, quieter anonymous session logging, header de-dupe
- Unify `/auth` with Google-first layout, magic-link email default, password + GitHub under More options; slim password signup (no username/full name)
- Conversion UX: auth-gate modal, save-to-dashboard on city pages, logged-out dashboard preview, `?next=` honored end-to-end
- Consolidate on a single `useAuth` AuthProvider; update auth/home-hub E2E stubs

## Test plan
- [x] `npm test -- --testPathPatterns=auth-form`
- [x] `npm run typecheck`
- [x] Playwright: `tests/e2e/auth.spec.ts` + `tests/e2e/weather-app.spec.ts` (chromium)
- [ ] CI: Build, E2E Chromium, Lighthouse
- [ ] After merge: confirm Supabase Phase 0 (leaked-password protection, min length ≥ 10, Turnstile keys in Vercel)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified sign-in experience on a single auth page (magic links, password options, Google/GitHub).
  * Added CAPTCHA support for auth and password reset, plus a modal-based “sign in to continue” flow.
  * Enabled “Save location” on public weather pages with sign-in gating and redirect back to the dashboard.

* **Bug Fixes**
  * Corrected auth redirect targets and preserved intended destinations.
  * Strengthened sign-out request protection and refined auth gating (dashboard and API behavior).

* **Tests**
  * Expanded auth flow/e2e coverage for the updated unified redirects and magic link flow.

* **Documentation**
  * Updated environment example with Turnstile configuration guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->