### PR TITLE
Improve SEO for space weather, city climate, and crawl metadata

### DIFF
--- a/__tests__/city-page-seo.test.ts
+++ b/__tests__/city-page-seo.test.ts
@@ -28,7 +28,7 @@ describe('city-page-seo', () => {
     expect(JSON.stringify(metadata.openGraph?.images)).toContain('/api/og?')
     expect(metadata.keywords).toContain('Boston climate')
     expect(metadata.keywords).toContain('climate in Boston')
-    expect(metadata.description).toContain('nor')
+    expect(metadata.description).toContain("nor'easter")
   })
 
   it('lists ten priority city slugs from GSC traffic', () => {

--- a/__tests__/city-page-seo.test.ts
+++ b/__tests__/city-page-seo.test.ts
@@ -16,9 +16,9 @@ describe('city-page-seo', () => {
   })
 
   it('includes climate and year-round language in descriptions', () => {
-    const description = buildCityPageDescription(boston)
-    expect(description).toContain('climate averages')
-    expect(description).toContain('monthly weather')
+    const description = buildCityPageDescription(boston, 'boston-ma')
+    expect(description).toContain('Boston MA climate')
+    expect(description).toContain('year-round')
     expect(description).toContain('best time to visit')
   })
 
@@ -27,6 +27,8 @@ describe('city-page-seo', () => {
     expect(metadata.alternates?.canonical).toBe('https://www.16bitweather.co/weather/boston-ma')
     expect(JSON.stringify(metadata.openGraph?.images)).toContain('/api/og?')
     expect(metadata.keywords).toContain('Boston climate')
+    expect(metadata.keywords).toContain('climate in Boston')
+    expect(metadata.description).toContain('nor')
   })
 
   it('lists ten priority city slugs from GSC traffic', () => {

--- a/__tests__/newsletter/publish-slug.test.ts
+++ b/__tests__/newsletter/publish-slug.test.ts
@@ -35,6 +35,21 @@ describe('newsletter publish slug/title SEO', () => {
     expect(header.title.length).toBeLessThanOrEqual(70)
   })
 
+  it('falls back to topic title when Wednesday theme is empty', () => {
+    const input: PublishWednesdayInput = {
+      ...baseWednesday,
+      topicSlug: 'volcanoes',
+      topicTitle: 'Volcanoes & Atmospheric Impact',
+      theme: '',
+    }
+
+    const header = buildPublishHeaderForTest(input, '2026-06-06')
+
+    expect(header.slug).toBe('volcanoes-2026-06-06')
+    expect(header.title).toBe('Volcanoes & Atmospheric Impact')
+    expect(header.summary).toBe('Volcanoes & Atmospheric Impact')
+  })
+
   it('dates Sunday weekly titles for clearer SERP snippets', () => {
     const input: PublishSundayInput = {
       cadence: 'sunday_rearview',

--- a/__tests__/newsletter/publish-slug.test.ts
+++ b/__tests__/newsletter/publish-slug.test.ts
@@ -1,0 +1,60 @@
+import { buildPublishHeaderForTest } from '@/scripts/newsletter/publish'
+import type { PublishSundayInput, PublishWednesdayInput } from '@/scripts/newsletter/publish'
+
+const baseWednesday: Omit<PublishWednesdayInput, 'theme' | 'topicSlug' | 'topicTitle'> = {
+  cadence: 'wednesday_topic',
+  body: 'Body',
+  openerHash: 'abc',
+  keyPhrases: [],
+  similarityMax: 0,
+  similarityJudge: 'test',
+  modelUsed: 'test',
+  images: [],
+  spotlight: null,
+  retries: 0,
+  wordCount: 100,
+  closerUsed: 'test',
+}
+
+describe('newsletter publish slug/title SEO', () => {
+  it('uses topic-slug + date for Wednesday posts instead of first-sentence prose', () => {
+    const input: PublishWednesdayInput = {
+      ...baseWednesday,
+      topicSlug: 'ocean_currents',
+      topicTitle: 'Ocean Currents & Heat Transport',
+      theme:
+        'Bergen, Norway sits at 60.4 N — roughly the same latitude as Anchorage — yet its winters stay mild because of the Gulf Stream.',
+    }
+
+    const header = buildPublishHeaderForTest(input, '2026-06-06')
+
+    expect(header.slug).toBe('ocean-currents-2026-06-06')
+    expect(header.slug).not.toContain('bergen')
+    expect(header.slug.length).toBeLessThanOrEqual(40)
+    expect(header.title.startsWith('Ocean Currents')).toBe(true)
+    expect(header.title.length).toBeLessThanOrEqual(70)
+  })
+
+  it('dates Sunday weekly titles for clearer SERP snippets', () => {
+    const input: PublishSundayInput = {
+      cadence: 'sunday_rearview',
+      body: 'Body',
+      openerHash: 'abc',
+      keyPhrases: [],
+      similarityMax: 0,
+      similarityJudge: 'test',
+      modelUsed: 'test',
+      images: [],
+      spotlight: null,
+      retries: 0,
+      wordCount: 100,
+      closerUsed: 'test',
+    }
+
+    const header = buildPublishHeaderForTest(input, '2026-06-14')
+
+    expect(header.slug).toBe('this-week-in-weather-2026-06-14')
+    expect(header.title).toBe('This Week in Weather — June 14, 2026')
+    expect(header.summary).toContain('June 14, 2026')
+  })
+})

--- a/__tests__/space-weather-seo.test.ts
+++ b/__tests__/space-weather-seo.test.ts
@@ -1,0 +1,57 @@
+/**
+ * SEO tests for space-weather page crawlable content.
+ */
+
+import fs from 'fs'
+import path from 'path'
+import {
+  buildSpaceWeatherAppJsonLd,
+  buildSpaceWeatherFaqJsonLd,
+  SPACE_WEATHER_FAQS,
+} from '@/components/space-weather/space-weather-seo-content'
+
+describe('Space Weather SEO', () => {
+  it('space-weather page should be a server component with crawlable SEO content', () => {
+    const pagePath = path.join(process.cwd(), 'app', 'space-weather', 'page.tsx')
+    const content = fs.readFileSync(pagePath, 'utf-8')
+
+    expect(content).not.toContain("'use client'")
+    expect(content).toContain('SpaceWeatherSeoContent')
+    expect(content).toContain('buildSpaceWeatherFaqJsonLd')
+    expect(content).toContain('SpaceWeatherClient')
+  })
+
+  it('space-weather SEO content targets monitor/tracker queries', () => {
+    const seoPath = path.join(
+      process.cwd(),
+      'components',
+      'space-weather',
+      'space-weather-seo-content.tsx',
+    )
+    const content = fs.readFileSync(seoPath, 'utf-8')
+
+    expect(content).toContain('Solar Flare Monitor')
+    expect(content).toContain('href="/stargazer"')
+    expect(content).toContain('href="/blog"')
+    expect(content).toContain('SPACE_WEATHER_FAQS')
+  })
+
+  it('builds FAQ and WebApplication JSON-LD', () => {
+    const faq = buildSpaceWeatherFaqJsonLd()
+    expect(faq['@type']).toBe('FAQPage')
+    expect(faq.mainEntity).toHaveLength(SPACE_WEATHER_FAQS.length)
+
+    const app = buildSpaceWeatherAppJsonLd()
+    expect(app['@type']).toBe('WebApplication')
+    expect(app.url).toBe('https://www.16bitweather.co/space-weather')
+  })
+
+  it('layout metadata includes high-intent keywords', () => {
+    const layoutPath = path.join(process.cwd(), 'app', 'space-weather', 'layout.tsx')
+    const content = fs.readFileSync(layoutPath, 'utf-8')
+
+    expect(content).toContain('solar flare monitor')
+    expect(content).toContain('space weather tracker')
+    expect(content).toContain('Kp index live')
+  })
+})

--- a/app/aviation/layout.tsx
+++ b/app/aviation/layout.tsx
@@ -1,11 +1,13 @@
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
-  title: 'Aviation Weather - SIGMETs & Flight Conditions | 16 Bit Weather',
-  description: 'Aviation weather with SIGMETs, AIRMETs, turbulence maps, and real-time flight conditions. Terminal-style weather briefing for pilots.',
-  keywords: 'aviation weather, SIGMET, AIRMET, turbulence, flight conditions, pilot weather, aviation alerts',
+  title: 'Aviation Weather SIGMETs, Turbulence & Flight Conditions | 16 Bit Weather',
+  description:
+    'Aviation weather briefing with SIGMETs, AIRMETs, turbulence maps, and real-time flight conditions. Educational terminal-style weather for pilots and enthusiasts.',
+  keywords:
+    'aviation weather, aviation weather SIGMET, SIGMET, AIRMET, turbulence, flight conditions, pilot weather, aviation alerts',
   openGraph: {
-    title: 'Aviation Weather',
+    title: 'Aviation Weather — SIGMETs & Flight Conditions',
     description: 'SIGMETs, turbulence maps, and real-time flight conditions.',
     url: 'https://www.16bitweather.co/aviation',
     siteName: '16 Bit Weather',
@@ -15,7 +17,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Aviation Weather',
+    title: 'Aviation Weather — SIGMETs & Flight Conditions',
     description: 'SIGMETs, turbulence maps, and real-time flight conditions.',
     images: ['/api/og?title=Aviation+Weather&subtitle=SIGMETs+%2B+Flight+Conditions'],
   },

--- a/app/education/glossary/layout.tsx
+++ b/app/education/glossary/layout.tsx
@@ -9,20 +9,20 @@ import FeaturedCityLinks from '@/components/featured-city-links'
 const GLOSSARY_URL = 'https://www.16bitweather.co/education/glossary'
 
 export const metadata: Metadata = {
-  title: 'Weather Glossary - Metric Definitions | 16 Bit Weather',
+  title: 'Weather Glossary: UV Index, Humidity, Pressure & More Explained | 16 Bit Weather',
   description:
-    'Understand every weather metric: UV Index, humidity, barometric pressure, wind, visibility, feels like temperature, precipitation, pollen, and more. In-depth definitions with practical tips.',
+    'Clear definitions of weather metrics — UV Index, humidity, barometric pressure, wind, visibility, feels-like temperature, precipitation, and pollen — with practical tips for reading a forecast.',
   keywords:
-    'weather glossary, UV index explained, humidity definition, barometric pressure meaning, wind speed, visibility weather, feels like temperature, precipitation measurement, pollen count, weather terms, meteorology glossary',
+    'weather glossary, weather terms explained, UV index explained, humidity definition, barometric pressure meaning, wind speed, visibility weather, feels like temperature, precipitation measurement, pollen count, meteorology glossary',
   openGraph: {
-    title: 'Weather Glossary - 16 Bit Weather',
+    title: 'Weather Glossary — Metrics Explained | 16 Bit Weather',
     description:
-      'In-depth definitions of every weather metric. UV Index, humidity, pressure, wind, and more explained with practical tips.',
+      'UV Index, humidity, pressure, wind, and more — weather metric definitions with practical tips.',
     url: GLOSSARY_URL,
     siteName: '16 Bit Weather',
     images: [
       {
-        url: '/api/og?title=Weather+Glossary&subtitle=Metric+Definitions',
+        url: '/api/og?title=Weather+Glossary&subtitle=UV%2C+Humidity%2C+Pressure+%26+More',
         width: 1200,
         height: 630,
         alt: 'Weather Glossary - 16 Bit Weather',
@@ -33,9 +33,9 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Weather Glossary - 16 Bit Weather',
-    description: 'In-depth definitions of every weather metric with practical tips',
-    images: ['/api/og?title=Weather+Glossary&subtitle=Metric+Definitions'],
+    title: 'Weather Glossary — Metrics Explained | 16 Bit Weather',
+    description: 'UV Index, humidity, pressure, wind, and more explained with practical tips',
+    images: ['/api/og?title=Weather+Glossary&subtitle=UV%2C+Humidity%2C+Pressure+%26+More'],
   },
   alternates: {
     canonical: GLOSSARY_URL,
@@ -82,9 +82,10 @@ const glossarySchema = {
     },
     {
       '@type': 'WebPage',
-      name: 'Weather Glossary - Metric Definitions',
+      name: 'Weather Glossary: UV Index, Humidity, Pressure & More Explained',
       url: GLOSSARY_URL,
-      description: 'In-depth definitions of weather metrics with practical tips',
+      description:
+        'Clear definitions of weather metrics with practical tips for reading a forecast',
       isPartOf: { '@id': 'https://www.16bitweather.co/#website' },
       about: { '@type': 'DefinedTermSet', url: GLOSSARY_URL },
     },

--- a/app/space-weather/layout.tsx
+++ b/app/space-weather/layout.tsx
@@ -1,23 +1,34 @@
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
-  title: 'Space Weather Monitor - Solar Activity & Aurora | 16 Bit Weather',
-  description: 'Real-time space weather monitoring. Track solar activity, Kp index, aurora forecast, solar wind conditions, and geomagnetic storm alerts.',
-  keywords: 'space weather, solar activity, aurora forecast, Kp index, solar wind, geomagnetic storm, solar flares',
+  title: 'Space Weather Monitor — Solar Flare Tracker & Live Kp Index | 16 Bit Weather',
+  description:
+    'Free space weather monitor and solar flare tracker. Live Kp index, solar wind, geomagnetic storm alerts, sunspots, X-ray flux, and aurora forecast from NOAA SWPC.',
+  keywords:
+    'space weather monitor, solar flare monitor, space weather tracker, solar flare tracker, Kp index live, solar activity today, solar wind, geomagnetic storm tracker, aurora forecast, solar storm monitor',
   openGraph: {
-    title: 'Space Weather Monitor',
-    description: 'Real-time solar activity, Kp index, and aurora forecast.',
+    title: 'Space Weather Monitor — Solar Flare Tracker & Kp Index',
+    description:
+      'Live solar flare monitor with Kp index, solar wind, geomagnetic storm alerts, and aurora forecast.',
     url: 'https://www.16bitweather.co/space-weather',
     siteName: '16 Bit Weather',
-    images: [{ url: '/api/og?title=Space+Weather+Monitor&subtitle=Solar+Activity+%2B+Aurora+Forecast', width: 1200, height: 630, alt: 'Space Weather Monitor' }],
+    images: [
+      {
+        url: '/api/og?title=Space+Weather+Monitor&subtitle=Solar+Flare+Tracker+%2B+Live+Kp',
+        width: 1200,
+        height: 630,
+        alt: 'Space Weather Monitor',
+      },
+    ],
     locale: 'en_US',
     type: 'website',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Space Weather Monitor',
-    description: 'Real-time solar activity, Kp index, and aurora forecast.',
-    images: ['/api/og?title=Space+Weather+Monitor&subtitle=Solar+Activity+%2B+Aurora+Forecast'],
+    title: 'Space Weather Monitor — Solar Flare Tracker & Kp Index',
+    description:
+      'Live solar flare monitor with Kp index, solar wind, and aurora forecast.',
+    images: ['/api/og?title=Space+Weather+Monitor&subtitle=Solar+Flare+Tracker+%2B+Live+Kp'],
   },
   alternates: { canonical: 'https://www.16bitweather.co/space-weather' },
 }

--- a/app/space-weather/page.tsx
+++ b/app/space-weather/page.tsx
@@ -1,201 +1,35 @@
-/**
- * 16-Bit Weather Platform - Space Weather Page
- *
- * Copyright (C) 2025 16-Bit Weather
- * Licensed under Fair Source License, Version 0.9
- *
- * Real-time space weather monitoring with solar data visualization
- */
-
-'use client';
-
-import React, { useEffect, useState, Suspense, lazy, useCallback, startTransition } from 'react';
-import { cn } from '@/lib/utils';
-import { useTheme } from '@/components/theme-provider';
-import { getComponentStyles, type ThemeType } from '@/lib/theme-utils';
-import PageWrapper from '@/components/page-wrapper';
-import type { SpaceWeatherAlert } from '@/components/space-weather/SpaceWeatherAlertTicker';
-import type { KpIndexData } from '@/components/space-weather/KpIndexGauge';
-import type { SolarWindData } from '@/components/space-weather/SolarWindStats';
-import type { SunspotData } from '@/components/space-weather/SunspotDisplay';
-import type { XRayFluxData } from '@/components/space-weather/XRayFluxChart';
-import type { AuroraForecastData } from '@/components/space-weather/AuroraForecastMap';
-import type { SpaceWeatherScalesData } from '@/components/space-weather/SpaceWeatherScales';
-import { ShareButtons } from '@/components/share-buttons';
-
-// Lazy load the heavy terminal component
-const SolarCommandTerminal = lazy(() => import('@/components/space-weather/SolarCommandTerminal'));
-
-interface SpaceWeatherData {
-  scales: SpaceWeatherScalesData | null;
-  alerts: SpaceWeatherAlert[];
-  kpIndex: KpIndexData | null;
-  solarWind: SolarWindData | null;
-  sunspots: SunspotData | null;
-  xrayFlux: XRayFluxData | null;
-  auroraForecast: AuroraForecastData | null;
-}
+import { Suspense } from 'react'
+import { safeJsonLd } from '@/lib/utils'
+import SpaceWeatherSeoContent, {
+  buildSpaceWeatherAppJsonLd,
+  buildSpaceWeatherFaqJsonLd,
+} from '@/components/space-weather/space-weather-seo-content'
+import SpaceWeatherClient from './space-weather-client'
 
 export default function SpaceWeatherPage() {
-  const { theme } = useTheme();
-  const themeClasses = getComponentStyles((theme || 'nord') as ThemeType, 'weather');
-  const [data, setData] = useState<SpaceWeatherData>({
-    scales: null,
-    alerts: [],
-    kpIndex: null,
-    solarWind: null,
-    sunspots: null,
-    xrayFlux: null,
-    auroraForecast: null,
-  });
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  const fetchAllData = useCallback(async () => {
-    try {
-      // Don't block initial render - set loading to false early
-      // so skeleton states render immediately
-
-      // Helper to fetch with timeout for better LCP
-      const fetchWithTimeout = async (url: string, timeoutMs = 3000): Promise<Response> => {
-        const controller = new AbortController();
-        const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
-        try {
-          const response = await fetch(url, { signal: controller.signal });
-          clearTimeout(timeoutId);
-          return response;
-        } catch (err) {
-          clearTimeout(timeoutId);
-          throw err;
-        }
-      };
-
-      // Fetch all space weather data in parallel with timeouts
-      const [scalesRes, alertsRes, kpRes, windRes, sunspotsRes, xrayRes, auroraRes] = await Promise.allSettled([
-        fetchWithTimeout('/api/space-weather/scales'),
-        fetchWithTimeout('/api/space-weather/alerts'),
-        fetchWithTimeout('/api/space-weather/kp-index'),
-        fetchWithTimeout('/api/space-weather/solar-wind'),
-        fetchWithTimeout('/api/space-weather/sunspots'),
-        fetchWithTimeout('/api/space-weather/xray-flux'),
-        fetchWithTimeout('/api/space-weather/aurora'),
-      ]);
-
-      // Parse results with error handling for each
-      const parseResult = async <T,>(result: PromiseSettledResult<Response>, defaultValue: T): Promise<T> => {
-        if (result.status === 'fulfilled' && result.value.ok) {
-          try {
-            return await result.value.json();
-          } catch {
-            return defaultValue;
-          }
-        }
-        return defaultValue;
-      };
-
-      // Parse and extract inner data from API response wrappers
-      // API routes return { data/scales: {...}, source: '...' } wrappers
-      const scalesWrapper = await parseResult<{ scales: SpaceWeatherScalesData } | null>(scalesRes, null);
-      const alertsWrapper = await parseResult<{ alerts: SpaceWeatherAlert[] }>(alertsRes, { alerts: [] });
-      const kpWrapper = await parseResult<{ data: KpIndexData } | null>(kpRes, null);
-      const windWrapper = await parseResult<{ data: SolarWindData } | null>(windRes, null);
-      const sunspotsWrapper = await parseResult<{ data: SunspotData } | null>(sunspotsRes, null);
-      const xrayWrapper = await parseResult<{ data: XRayFluxData } | null>(xrayRes, null);
-      const auroraWrapper = await parseResult<{ data: AuroraForecastData; kpIndex?: number } | null>(auroraRes, null);
-
-      setData({
-        scales: scalesWrapper?.scales ?? null,
-        alerts: alertsWrapper.alerts || [],
-        kpIndex: kpWrapper?.data ?? null,
-        solarWind: windWrapper?.data ?? null,
-        sunspots: sunspotsWrapper?.data ?? null,
-        xrayFlux: xrayWrapper?.data ?? null,
-        auroraForecast: auroraWrapper?.data ? {
-          ...auroraWrapper.data,
-          currentKp: auroraWrapper.kpIndex ?? 3,
-        } : null,
-      });
-      setError(null);
-    } catch (err) {
-      console.error('Error fetching space weather data:', err);
-      setError('Unable to load space weather data. Please try again later.');
-    } finally {
-      setIsLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    // Use startTransition to allow initial paint before data fetching
-    startTransition(() => {
-      fetchAllData();
-    });
-
-    // Refresh data every 5 minutes
-    const interval = setInterval(() => {
-      startTransition(() => {
-        fetchAllData();
-      });
-    }, 5 * 60 * 1000);
-    return () => clearInterval(interval);
-  }, [fetchAllData]);
+  const appJsonLd = buildSpaceWeatherAppJsonLd()
+  const faqJsonLd = buildSpaceWeatherFaqJsonLd()
 
   return (
-    <PageWrapper>
-      <div className={cn('container mx-auto px-4 py-8', themeClasses.background)}>
-        {/* Header Section */}
-        <div className="mb-8">
-          <h1
-            className={cn(
-              'text-4xl sm:text-5xl md:text-6xl font-extrabold mb-4 font-mono',
-              themeClasses.accentText,
-              themeClasses.glow
-            )}
-          >
-            SPACE WEATHER
-          </h1>
-          <p className={cn('text-base sm:text-lg font-mono max-w-3xl', themeClasses.text)}>
-            Real-time solar monitoring and space weather intelligence. Track solar flares,
-            geomagnetic storms, and aurora forecasts with data from NOAA SWPC, NASA SDO,
-            and ESA/NASA SOHO.
-          </p>
-        </div>
-          <ShareButtons
-            config={{
-              title: 'Space Weather Monitor',
-              text: 'Real-time space weather -- solar activity, Kp index, and aurora forecast at 16bitweather.co',
-              url: 'https://www.16bitweather.co/space-weather',
-            }}
-            className="mt-3"
-          />
-
-        {/* Error Display */}
-        {error && (
-          <div className={cn(
-            'mb-6 p-4 border-4 border-red-500 bg-red-500/10 font-mono text-sm',
-            'text-red-500'
-          )}>
-            {error}
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: safeJsonLd(appJsonLd) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: safeJsonLd(faqJsonLd) }}
+      />
+      <Suspense
+        fallback={
+          <div className="container mx-auto px-4 py-16 font-mono text-center text-weather-muted">
+            Loading space weather monitor…
           </div>
-        )}
-
-        {/* Main Terminal */}
-        <Suspense fallback={
-          <div className={cn('border-4 p-8 text-center font-mono', themeClasses.borderColor, themeClasses.background)}>
-            <div className="animate-pulse">Initializing Solar Command Terminal...</div>
-          </div>
-        }>
-          <SolarCommandTerminal
-            scales={data.scales}
-            alerts={data.alerts}
-            kpIndex={data.kpIndex}
-            solarWind={data.solarWind}
-            sunspots={data.sunspots}
-            xrayFlux={data.xrayFlux}
-            auroraForecast={data.auroraForecast}
-            isLoading={isLoading}
-          />
-        </Suspense>
-      </div>
-    </PageWrapper>
-  );
+        }
+      >
+        <SpaceWeatherClient />
+      </Suspense>
+      <SpaceWeatherSeoContent />
+    </>
+  )
 }

--- a/app/space-weather/space-weather-client.tsx
+++ b/app/space-weather/space-weather-client.tsx
@@ -1,0 +1,201 @@
+/**
+ * 16-Bit Weather Platform - Space Weather Page
+ *
+ * Copyright (C) 2025 16-Bit Weather
+ * Licensed under Fair Source License, Version 0.9
+ *
+ * Real-time space weather monitoring with solar data visualization
+ */
+
+'use client';
+
+import React, { useEffect, useState, Suspense, lazy, useCallback, startTransition } from 'react';
+import { cn } from '@/lib/utils';
+import { useTheme } from '@/components/theme-provider';
+import { getComponentStyles, type ThemeType } from '@/lib/theme-utils';
+import PageWrapper from '@/components/page-wrapper';
+import type { SpaceWeatherAlert } from '@/components/space-weather/SpaceWeatherAlertTicker';
+import type { KpIndexData } from '@/components/space-weather/KpIndexGauge';
+import type { SolarWindData } from '@/components/space-weather/SolarWindStats';
+import type { SunspotData } from '@/components/space-weather/SunspotDisplay';
+import type { XRayFluxData } from '@/components/space-weather/XRayFluxChart';
+import type { AuroraForecastData } from '@/components/space-weather/AuroraForecastMap';
+import type { SpaceWeatherScalesData } from '@/components/space-weather/SpaceWeatherScales';
+import { ShareButtons } from '@/components/share-buttons';
+
+// Lazy load the heavy terminal component
+const SolarCommandTerminal = lazy(() => import('@/components/space-weather/SolarCommandTerminal'));
+
+interface SpaceWeatherData {
+  scales: SpaceWeatherScalesData | null;
+  alerts: SpaceWeatherAlert[];
+  kpIndex: KpIndexData | null;
+  solarWind: SolarWindData | null;
+  sunspots: SunspotData | null;
+  xrayFlux: XRayFluxData | null;
+  auroraForecast: AuroraForecastData | null;
+}
+
+export default function SpaceWeatherClient() {
+  const { theme } = useTheme();
+  const themeClasses = getComponentStyles((theme || 'nord') as ThemeType, 'weather');
+  const [data, setData] = useState<SpaceWeatherData>({
+    scales: null,
+    alerts: [],
+    kpIndex: null,
+    solarWind: null,
+    sunspots: null,
+    xrayFlux: null,
+    auroraForecast: null,
+  });
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchAllData = useCallback(async () => {
+    try {
+      // Don't block initial render - set loading to false early
+      // so skeleton states render immediately
+
+      // Helper to fetch with timeout for better LCP
+      const fetchWithTimeout = async (url: string, timeoutMs = 3000): Promise<Response> => {
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+        try {
+          const response = await fetch(url, { signal: controller.signal });
+          clearTimeout(timeoutId);
+          return response;
+        } catch (err) {
+          clearTimeout(timeoutId);
+          throw err;
+        }
+      };
+
+      // Fetch all space weather data in parallel with timeouts
+      const [scalesRes, alertsRes, kpRes, windRes, sunspotsRes, xrayRes, auroraRes] = await Promise.allSettled([
+        fetchWithTimeout('/api/space-weather/scales'),
+        fetchWithTimeout('/api/space-weather/alerts'),
+        fetchWithTimeout('/api/space-weather/kp-index'),
+        fetchWithTimeout('/api/space-weather/solar-wind'),
+        fetchWithTimeout('/api/space-weather/sunspots'),
+        fetchWithTimeout('/api/space-weather/xray-flux'),
+        fetchWithTimeout('/api/space-weather/aurora'),
+      ]);
+
+      // Parse results with error handling for each
+      const parseResult = async <T,>(result: PromiseSettledResult<Response>, defaultValue: T): Promise<T> => {
+        if (result.status === 'fulfilled' && result.value.ok) {
+          try {
+            return await result.value.json();
+          } catch {
+            return defaultValue;
+          }
+        }
+        return defaultValue;
+      };
+
+      // Parse and extract inner data from API response wrappers
+      // API routes return { data/scales: {...}, source: '...' } wrappers
+      const scalesWrapper = await parseResult<{ scales: SpaceWeatherScalesData } | null>(scalesRes, null);
+      const alertsWrapper = await parseResult<{ alerts: SpaceWeatherAlert[] }>(alertsRes, { alerts: [] });
+      const kpWrapper = await parseResult<{ data: KpIndexData } | null>(kpRes, null);
+      const windWrapper = await parseResult<{ data: SolarWindData } | null>(windRes, null);
+      const sunspotsWrapper = await parseResult<{ data: SunspotData } | null>(sunspotsRes, null);
+      const xrayWrapper = await parseResult<{ data: XRayFluxData } | null>(xrayRes, null);
+      const auroraWrapper = await parseResult<{ data: AuroraForecastData; kpIndex?: number } | null>(auroraRes, null);
+
+      setData({
+        scales: scalesWrapper?.scales ?? null,
+        alerts: alertsWrapper.alerts || [],
+        kpIndex: kpWrapper?.data ?? null,
+        solarWind: windWrapper?.data ?? null,
+        sunspots: sunspotsWrapper?.data ?? null,
+        xrayFlux: xrayWrapper?.data ?? null,
+        auroraForecast: auroraWrapper?.data ? {
+          ...auroraWrapper.data,
+          currentKp: auroraWrapper.kpIndex ?? 3,
+        } : null,
+      });
+      setError(null);
+    } catch (err) {
+      console.error('Error fetching space weather data:', err);
+      setError('Unable to load space weather data. Please try again later.');
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    // Use startTransition to allow initial paint before data fetching
+    startTransition(() => {
+      fetchAllData();
+    });
+
+    // Refresh data every 5 minutes
+    const interval = setInterval(() => {
+      startTransition(() => {
+        fetchAllData();
+      });
+    }, 5 * 60 * 1000);
+    return () => clearInterval(interval);
+  }, [fetchAllData]);
+
+  return (
+    <PageWrapper>
+      <div className={cn('container mx-auto px-4 py-8', themeClasses.background)}>
+        {/* Header Section */}
+        <div className="mb-8">
+          <h1
+            className={cn(
+              'text-3xl sm:text-4xl md:text-5xl font-extrabold mb-4 font-mono',
+              themeClasses.accentText,
+              themeClasses.glow
+            )}
+          >
+            Space Weather Monitor
+          </h1>
+          <p className={cn('text-base sm:text-lg font-mono max-w-3xl', themeClasses.text)}>
+            Live solar flare monitor and space weather tracker — Kp index, solar wind,
+            geomagnetic storm alerts, and aurora forecast from NOAA SWPC, NASA SDO, and
+            ESA/NASA SOHO.
+          </p>
+        </div>
+          <ShareButtons
+            config={{
+              title: 'Space Weather Monitor — Solar Flare Tracker & Kp Index',
+              text: 'Live space weather tracker: solar flares, Kp index, solar wind, and aurora forecast at 16bitweather.co',
+              url: 'https://www.16bitweather.co/space-weather',
+            }}
+            className="mt-3"
+          />
+
+        {/* Error Display */}
+        {error && (
+          <div className={cn(
+            'mb-6 p-4 border-4 border-red-500 bg-red-500/10 font-mono text-sm',
+            'text-red-500'
+          )}>
+            {error}
+          </div>
+        )}
+
+        {/* Main Terminal */}
+        <Suspense fallback={
+          <div className={cn('border-4 p-8 text-center font-mono', themeClasses.borderColor, themeClasses.background)}>
+            <div className="animate-pulse">Initializing Solar Command Terminal...</div>
+          </div>
+        }>
+          <SolarCommandTerminal
+            scales={data.scales}
+            alerts={data.alerts}
+            kpIndex={data.kpIndex}
+            solarWind={data.solarWind}
+            sunspots={data.sunspots}
+            xrayFlux={data.xrayFlux}
+            auroraForecast={data.auroraForecast}
+            isLoading={isLoading}
+          />
+        </Suspense>
+      </div>
+    </PageWrapper>
+  );
+}

--- a/app/space-weather/space-weather-client.tsx
+++ b/app/space-weather/space-weather-client.tsx
@@ -117,7 +117,7 @@ export default function SpaceWeatherClient() {
       });
       setError(null);
     } catch (err) {
-      console.error('Error fetching space weather data:', err);
+      console.error('[SpaceWeatherClient]', err);
       setError('Unable to load space weather data. Please try again later.');
     } finally {
       setIsLoading(false);

--- a/app/tropical/layout.tsx
+++ b/app/tropical/layout.tsx
@@ -1,22 +1,23 @@
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
-  title: 'Tropical Tracker — NHC Outlooks & Atlantic Satellite | 16 Bit Weather',
+  title: 'Tropical Weather Tracker — Atlantic Satellite & NHC Outlooks | 16 Bit Weather',
   description:
-    'Live NHC tropical weather outlooks, Atlantic basin satellite imagery, and sea surface temperatures — hurricane season tracking in a retro terminal UI.',
-  keywords: 'tropical weather, NHC outlook, hurricane tracker, tropical storm, satellite imagery, sea surface temperature',
+    'Track Atlantic tropical weather with live NHC outlooks, tropical Atlantic satellite imagery, and sea surface temperatures in a retro terminal UI.',
+  keywords:
+    'tropical weather, Atlantic tropical satellite, tropical Atlantic satellite, NHC outlook, hurricane tracker, tropical storm, satellite imagery, sea surface temperature',
   openGraph: {
-    title: 'Tropical Tracker | 16 Bit Weather',
+    title: 'Tropical Weather Tracker — Atlantic Satellite & NHC | 16 Bit Weather',
     description:
-      'Live NHC tropical outlooks, Atlantic satellite imagery, and sea surface temperature analysis.',
+      'Live NHC tropical outlooks, Atlantic basin satellite imagery, and sea surface temperature analysis.',
     url: 'https://www.16bitweather.co/tropical',
     siteName: '16 Bit Weather',
     images: [
       {
-        url: '/api/og?title=Tropical+Weather&subtitle=NHC+Outlook+%2B+Satellite',
+        url: '/api/og?title=Tropical+Weather+Tracker&subtitle=Atlantic+Satellite+%2B+NHC',
         width: 1200,
         height: 630,
-        alt: 'Tropical Weather',
+        alt: 'Tropical Weather Tracker',
       },
     ],
     locale: 'en_US',
@@ -24,10 +25,10 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Tropical Tracker | 16 Bit Weather',
+    title: 'Tropical Weather Tracker — Atlantic Satellite & NHC',
     description:
       'Live NHC tropical outlooks, Atlantic satellite imagery, and sea surface temperatures.',
-    images: ['/api/og?title=Tropical+Weather&subtitle=NHC+Outlook+%2B+Satellite'],
+    images: ['/api/og?title=Tropical+Weather+Tracker&subtitle=Atlantic+Satellite+%2B+NHC'],
   },
   alternates: {
     canonical: 'https://www.16bitweather.co/tropical',

--- a/components/space-weather/space-weather-seo-content.tsx
+++ b/components/space-weather/space-weather-seo-content.tsx
@@ -1,0 +1,106 @@
+import Link from 'next/link'
+
+const BASE_URL = 'https://www.16bitweather.co'
+
+export const SPACE_WEATHER_FAQS = [
+  {
+    question: 'What is a space weather monitor?',
+    answer:
+      'A space weather monitor tracks solar and geomagnetic conditions in near real time — solar flares (X-ray flux), the planetary Kp index, solar wind speed and density, sunspots, and aurora outlooks — so you can see storm risk as it develops.',
+  },
+  {
+    question: 'What does the Kp index measure?',
+    answer:
+      'The Kp index is a 0–9 scale of global geomagnetic activity. Higher Kp means a stronger geomagnetic storm and a better chance of aurora at lower latitudes. Live Kp and recent history are shown on this page from NOAA SWPC data.',
+  },
+  {
+    question: 'How do I track solar flares and solar storms?',
+    answer:
+      'Watch GOES X-ray flux for flare class (C, M, X), check SWPC scales for radio blackout and radiation storm levels, and follow solar wind and Kp for geomagnetic response. This solar flare monitor and storm tracker combines those feeds in one terminal.',
+  },
+  {
+    question: 'Where does 16 Bit Weather get space weather data?',
+    answer:
+      'Primary sources are NOAA Space Weather Prediction Center (scales, Kp, solar wind, alerts), NASA SDO imagery, and ESA/NASA SOHO coronagraph frames. Data refreshes automatically while you keep the page open.',
+  },
+] as const
+
+export function buildSpaceWeatherFaqJsonLd() {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: SPACE_WEATHER_FAQS.map((faq) => ({
+      '@type': 'Question',
+      name: faq.question,
+      acceptedAnswer: { '@type': 'Answer', text: faq.answer },
+    })),
+  }
+}
+
+export function buildSpaceWeatherAppJsonLd() {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name: 'Space Weather Monitor',
+    description:
+      'Free solar flare monitor and space weather tracker with live Kp index, solar wind, aurora forecast, and geomagnetic storm alerts.',
+    url: `${BASE_URL}/space-weather`,
+    applicationCategory: 'WeatherApplication',
+    operatingSystem: 'Any',
+    offers: {
+      '@type': 'Offer',
+      price: '0',
+      priceCurrency: 'USD',
+    },
+  }
+}
+
+/**
+ * Server-rendered crawlable copy for /space-weather. Renders below the
+ * interactive terminal so Google can index monitor/tracker intent copy.
+ */
+export default function SpaceWeatherSeoContent() {
+  return (
+    <article
+      className="mx-auto max-w-3xl px-4 py-10 text-sm leading-relaxed text-weather-muted font-mono"
+      aria-label="About the space weather monitor"
+      data-testid="space-weather-seo-content"
+    >
+      <h2 className="mb-4 text-xl font-bold text-weather-primary uppercase tracking-wide">
+        Solar Flare Monitor &amp; Space Weather Tracker
+      </h2>
+      <p className="mb-4 text-weather-text">
+        Use this free space weather monitor to follow solar activity in real time: X-ray flare
+        class, planetary Kp index, solar wind plasma, sunspot regions, SWPC scales, and aurora
+        forecast guidance. It is built for anyone watching geomagnetic storms — from aurora
+        chasers to radio operators and aviation weather hobbyists.
+      </p>
+      <p className="mb-4 text-weather-text">
+        Start with current scales and alerts, then drill into Kp history, solar wind speed, and
+        flare timelines. Pair storm watches with the{' '}
+        <Link href="/stargazer" className="text-weather-primary underline underline-offset-2">
+          Stargazer sky forecast
+        </Link>{' '}
+        when aurora potential rises, or read the weekly context on the{' '}
+        <Link href="/blog" className="text-weather-primary underline underline-offset-2">
+          weather blog
+        </Link>
+        .
+      </p>
+      <p className="mb-6 text-weather-text">
+        All feeds on {BASE_URL.replace('https://', '')}/space-weather are free and update while the
+        page is open — no account required.
+      </p>
+
+      <h3 className="mb-3 text-lg font-semibold text-weather-primary">Space Weather FAQ</h3>
+      <dl className="space-y-4">
+        {SPACE_WEATHER_FAQS.map((faq) => (
+          <div key={faq.question}>
+            <dt className="font-semibold text-weather-text">{faq.question}</dt>
+            <dd className="mt-1">{faq.answer}</dd>
+          </div>
+        ))}
+      </dl>
+    </article>
+  )
+}

--- a/content/blog/2026-06-07-this-week-in-weather-2026-06-07.md
+++ b/content/blog/2026-06-07-this-week-in-weather-2026-06-07.md
@@ -1,9 +1,9 @@
 ---
 slug: this-week-in-weather-2026-06-07
-title: This Week in Weather
+title: "This Week in Weather — June 7, 2026: Alabama Leads Storm Reports"
 date: 2026-06-07T19:58:42.901Z
 author: 16bitbot
-summary: Rearview of the past 7 days and the pattern shaping the week ahead.
+summary: "Alabama-led severe week, multi-state tornado sequence, M9.7 solar flare, and the Rockies ridge shaping the forecast."
 tags:
   - weekly-recap
   - forecast

--- a/content/blog/2026-06-14-this-week-in-weather-2026-06-14.md
+++ b/content/blog/2026-06-14-this-week-in-weather-2026-06-14.md
@@ -1,9 +1,9 @@
 ---
 slug: this-week-in-weather-2026-06-14
-title: This Week in Weather
+title: "This Week in Weather — June 14, 2026: 205 Tornado Warnings"
 date: 2026-06-14T20:48:00.887Z
 author: 16bitbot
-summary: Rearview of the past 7 days and the pattern shaping the week ahead.
+summary: "Rearview of 205 tornado warnings, Plains-to-Ohio Valley severe weather, and the western ridge shaping the week ahead."
 tags:
   - weekly-recap
   - forecast

--- a/content/blog/2026-06-28-this-week-in-weather-2026-06-28.md
+++ b/content/blog/2026-06-28-this-week-in-weather-2026-06-28.md
@@ -1,9 +1,9 @@
 ---
 slug: this-week-in-weather-2026-06-28
-title: This Week in Weather
+title: "This Week in Weather — June 28, 2026: Heat Ridge & 169 Tornado Warnings"
 date: 2026-06-28T23:39:00.839Z
 author: 16bitbot
-summary: Rearview of the past 7 days and the pattern shaping the week ahead.
+summary: "169 tornado warnings, Northern Plains supercells, and a locked southern heat ridge heading into early July."
 tags:
   - weekly-recap
   - forecast

--- a/content/blog/2026-07-05-this-week-in-weather-2026-07-05.md
+++ b/content/blog/2026-07-05-this-week-in-weather-2026-07-05.md
@@ -1,9 +1,9 @@
 ---
 slug: this-week-in-weather-2026-07-05
-title: This Week in Weather
+title: "This Week in Weather — July 5, 2026: Wind Event & X1.3 Flare"
 date: 2026-07-05T20:42:29.853Z
 author: 16bitbot
-summary: Rearview of the past 7 days and the pattern shaping the week ahead.
+summary: "2,576 wind reports, July 4–5 tornado warnings, an X1.3 solar flare, and the southern heat ridge for the week ahead."
 tags:
   - weekly-recap
   - forecast

--- a/lib/city-metadata.ts
+++ b/lib/city-metadata.ts
@@ -155,13 +155,17 @@ export const cityData: { [key: string]: {
     name: 'Atlanta',
     state: 'GA',
     searchTerm: 'Atlanta, GA',
-    title: 'Atlanta Weather Forecast - 16 Bit Weather',
-    description: 'Current weather conditions and 5-day forecast for Atlanta, GA. Real-time weather data for the Southeast hub with severe storm tracking.',
+    title: 'Atlanta Georgia Climate & Summer Weather Guide - 16 Bit Weather',
+    description:
+      'Atlanta climate and summer weather: humid subtropical seasons, monthly averages, severe storm risk, and the best time to visit.',
     content: {
-      intro: 'Atlanta has a humid subtropical climate with hot summers and mild winters. Located in the Piedmont region of Georgia, the city experiences four seasons with occasional severe weather.',
-      climate: 'Summer highs reach the upper 80s-90s°F (31-33°C) with high humidity. Winters are mild with occasional cold snaps. The city receives about 50 inches of rain annually.',
-      patterns: 'Atlanta experiences severe thunderstorms and occasional tornadoes in spring. Ice storms can impact the city in winter. Summer brings frequent afternoon thunderstorms.'
-    }
+      intro:
+        'Atlanta has a humid subtropical climate with hot, stormy summers and mild winters. Sitting about 1,050 feet above sea level in Georgia\'s Piedmont, the city gets four seasons — and frequent severe thunderstorms in spring.',
+      climate:
+        'Summer highs reach the upper 80s–90s°F with high humidity and near-daily afternoon storms. Winters are mild (lows often in the 30s°F) but ice storms can shut the city down. Annual rainfall is about 50 inches — more than Seattle.',
+      patterns:
+        'Dixie Alley severe weather peaks in spring. Fall is the most comfortable season. Snow is rare (~2 inches/year), but even light ice events paralyze roads. Hurricane remnants occasionally bring heavy rain in late summer and fall.',
+    },
   },
   'denver-co': {
     name: 'Denver',
@@ -203,13 +207,17 @@ export const cityData: { [key: string]: {
     name: 'Boston',
     state: 'MA',
     searchTerm: 'Boston, MA',
-    title: 'Boston Weather Forecast - 16 Bit Weather',
-    description: 'Current weather conditions and 5-day forecast for Boston, MA. Real-time New England weather with nor\'easter and snowstorm tracking.',
+    title: 'Boston MA Climate & Year-Round Weather Guide - 16 Bit Weather',
+    description:
+      'Boston climate and year-round weather: monthly averages, nor\'easter winters, humid summers, and the best time to visit New England.',
     content: {
-      intro: 'Boston has a humid continental climate with cold winters and warm summers. The city\'s coastal location influences its weather, bringing ocean breezes and nor\'easters.',
-      climate: 'Summers are warm with highs in the 80s°F (27-29°C). Winters are cold with temperatures often below freezing and significant snowfall. Annual precipitation is about 44 inches.',
-      patterns: 'Boston experiences nor\'easters bringing heavy snow in winter and occasional hurricanes in fall. The city sees rapid weather changes due to its New England location.'
-    }
+      intro:
+        'Boston has a humid continental climate with cold, snowy winters and warm, humid summers. The Atlantic shoreline shapes the city\'s weather — ocean moderation, sea breezes, and powerful nor\'easters that define New England winters.',
+      climate:
+        'Year-round, Boston averages about 44 inches of precipitation. Summer highs typically sit in the upper 70s to low 80s°F with sticky humidity; winter highs hover in the upper 30s°F with frequent freezes. Snow averages near 48 inches per year, but individual winters swing from under a foot to more than 100 inches.',
+      patterns:
+        'Nor\'easters are the signature winter hazard, often tracking just offshore and dumping heavy snow on the metro. Spring arrives late; fall foliage peaks in mid-to-late October. Rapid air-mass changes are common when Canadian cold meets Atlantic moisture.',
+    },
   },
   'las-vegas-nv': {
     name: 'Las Vegas',
@@ -901,6 +909,8 @@ export const cityEnrichments: Record<string, CitySeoEnrichment> = {
       'Atlanta averages about 50 inches of rain per year, more than Seattle.',
     ],
     faqs: [
+      { question: 'What is Atlanta Georgia climate like?', answer: 'Atlanta has a humid subtropical climate (Köppen Cfa): hot humid summers, mild winters, about 50 inches of rain per year, and a lively severe-weather season in spring.' },
+      { question: 'What is Atlanta summer weather like?', answer: 'Summers are hot and humid with highs in the upper 80s°F, dewpoints often in the low 70s°F, and frequent afternoon thunderstorms from June through August.' },
       { question: 'When is the best time to visit Atlanta?', answer: 'Mid-September through early November offers the best weather — mild, dry, sunny days in the 70s°F with spectacular fall color in the nearby mountains. Spring (March-May) is also beautiful with blooming trees.' },
       { question: 'Does Atlanta get tornadoes?', answer: 'Yes. Atlanta sits in "Dixie Alley" and sees several tornado warnings each spring and occasionally in fall. The 2008 Atlanta tornado caused damage to downtown — rare for a major city.' },
       { question: 'How much snow does Atlanta get?', answer: 'Very little — about 2 inches per year on average. The city is poorly equipped for snow and ice, and even small amounts can shut down highways. January and February are the most likely months.' },
@@ -973,10 +983,13 @@ export const cityEnrichments: Record<string, CitySeoEnrichment> = {
       'The 2015 winter broke Boston\'s all-time snowfall record with 110.6 inches, including 94 inches in February alone.',
     ],
     faqs: [
+      { question: 'What is the climate in Boston Massachusetts?', answer: 'Boston has a humid continental climate (Köppen Dfa): cold snowy winters, warm humid summers, and about 44 inches of precipitation a year. The Atlantic coast moderates extremes but fuels nor\'easters.' },
+      { question: 'What is Boston weather like year round?', answer: 'Winters average highs in the upper 30s°F with frequent snow; springs are cool and late; summers reach the 80s°F with humidity; fall is crisp with peak foliage in mid-to-late October. Expect rapid day-to-day changes.' },
+      { question: 'How cold does Boston get in winter?', answer: 'Average winter highs are in the upper 30s°F with lows in the 20s°F. Arctic outbreaks can push temperatures below zero, and coastal wind chills feel much colder during nor\'easters.' },
+      { question: 'How cold is Boston compared with inland New England?', answer: 'Boston is usually a few degrees milder than inland Massachusetts because of the ocean, but wind and coastal flooding can make storms feel harsher along the shore.' },
       { question: 'When is the best time to visit Boston?', answer: 'Late September through mid-October delivers Boston\'s best weather — mild days in the 60s-70s°F, cool nights, sunshine, and peak fall foliage. Late spring (May-June) is also beautiful.' },
-      { question: 'How cold does Boston get in winter?', answer: 'Average winter highs are in the upper 30s°F with lows in the 20s°F. Arctic outbreaks can push temperatures below zero, and wind chills along the coast can feel much colder.' },
-      { question: 'What is a nor\'easter?', answer: 'A powerful storm that tracks up the US East Coast, pulling moisture from the Atlantic and slamming New England with heavy snow, high winds, and coastal flooding. Boston can get multiple nor\'easters per winter.' },
       { question: 'How much snow does Boston get?', answer: 'About 48 inches per year on average, but variability is extreme — some winters see 15 inches, others over 100. The historic 2014-15 winter dropped 110 inches in three months.' },
+      { question: 'What is a nor\'easter?', answer: 'A powerful storm that tracks up the US East Coast, pulling moisture from the Atlantic and slamming New England with heavy snow, high winds, and coastal flooding. Boston can get multiple nor\'easters per winter.' },
     ],
   },
   'las-vegas-nv': {

--- a/lib/seo/city-page-seo.ts
+++ b/lib/seo/city-page-seo.ts
@@ -29,7 +29,16 @@ export function buildCityPageTitle(city: CityMeta, citySlug: string): string {
   return `${label} Climate & Year-Round Weather | 16 Bit Weather`
 }
 
-export function buildCityPageDescription(city: CityMeta): string {
+export function buildCityPageDescription(city: CityMeta, citySlug?: string): string {
+  if (citySlug === 'boston-ma') {
+    return `Boston MA climate and year-round weather guide: monthly averages, nor'easter winters, humid summers, and best time to visit. Live forecast plus New England climate patterns.`
+  }
+  if (citySlug === 'atlanta-ga') {
+    return `Atlanta Georgia climate and summer weather guide: humid subtropical seasons, monthly averages, severe storm risk, and best time to visit. Live forecast included.`
+  }
+  if (citySlug && (PRIORITY_SEO_CITY_SLUGS as readonly string[]).includes(citySlug)) {
+    return `${city.name}, ${city.state} climate averages, monthly weather patterns, and year-round temperature guide. Live forecast, 7-day outlook, and best time to visit.`
+  }
   return `${city.name}, ${city.state} climate averages, monthly weather patterns, and best time to visit. Live forecast, 7-day outlook, and year-round temperature data with retro terminal style.`
 }
 
@@ -39,7 +48,10 @@ export function buildCityPageKeywords(city: CityMeta): string {
     `${city.name} ${city.state} weather`,
     `${city.name} climate`,
     `${city.name} ${city.state} climate`,
+    `climate in ${city.name}`,
+    `climate of ${city.name}`,
     `${city.name} weather year round`,
+    `${city.name} weather by month`,
     `${city.name} forecast`,
     `best time to visit ${city.name}`,
     `${city.name} monthly weather`,
@@ -52,7 +64,7 @@ export function buildCityPageMetadata(city: CityMeta, citySlug: string): Pick<
   'title' | 'description' | 'keywords' | 'openGraph' | 'twitter' | 'alternates'
 > {
   const pageTitle = buildCityPageTitle(city, citySlug)
-  const description = buildCityPageDescription(city)
+  const description = buildCityPageDescription(city, citySlug)
   const ogImage = `/api/og?title=${encodeURIComponent(city.name + ', ' + city.state)}&subtitle=Climate+%26+Weather+Guide`
 
   return {

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -25,7 +25,7 @@
 - Shareable phenomenon guides: https://www.16bitweather.co/education/phenomena/{slug} (e.g. /education/phenomena/thundersnow)
 - Live radar: https://www.16bitweather.co/radar
 - Stargazer / tonight's sky forecast: https://www.16bitweather.co/stargazer
-- Space weather: https://www.16bitweather.co/space-weather
+- Space weather monitor / solar flare tracker: https://www.16bitweather.co/space-weather
 - Blog (weekly weather dispatches): https://www.16bitweather.co/blog
 - About: https://www.16bitweather.co/about
 

--- a/scripts/newsletter/publish.ts
+++ b/scripts/newsletter/publish.ts
@@ -136,7 +136,9 @@ function buildHeader(input: PublishInput, datePrefix: string): { title: string; 
     // Keyword-led slug: topic + date (not first-sentence theme prose).
     const slug = slugify(`${input.topicSlug}-${datePrefix}`);
     const themeSnippet = input.theme.slice(0, 50).replace(/[.!?]+$/, '');
-    const title = `${input.topicTitle}: ${themeSnippet}`.slice(0, 70);
+    const title = input.theme.length > 0
+      ? `${input.topicTitle}: ${themeSnippet}`.slice(0, 70)
+      : input.topicTitle.slice(0, 70);
     const summary = input.theme.length > 0 ? input.theme.slice(0, 155) : input.topicTitle;
     return { title, summary, slug };
   }

--- a/scripts/newsletter/publish.ts
+++ b/scripts/newsletter/publish.ts
@@ -133,16 +133,48 @@ function formatImageAuditEntry(entry: ImageAuditEntry): string {
 
 function buildHeader(input: PublishInput, datePrefix: string): { title: string; summary: string; slug: string } {
   if (input.cadence === 'wednesday_topic') {
-    const themeSnippet = input.theme.slice(0, 60).replace(/[.!?]+$/, '');
-    const slug = slugify(`${input.topicSlug}-${themeSnippet}`);
-    const title = `${input.topicTitle}: ${input.theme}`.slice(0, 110);
-    const summary = input.theme.length > 0 ? input.theme : input.topicTitle;
+    // Keyword-led slug: topic + date (not first-sentence theme prose).
+    const slug = slugify(`${input.topicSlug}-${datePrefix}`);
+    const themeSnippet = input.theme.slice(0, 50).replace(/[.!?]+$/, '');
+    const title = `${input.topicTitle}: ${themeSnippet}`.slice(0, 70);
+    const summary = input.theme.length > 0 ? input.theme.slice(0, 155) : input.topicTitle;
     return { title, summary, slug };
   }
+  const dateLabel = formatDateLabel(datePrefix);
   const slug = `this-week-in-weather-${datePrefix}`;
-  const title = `This Week in Weather`;
-  const summary = `Rearview of the past 7 days and the pattern shaping the week ahead.`;
+  const title = `This Week in Weather — ${dateLabel}`;
+  const summary = `Severe weather rearview, storm reports, and the forecast pattern for the week of ${dateLabel}.`;
   return { title, summary, slug };
+}
+
+/** Exported for unit tests — keep slug generation stable and SEO-safe. */
+export function buildPublishHeaderForTest(
+  input: PublishInput,
+  datePrefix: string,
+): { title: string; summary: string; slug: string } {
+  return buildHeader(input, datePrefix);
+}
+
+function formatDateLabel(datePrefix: string): string {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(datePrefix);
+  if (!match) return datePrefix;
+  const [, y, m, d] = match;
+  const months = [
+    'January',
+    'February',
+    'March',
+    'April',
+    'May',
+    'June',
+    'July',
+    'August',
+    'September',
+    'October',
+    'November',
+    'December',
+  ];
+  const monthName = months[Number(m) - 1] ?? m;
+  return `${monthName} ${Number(d)}, ${y}`;
 }
 
 function buildTags(input: PublishInput): string[] {

--- a/tests/e2e/blog.spec.ts
+++ b/tests/e2e/blog.spec.ts
@@ -3,12 +3,14 @@ import { test, expect } from './fixtures';
 test('weekly blog renders topic-aligned imagery without generated placeholders', async ({ page }) => {
   await page.goto('/blog/this-week-in-weather-2026-06-14', { waitUntil: 'domcontentloaded' });
 
-  await expect(page.locator('article h1').filter({ hasText: /This Week in Weather/i })).toBeVisible({
-    timeout: 30000,
-  });
-
   const article = page.locator('article');
-  await expect(article.getByText(/205 tornado warnings/i)).toBeVisible();
+  await expect(
+    article.getByRole('heading', {
+      level: 1,
+      name: /This Week in Weather — June 14, 2026: 205 Tornado Warnings/i,
+    }),
+  ).toBeVisible({ timeout: 30000 });
+  await expect(article.getByText(/headline number is 205 tornado warnings/i)).toBeVisible();
   await expect(article.getByAltText(/mesocyclone structure within a supercell/i)).toBeVisible();
   await expect(article.getByAltText(/normal, reverse, and strike-slip fault motion/i)).toBeVisible();
   await expect(article.getByAltText(/GOES-16 mid-level water vapor/i)).toBeVisible();

--- a/tests/e2e/space-weather.spec.ts
+++ b/tests/e2e/space-weather.spec.ts
@@ -22,6 +22,7 @@ test.beforeEach(async ({ page }) => {
 test('renders the Space Weather shell', async ({ page }) => {
   await expect(page).toHaveTitle(/Space Weather/i);
   await expect(
-    page.getByRole('heading', { level: 1, name: /SPACE WEATHER/i }).first()
+    page.getByRole('heading', { level: 1, name: /Space Weather Monitor/i }).first()
   ).toBeVisible({ timeout: 30000 });
+  await expect(page.getByTestId('space-weather-seo-content')).toBeVisible();
 });


### PR DESCRIPTION
## Summary
- Make `/space-weather` crawlable with server-rendered FAQ copy, WebApplication/FAQ JSON-LD, and high-intent metadata (solar flare monitor, Kp tracker).
- Tighten titles/meta for glossary, tropical, aviation, and recent weekly blog posts already near page 2 in GSC.
- Enrich Boston/Atlanta climate content and FAQ answers around real Search Console queries; improve priority-city description builders.
- Fix future Wednesday newsletter slugs to `topic-date` instead of first-sentence prose; date Sunday weekly titles for clearer SERP snippets.

## Test plan
- [x] `npm test -- space-weather-seo.test.ts city-page-seo.test.ts publish-slug.test.ts`
- [x] `npm run typecheck`
- [x] `npx playwright test tests/e2e/space-weather.spec.ts --project=chromium`
- [ ] Spot-check `/space-weather`, `/weather/boston-ma`, `/education/glossary` in production preview
- [ ] After merge: optionally request indexing in GSC for `/space-weather` and top city pages (sitemap already submitted)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Launched a dedicated **Space Weather Monitor** experience with live solar/space-weather tracking, FAQs, and crawlable SEO content.
* **Enhancements**
  * Refreshed **city weather guides** with clearer, seasonally focused climate wording and updated FAQ content.
  * Improved **newsletter** header generation so titles/summaries/slugs follow clearer topic/date formats.
  * Updated **SEO and social metadata** across aviation, tropical, education glossary, and space-weather pages; refreshed weekly blog post headlines/summaries.
* **Bug Fixes**
  * Improved consistency of SEO descriptions and structured data output.
* **Tests**
  * Updated e2e/unit coverage for the revised SEO and content strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->