### PR TITLE
Fix pollen card empty categories and color mapping

### DIFF
--- a/__tests__/pollen-display-hotfix.test.ts
+++ b/__tests__/pollen-display-hotfix.test.ts
@@ -25,6 +25,18 @@ describe('normalizePollenCategories', () => {
     expect(normalized.grass).toEqual({ Grass: 'Moderate' });
     expect(normalized.weed).toEqual({ Ragweed: 'High' });
   });
+
+  it('treats null or undefined maps as None', () => {
+    const normalized = normalizePollenCategories(
+      null as unknown as Record<string, string>,
+      undefined as unknown as Record<string, string>,
+      {},
+    );
+
+    expect(normalized.tree).toEqual({ Tree: 'None' });
+    expect(normalized.grass).toEqual({ Grass: 'None' });
+    expect(normalized.weed).toEqual({ Weed: 'None' });
+  });
 });
 
 describe('getPollenColor', () => {

--- a/__tests__/pollen-display-hotfix.test.ts
+++ b/__tests__/pollen-display-hotfix.test.ts
@@ -1,0 +1,49 @@
+import { getPollenColor } from '@/lib/air-quality-utils';
+import { normalizePollenCategories } from '@/lib/pollen/normalize-pollen-categories';
+
+describe('normalizePollenCategories', () => {
+  it('fills empty tree and weed with None when grass has data', () => {
+    const normalized = normalizePollenCategories(
+      {},
+      { Grasses: 'Very Low' },
+      {},
+    );
+
+    expect(normalized.tree).toEqual({ Tree: 'None' });
+    expect(normalized.grass).toEqual({ Grasses: 'Very Low' });
+    expect(normalized.weed).toEqual({ Weed: 'None' });
+  });
+
+  it('preserves populated categories', () => {
+    const normalized = normalizePollenCategories(
+      { Oak: 'Low' },
+      { Grass: 'Moderate' },
+      { Ragweed: 'High' },
+    );
+
+    expect(normalized.tree).toEqual({ Oak: 'Low' });
+    expect(normalized.grass).toEqual({ Grass: 'Moderate' });
+    expect(normalized.weed).toEqual({ Ragweed: 'High' });
+  });
+});
+
+describe('getPollenColor', () => {
+  it('maps None and Very Low to muted or green styles', () => {
+    expect(getPollenColor('None')).toBe('text-gray-400 font-semibold');
+    expect(getPollenColor('none')).toBe('text-gray-400 font-semibold');
+    expect(getPollenColor('Very Low')).toBe('text-green-400 font-semibold');
+    expect(getPollenColor('very low')).toBe('text-green-400 font-semibold');
+  });
+
+  it('maps unavailable and no data to muted gray', () => {
+    expect(getPollenColor('Unavailable')).toBe('text-gray-400 font-semibold');
+    expect(getPollenColor('No Data')).toBe('text-gray-400 font-semibold');
+  });
+
+  it('keeps existing severity colors', () => {
+    expect(getPollenColor('Low')).toBe('text-green-400 font-semibold');
+    expect(getPollenColor('Moderate')).toBe('text-yellow-400 font-semibold');
+    expect(getPollenColor('High')).toBe('text-orange-400 font-semibold');
+    expect(getPollenColor('Very High')).toBe('text-red-400 font-semibold');
+  });
+});

--- a/app/api/weather/pollen/route.ts
+++ b/app/api/weather/pollen/route.ts
@@ -11,6 +11,7 @@ import { rateLimitRequest } from '@/lib/services/weather-rate-limiter';
 import { fetchWithTimeout } from '@/lib/fetch-with-timeout';
 import { fetchOpenMeteoAirQuality } from '@/lib/open-meteo';
 import { mapOpenMeteoPollenHourly } from '@/lib/pollen/open-meteo-pollen';
+import { normalizePollenCategories } from '@/lib/pollen/normalize-pollen-categories';
 
 const unavailableBody = {
   tree: { Tree: 'Unavailable' },
@@ -153,11 +154,16 @@ export async function GET(request: NextRequest) {
               Object.keys(weedBreakdown).length > 0;
 
             if (hasGoogleData) {
+              const normalized = normalizePollenCategories(
+                treeBreakdown,
+                grassBreakdown,
+                weedBreakdown,
+              );
               return NextResponse.json(
                 {
-                  tree: treeBreakdown,
-                  grass: grassBreakdown,
-                  weed: weedBreakdown,
+                  tree: normalized.tree,
+                  grass: normalized.grass,
+                  weed: normalized.weed,
                   source: 'google',
                 },
                 {
@@ -178,6 +184,23 @@ export async function GET(request: NextRequest) {
     try {
       const aq = await fetchOpenMeteoAirQuality(latitude, longitude);
       const mapped = mapOpenMeteoPollenHourly(aq.hourly, aq.utc_offset_seconds);
+      if (mapped.source === 'open-meteo') {
+        const normalized = normalizePollenCategories(mapped.tree, mapped.grass, mapped.weed);
+        return NextResponse.json(
+          {
+            tree: normalized.tree,
+            grass: normalized.grass,
+            weed: normalized.weed,
+            source: mapped.source,
+          },
+          {
+            headers: {
+              'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=600',
+              ...rateLimit.headers,
+            },
+          },
+        );
+      }
       return NextResponse.json(
         {
           tree: mapped.tree,

--- a/components/pollen-display.tsx
+++ b/components/pollen-display.tsx
@@ -45,9 +45,11 @@ function PollenCategory({ categoryName, categoryData, theme, minimal }: PollenCa
   // Theme-aware text styles using CSS variables
   const textStyles = minimal ? 'text-white/80' : 'text-foreground'
 
-  // Filter out empty / unavailable entries
+  // Filter out unavailable entries; None and numeric levels are valid readings
   const validData = Object.entries(categoryData).filter(
-    ([_, category]) => category !== 'No Data' && category !== 'Unavailable',
+    ([_, category]) =>
+      category !== 'No Data'
+      && category !== 'Unavailable',
   )
 
   const renderPollenData = () => {

--- a/components/pollen-display.tsx
+++ b/components/pollen-display.tsx
@@ -46,7 +46,7 @@ function PollenCategory({ categoryName, categoryData, theme, minimal }: PollenCa
   const textStyles = minimal ? 'text-white/80' : 'text-foreground'
 
   // Filter out unavailable entries; None and numeric levels are valid readings
-  const validData = Object.entries(categoryData).filter(
+  const validData = Object.entries(categoryData ?? {}).filter(
     ([_, category]) =>
       category !== 'No Data'
       && category !== 'Unavailable',

--- a/lib/air-quality-utils.ts
+++ b/lib/air-quality-utils.ts
@@ -87,15 +87,26 @@ export const getAQISeverityChrome = (aqi: number): AQISeverityChrome => {
  * Get color class for pollen category level
  */
 export const getPollenColor = (category: string | number): string => {
-  const cat = typeof category === 'string' ? category.toLowerCase() : category.toString();
-  
-  if (cat === 'no data' || cat === '0') return 'text-gray-400 font-semibold';
-  if (cat === 'low' || cat === '1' || cat === '2') return 'text-green-400 font-semibold';
-  if (cat === 'moderate' || cat === '3' || cat === '4' || cat === '5') return 'text-yellow-400 font-semibold';
-  if (cat === 'high' || cat === '6' || cat === '7' || cat === '8') return 'text-orange-400 font-semibold';
-  if (cat === 'very high' || cat === '9' || cat === '10') return 'text-red-400 font-semibold';
-  
-  return 'text-white font-semibold'; // Default fallback
+  const cat = typeof category === 'string' ? category.toLowerCase().trim() : category.toString();
+
+  if (cat === 'no data' || cat === 'unavailable' || cat === '0') {
+    return 'text-gray-400 font-semibold';
+  }
+  if (cat === 'none') return 'text-gray-400 font-semibold';
+  if (cat === 'very low' || cat === 'low' || cat === '1' || cat === '2') {
+    return 'text-green-400 font-semibold';
+  }
+  if (cat === 'moderate' || cat === '3' || cat === '4' || cat === '5') {
+    return 'text-yellow-400 font-semibold';
+  }
+  if (cat === 'high' || cat === '6' || cat === '7' || cat === '8') {
+    return 'text-orange-400 font-semibold';
+  }
+  if (cat === 'very high' || cat === '9' || cat === '10') {
+    return 'text-red-400 font-semibold';
+  }
+
+  return 'text-white font-semibold';
 };
 
 /**

--- a/lib/air-quality-utils.ts
+++ b/lib/air-quality-utils.ts
@@ -87,7 +87,7 @@ export const getAQISeverityChrome = (aqi: number): AQISeverityChrome => {
  * Get color class for pollen category level
  */
 export const getPollenColor = (category: string | number): string => {
-  const cat = typeof category === 'string' ? category.toLowerCase().trim() : category.toString();
+  const cat = typeof category === 'string' ? category.toLowerCase().trim() : String(category ?? '');
 
   if (cat === 'no data' || cat === 'unavailable' || cat === '0') {
     return 'text-gray-400 font-semibold';

--- a/lib/pollen/normalize-pollen-categories.ts
+++ b/lib/pollen/normalize-pollen-categories.ts
@@ -1,0 +1,24 @@
+export type PollenCategoryGroup = 'tree' | 'grass' | 'weed';
+
+const DEFAULT_LABEL: Record<PollenCategoryGroup, string> = {
+  tree: 'Tree',
+  grass: 'Grass',
+  weed: 'Weed',
+};
+
+/** Ensure each pollen group has at least one row when upstream succeeded. */
+export function normalizePollenCategories(
+  tree: Record<string, string>,
+  grass: Record<string, string>,
+  weed: Record<string, string>,
+): {
+  tree: Record<string, string>;
+  grass: Record<string, string>;
+  weed: Record<string, string>;
+} {
+  return {
+    tree: Object.keys(tree).length > 0 ? tree : { [DEFAULT_LABEL.tree]: 'None' },
+    grass: Object.keys(grass).length > 0 ? grass : { [DEFAULT_LABEL.grass]: 'None' },
+    weed: Object.keys(weed).length > 0 ? weed : { [DEFAULT_LABEL.weed]: 'None' },
+  };
+}

--- a/lib/pollen/normalize-pollen-categories.ts
+++ b/lib/pollen/normalize-pollen-categories.ts
@@ -17,8 +17,8 @@ export function normalizePollenCategories(
   weed: Record<string, string>;
 } {
   return {
-    tree: Object.keys(tree).length > 0 ? tree : { [DEFAULT_LABEL.tree]: 'None' },
-    grass: Object.keys(grass).length > 0 ? grass : { [DEFAULT_LABEL.grass]: 'None' },
-    weed: Object.keys(weed).length > 0 ? weed : { [DEFAULT_LABEL.weed]: 'None' },
+    tree: tree && Object.keys(tree).length > 0 ? tree : { [DEFAULT_LABEL.tree]: 'None' },
+    grass: grass && Object.keys(grass).length > 0 ? grass : { [DEFAULT_LABEL.grass]: 'None' },
+    weed: weed && Object.keys(weed).length > 0 ? weed : { [DEFAULT_LABEL.weed]: 'None' },
   };
 }


### PR DESCRIPTION
## Summary
- Normalize empty tree/grass/weed groups to `None` in the pollen API when Google or Open-Meteo returns partial data
- Treat `None` as a valid reading in `PollenDisplay` instead of showing misleading "No Data"
- Map `None`, `Very Low`, and `Unavailable` in `getPollenColor` for consistent muted/green styling

## Test plan
- [x] `npm test -- pollen-display-hotfix.test.ts`
- [x] `npm run typecheck`
- [ ] Manual: load home dashboard for Austin and confirm tree/weed show `None` with grass `Very Low` styled green


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved pollen data handling so missing tree, grass, or weed readings display as “None” instead of appearing blank.
  - Standardized pollen readings across supported weather data sources.
  - Improved pollen color styling for “Unavailable,” “No Data,” “None,” and “Very Low” values.
  - Preserved valid numeric severity levels and existing category readings.

- **Tests**
  - Added coverage for pollen category normalization and color mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->