### PR TITLE
Fix newsletter commits by installing gitleaks

### DIFF
--- a/.github/workflows/newsletter-sunday.yml
+++ b/.github/workflows/newsletter-sunday.yml
@@ -27,6 +27,21 @@ jobs:
 
       - run: npm ci
 
+      - name: Install gitleaks
+        env:
+          GITLEAKS_VERSION: '8.30.1'
+        run: |
+          set -euo pipefail
+          asset="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          url="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${asset}"
+          curl --fail --location --retry 3 --output "$asset" "$url"
+          printf '%s  %s\n' \
+            '551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb' \
+            "$asset" | sha256sum --check -
+          tar -xzf "$asset" gitleaks
+          sudo install -m 0755 gitleaks /usr/local/bin/gitleaks
+          gitleaks version
+
       - name: Generate Sunday post
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/newsletter-wednesday.yml
+++ b/.github/workflows/newsletter-wednesday.yml
@@ -27,6 +27,21 @@ jobs:
 
       - run: npm ci
 
+      - name: Install gitleaks
+        env:
+          GITLEAKS_VERSION: '8.30.1'
+        run: |
+          set -euo pipefail
+          asset="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          url="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${asset}"
+          curl --fail --location --retry 3 --output "$asset" "$url"
+          printf '%s  %s\n' \
+            '551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb' \
+            "$asset" | sha256sum --check -
+          tar -xzf "$asset" gitleaks
+          sudo install -m 0755 gitleaks /usr/local/bin/gitleaks
+          gitleaks version
+
       - name: Generate Wednesday post
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/__tests__/newsletter-workflows.test.ts
+++ b/__tests__/newsletter-workflows.test.ts
@@ -80,7 +80,7 @@ it('keeps the newsletter installer blocks identical', () => {
 
 it('rejects an installer block missing a required command', () => {
   const workflow = readWorkflow(WORKFLOW_FILES[0]).replace(
-    '          tar -xzf "$asset" gitleaks\n',
+    'tar -xzf "$asset" gitleaks',
     '',
   );
 

--- a/__tests__/newsletter-workflows.test.ts
+++ b/__tests__/newsletter-workflows.test.ts
@@ -8,6 +8,7 @@ const WORKFLOW_FILES = [
 const GITLEAKS_VERSION = '8.30.1';
 const GITLEAKS_CHECKSUM =
   '551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb';
+const SHELL_GITLEAKS_VERSION = ['$', '{GITLEAKS_VERSION}'].join('');
 const REQUIRED_INSTALLER_COMMANDS = [
   'curl --fail --location --retry 3 --output "$asset" "$url"',
   'sha256sum --check -',
@@ -54,7 +55,7 @@ describe.each(WORKFLOW_FILES)('%s', (workflowPath) => {
       `GITLEAKS_VERSION: '${GITLEAKS_VERSION}'`,
     );
     expect(installerBlock).toContain(
-      'asset="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"',
+      `asset="gitleaks_${SHELL_GITLEAKS_VERSION}_linux_x64.tar.gz"`,
     );
     expect(installerBlock).toContain(GITLEAKS_CHECKSUM);
     expectRequiredInstallerCommands(installerBlock);

--- a/__tests__/newsletter-workflows.test.ts
+++ b/__tests__/newsletter-workflows.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const WORKFLOW_FILES = [
+  '.github/workflows/newsletter-sunday.yml',
+  '.github/workflows/newsletter-wednesday.yml',
+];
+const GITLEAKS_VERSION = '8.30.1';
+const GITLEAKS_CHECKSUM =
+  '551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb';
+
+describe.each(WORKFLOW_FILES)('%s', (workflowPath) => {
+  const workflow = readFileSync(join(process.cwd(), workflowPath), 'utf8');
+
+  it('installs the pinned gitleaks release before generating content', () => {
+    expect(workflow).toContain("- name: Install gitleaks");
+    expect(workflow).toContain(`GITLEAKS_VERSION: '${GITLEAKS_VERSION}'`);
+    expect(workflow).toContain(
+      'asset="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"',
+    );
+    expect(workflow).toContain(GITLEAKS_CHECKSUM);
+    expect(workflow).toContain('sha256sum --check -');
+    expect(workflow.indexOf('- name: Install gitleaks')).toBeLessThan(
+      workflow.indexOf('- name: Generate '),
+    );
+  });
+
+  it('keeps the Husky secret scan enabled', () => {
+    expect(workflow).not.toMatch(/\bHUSKY=0\b/);
+    expect(workflow).not.toContain('--no-verify');
+  });
+});

--- a/__tests__/newsletter-workflows.test.ts
+++ b/__tests__/newsletter-workflows.test.ts
@@ -8,18 +8,56 @@ const WORKFLOW_FILES = [
 const GITLEAKS_VERSION = '8.30.1';
 const GITLEAKS_CHECKSUM =
   '551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb';
+const REQUIRED_INSTALLER_COMMANDS = [
+  'curl --fail --location --retry 3 --output "$asset" "$url"',
+  'sha256sum --check -',
+  'tar -xzf "$asset" gitleaks',
+  'sudo install -m 0755 gitleaks /usr/local/bin/gitleaks',
+  'gitleaks version',
+];
+
+function readWorkflow(workflowPath: string): string {
+  return readFileSync(join(process.cwd(), workflowPath), 'utf8');
+}
+
+function extractInstallerBlock(workflow: string): string {
+  const stepStart = workflow.indexOf('      - name: Install gitleaks');
+
+  expect(stepStart).toBeGreaterThanOrEqual(0);
+
+  const nextStep = workflow.indexOf('\n      - ', stepStart + 1);
+  return workflow.slice(stepStart, nextStep === -1 ? undefined : nextStep);
+}
+
+function expectRequiredInstallerCommands(installerBlock: string): void {
+  for (const command of REQUIRED_INSTALLER_COMMANDS) {
+    expect(installerBlock).toContain(command);
+  }
+}
+
+function normalizeInstallerBlock(installerBlock: string): string {
+  return installerBlock
+    .replaceAll('\r\n', '\n')
+    .split('\n')
+    .map((line) => line.trimEnd())
+    .join('\n')
+    .trim();
+}
 
 describe.each(WORKFLOW_FILES)('%s', (workflowPath) => {
-  const workflow = readFileSync(join(process.cwd(), workflowPath), 'utf8');
+  const workflow = readWorkflow(workflowPath);
 
   it('installs the pinned gitleaks release before generating content', () => {
-    expect(workflow).toContain("- name: Install gitleaks");
-    expect(workflow).toContain(`GITLEAKS_VERSION: '${GITLEAKS_VERSION}'`);
-    expect(workflow).toContain(
+    const installerBlock = extractInstallerBlock(workflow);
+
+    expect(installerBlock).toContain(
+      `GITLEAKS_VERSION: '${GITLEAKS_VERSION}'`,
+    );
+    expect(installerBlock).toContain(
       'asset="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"',
     );
-    expect(workflow).toContain(GITLEAKS_CHECKSUM);
-    expect(workflow).toContain('sha256sum --check -');
+    expect(installerBlock).toContain(GITLEAKS_CHECKSUM);
+    expectRequiredInstallerCommands(installerBlock);
     expect(workflow.indexOf('- name: Install gitleaks')).toBeLessThan(
       workflow.indexOf('- name: Generate '),
     );
@@ -29,4 +67,23 @@ describe.each(WORKFLOW_FILES)('%s', (workflowPath) => {
     expect(workflow).not.toMatch(/\bHUSKY=0\b/);
     expect(workflow).not.toContain('--no-verify');
   });
+});
+
+it('keeps the newsletter installer blocks identical', () => {
+  const installerBlocks = WORKFLOW_FILES.map(readWorkflow)
+    .map(extractInstallerBlock)
+    .map(normalizeInstallerBlock);
+
+  expect(installerBlocks[1]).toBe(installerBlocks[0]);
+});
+
+it('rejects an installer block missing a required command', () => {
+  const workflow = readWorkflow(WORKFLOW_FILES[0]).replace(
+    '          tar -xzf "$asset" gitleaks\n',
+    '',
+  );
+
+  expect(() =>
+    expectRequiredInstallerCommands(extractInstallerBlock(workflow)),
+  ).toThrow(/tar -xzf/);
 });

--- a/planning/newsletter-gitleaks-design.md
+++ b/planning/newsletter-gitleaks-design.md
@@ -1,0 +1,43 @@
+# Newsletter Gitleaks Setup Design
+
+## Problem
+
+The Sunday newsletter workflow generates and validates its post, then fails at
+`git commit` because the fail-closed Husky hook requires `gitleaks` and the
+GitHub-hosted runner does not install it. The Wednesday workflow uses the same
+commit path and is affected as well.
+
+## Design
+
+Add a setup step to both newsletter workflows before post generation. The step
+downloads a pinned official Linux x64 `gitleaks` release archive, verifies its
+published SHA-256 checksum, and installs the binary on the runner's `PATH`.
+The existing Husky hook remains enabled and performs the staged secret scan
+during `git commit`.
+
+The two workflow files will use the same version, asset name, checksum lookup,
+and installation commands so their behavior remains aligned.
+
+## Error Handling
+
+The setup step runs with shell error checking. A failed download, missing
+checksum, checksum mismatch, extraction failure, or installation failure stops
+the workflow before content generation or committing.
+
+## Verification
+
+- Add a static regression test that checks both newsletter workflows use the
+  same pinned version and Linux asset, verify the official SHA-256 checksum,
+  install `gitleaks` before content generation, and do not bypass Husky.
+- Run the regression test through a red-green cycle.
+- Run unit tests, workflow linting where available, local Playwright tests, and
+  dead-code detection.
+- After the change reaches `main`, start a fresh Sunday `workflow_dispatch`
+  run from updated `main`; rerunning the old run would reuse its broken workflow
+  definition.
+
+## Scope
+
+This change only updates the Sunday and Wednesday newsletter automation and its
+regression coverage. It does not weaken hooks, change newsletter generation, or
+recover the ephemeral post from the failed runner.

--- a/planning/newsletter-gitleaks-implementation-plan.md
+++ b/planning/newsletter-gitleaks-implementation-plan.md
@@ -1,0 +1,141 @@
+# Newsletter Gitleaks Setup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ensure both newsletter workflows can commit generated posts while preserving the fail-closed Husky secret scan.
+
+**Architecture:** Each workflow installs the same pinned official `gitleaks` Linux x64 binary before generating content. A Jest regression test reads the workflow definitions and enforces version, asset, checksum, ordering, and no-bypass requirements.
+
+**Tech Stack:** GitHub Actions YAML, Bash, gitleaks 8.30.1, Jest, TypeScript
+
+## Global Constraints
+
+- Pin `gitleaks` to version `8.30.1`.
+- Pin the official `gitleaks_8.30.1_linux_x64.tar.gz` SHA-256 digest to `551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb`.
+- Install before newsletter content generation.
+- Do not set `HUSKY=0` or use `git commit --no-verify`.
+- Keep Sunday and Wednesday setup commands identical.
+
+---
+
+### Task 1: Protect the Newsletter Workflow Security Contract
+
+**Files:**
+- Create: `__tests__/newsletter-workflows.test.ts`
+- Modify: `.github/workflows/newsletter-sunday.yml`
+- Modify: `.github/workflows/newsletter-wednesday.yml`
+
+**Interfaces:**
+- Consumes: the two newsletter workflow files as UTF-8 text.
+- Produces: CI workflows with `gitleaks` available on `PATH` before the Husky-protected commit.
+
+- [ ] **Step 1: Write the failing regression test**
+
+Create `__tests__/newsletter-workflows.test.ts`:
+
+```typescript
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const WORKFLOW_FILES = [
+  '.github/workflows/newsletter-sunday.yml',
+  '.github/workflows/newsletter-wednesday.yml',
+];
+const GITLEAKS_VERSION = '8.30.1';
+const GITLEAKS_CHECKSUM =
+  '551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb';
+
+describe.each(WORKFLOW_FILES)('%s', (workflowPath) => {
+  const workflow = readFileSync(join(process.cwd(), workflowPath), 'utf8');
+
+  it('installs the pinned gitleaks release before generating content', () => {
+    expect(workflow).toContain("- name: Install gitleaks");
+    expect(workflow).toContain(`GITLEAKS_VERSION: '${GITLEAKS_VERSION}'`);
+    expect(workflow).toContain(
+      'asset="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"',
+    );
+    expect(workflow).toContain(GITLEAKS_CHECKSUM);
+    expect(workflow).toContain('sha256sum --check -');
+    expect(workflow.indexOf('- name: Install gitleaks')).toBeLessThan(
+      workflow.indexOf('- name: Generate '),
+    );
+  });
+
+  it('keeps the Husky secret scan enabled', () => {
+    expect(workflow).not.toMatch(/\bHUSKY=0\b/);
+    expect(workflow).not.toContain('--no-verify');
+  });
+});
+```
+
+- [ ] **Step 2: Run the regression test and verify RED**
+
+Run:
+
+```bash
+npm test -- newsletter-workflows.test.ts --runInBand
+```
+
+Expected: both workflow cases fail because `- name: Install gitleaks` is absent.
+
+- [ ] **Step 3: Add the pinned installer to both workflows**
+
+Insert this step after `npm ci` and before each `Generate ... post` step:
+
+```yaml
+      - name: Install gitleaks
+        env:
+          GITLEAKS_VERSION: '8.30.1'
+        run: |
+          set -euo pipefail
+          asset="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          url="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${asset}"
+          curl --fail --location --retry 3 --output "$asset" "$url"
+          printf '%s  %s\n' \
+            '551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb' \
+            "$asset" | sha256sum --check -
+          tar -xzf "$asset" gitleaks
+          sudo install -m 0755 gitleaks /usr/local/bin/gitleaks
+          gitleaks version
+```
+
+- [ ] **Step 4: Run targeted verification and verify GREEN**
+
+Run:
+
+```bash
+npm test -- newsletter-workflows.test.ts --runInBand
+```
+
+Expected: 1 suite and 4 tests pass.
+
+- [ ] **Step 5: Run repository validation**
+
+Run:
+
+```bash
+npm run lint
+npm run typecheck
+npm test -- --runInBand
+npm run knip
+npx playwright test --project=chromium
+```
+
+Expected: all commands exit 0. If Playwright requires browsers, run `npx playwright install chromium` and retry once.
+
+- [ ] **Step 6: Review and commit**
+
+Review the staged and unstaged diff for correctness, security, type safety, test coverage, and repository conventions. Then commit:
+
+```bash
+git add \
+  __tests__/newsletter-workflows.test.ts \
+  .github/workflows/newsletter-sunday.yml \
+  .github/workflows/newsletter-wednesday.yml \
+  planning/newsletter-gitleaks-implementation-plan.md
+git commit -m "fix(ci): install gitleaks for newsletter commits"
+```
+
+- [ ] **Step 7: Push and open the PR**
+
+Push `fix/newsletter-gitleaks` and create a PR to `main` summarizing the root cause, both corrected workflows, regression coverage, and local checks. After merge, start a fresh Sunday workflow dispatch from `main` rather than rerunning run `29688586702`.


### PR DESCRIPTION
## Summary
- install pinned gitleaks 8.30.1 in both newsletter workflows before content generation
- verify the official Linux x64 SHA-256 checksum before installation
- add regression coverage for the complete installer contract, workflow parity, ordering, and Husky enforcement

## Root cause
The fail-closed Husky pre-commit hook introduced on main correctly refused to commit when gitleaks was unavailable. GitHub-hosted newsletter runners did not install gitleaks, so Sunday run 29688586702 generated and validated its post but failed before pushing a branch or opening a PR.

## Test plan
- [x] `npm run lint` (0 errors; 8 existing warnings)
- [x] `npm run typecheck`
- [x] `npm test -- --runInBand` (139 suites, 852 tests)
- [x] `npm run knip` (0 errors; 8 existing configuration hints)
- [x] local Chromium Playwright completed once with 58 passed and 2 skipped

## Known test instability
Later local Playwright reruns intermittently failed the existing aviation detail tests while all workflow, unit, type, lint, and dead-code checks remained clean. This PR does not modify application or aviation code.

After merge, start a fresh Sunday workflow dispatch from updated main. Rerunning the old failed run would reuse its original workflow definition.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Newsletter automation now installs and verifies the required secret-scanning tool before generating content, preventing workflow failures during commits.
  * Secret scanning remains enabled without bypasses.

* **Tests**
  * Added regression coverage to verify installation, version pinning, checksum validation, workflow ordering, and consistent configuration.

* **Documentation**
  * Added design and implementation guidance for maintaining secure newsletter workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->