### PR TITLE
Type-check on pre-push so CI is not the first sign of a type error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,7 @@ components/api-test.tsx
 
 # Build artifacts
 tsconfig.tsbuildinfo
+tsconfig.tests.tsbuildinfo
 playwright-report/
 test-results/
 results/

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -10,6 +10,9 @@
 
 # git feeds pre-push "<local ref> <local sha> <remote ref> <remote sha>" per ref.
 # A branch deletion has an all-zero local sha and nothing worth checking.
+#
+# Note: this blocks on EOF, so invoking the hook by hand (`sh .husky/pre-push`)
+# appears to hang until stdin is closed. Feed it a ref line or /dev/null.
 refs="$(cat)"
 if [ -n "$refs" ]; then
   deleting_only=1
@@ -49,6 +52,21 @@ else
 fi
 
 # ── 2. Types ─────────────────────────────────────────────────────────────────
+
+# Local-only. The newsletter workflows run `npm ci` (which installs husky) and
+# then `git push`, and they must not pass --no-verify or set HUSKY=0 — see
+# __tests__/newsletter-workflows.test.ts and planning/newsletter-gitleaks-design.md.
+# Without this guard those cron runs would compile the whole repo twice before
+# pushing, and a type error on main would fail the newsletter rather than the
+# change that introduced it. ci.yml already type-checks both projects on every
+# PR, so running it again here would be redundant as well as harmful.
+#
+# The secret scan above deliberately still runs in CI: that one is a security
+# gate, and the design doc requires those workflows to keep it.
+if [ -n "${CI:-}" ]; then
+  echo "[pre-push] CI detected - skipping type check (ci.yml covers it)"
+  exit 0
+fi
 
 if [ ! -x node_modules/.bin/tsc ]; then
   echo "[pre-push] TypeScript not installed - run 'npm ci' before pushing."

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,12 +1,38 @@
 #!/usr/bin/env sh
-# Block pushes that contain secrets anywhere in unpushed commits.
-# Backstop in case pre-commit was bypassed (--no-verify) or a different machine
-# committed without gitleaks installed.
+# Two gates before anything leaves this machine:
+#   1. Secret scan over the unpushed commits.
+#   2. Type check, so a red CI run isn't the first sign of a type error.
+#
+# Kept at push time rather than commit time: the type check costs a few seconds,
+# which is fine once per push but not on every commit.
+#
+# Bypass in a true emergency with `git push --no-verify`.
+
+# git feeds pre-push "<local ref> <local sha> <remote ref> <remote sha>" per ref.
+# A branch deletion has an all-zero local sha and nothing worth checking.
+refs="$(cat)"
+if [ -n "$refs" ]; then
+  deleting_only=1
+  while read -r _local_ref local_sha _rest; do
+    [ -z "$local_sha" ] && continue
+    case "$local_sha" in
+      *[!0]*) deleting_only=0 ;;
+    esac
+  done <<EOF
+$refs
+EOF
+  if [ "$deleting_only" = "1" ]; then
+    exit 0
+  fi
+fi
+
+# ── 1. Secrets ───────────────────────────────────────────────────────────────
 
 if ! command -v gitleaks >/dev/null 2>&1; then
   echo "[pre-push] gitleaks not installed. Install one of:"
   echo "  - macOS:        brew install gitleaks"
   echo "  - Debian/Ubuntu: sudo apt-get install gitleaks"
+  echo "  - Arch:         sudo pacman -S gitleaks"
   echo "  - Other:        https://github.com/gitleaks/gitleaks#installing"
   echo "[pre-push] refusing to push without a secret scan"
   exit 1
@@ -17,7 +43,32 @@ fi
 # history as a safe fallback.
 upstream="$(git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null || true)"
 if [ -n "$upstream" ]; then
-  gitleaks git --log-opts="${upstream}..HEAD" --redact -v --no-banner
+  gitleaks git --log-opts="${upstream}..HEAD" --redact -v --no-banner || exit 1
 else
-  gitleaks git --redact -v --no-banner
+  gitleaks git --redact -v --no-banner || exit 1
 fi
+
+# ── 2. Types ─────────────────────────────────────────────────────────────────
+
+if [ ! -x node_modules/.bin/tsc ]; then
+  echo "[pre-push] TypeScript not installed - run 'npm ci' before pushing."
+  echo "[pre-push] refusing to push without a type check"
+  exit 1
+fi
+
+# Same two projects CI type-checks (see .github/workflows/ci.yml). Run tsc
+# directly rather than via npm so the output is the compiler's, not a script
+# wrapper's.
+echo "[pre-push] type-checking app..."
+if ! node_modules/.bin/tsc --noEmit; then
+  echo "[pre-push] type errors above - push aborted (CI would fail on these)"
+  exit 1
+fi
+
+echo "[pre-push] type-checking tests..."
+if ! node_modules/.bin/tsc --noEmit -p tsconfig.tests.json; then
+  echo "[pre-push] type errors in tests above - push aborted"
+  exit 1
+fi
+
+echo "[pre-push] secrets + types ok"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ Use targeted commands first, then broaden validation when changing shared behavi
 - Use `gh` for GitHub workflow tasks when requested.
 - Before opening a PR, summarize what changed, why it changed, tests run, and known risks.
 - Do not push, open PRs, bypass hooks, delete files, or reset git state unless explicitly asked.
-- The pre-push hook runs gitleaks on unpushed commits; E2E and Lighthouse run in GitHub Actions.
+- The pre-push hook runs gitleaks on unpushed commits, then type-checks both TS projects (skipped when `CI` is set); E2E and Lighthouse run in GitHub Actions.
 
 ## Agent Operating Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,11 +48,16 @@ Hooks live in `.husky/` (installed via the `prepare` script):
 - `pre-commit` — gitleaks secret scan of the staged diff
 - `pre-push` — gitleaks secret scan of unpushed commits, then `tsc --noEmit`
   against both `tsconfig.json` and `tsconfig.tests.json` (the same two projects
-  CI type-checks). Roughly 4s. Skipped entirely when the push only deletes refs.
+  CI type-checks)
 
-Both hooks hard-fail if `gitleaks` is not installed; pre-push also hard-fails if
-`node_modules/.bin/tsc` is missing (run `npm ci`). Bypass in an emergency with
-`git commit --no-verify` / `git push --no-verify`.
+The type check is local-only: it is skipped when `CI` is set, because `ci.yml`
+already type-checks both projects and the newsletter workflows push from CI
+without being allowed to bypass hooks. The secret scan always runs there.
+
+A push that only deletes refs skips both gates — a deletion sends no objects.
+Otherwise both hooks hard-fail if `gitleaks` is not installed, and pre-push also
+hard-fails if `node_modules/.bin/tsc` is missing (run `npm ci`). Bypass in an
+emergency with `git commit --no-verify` / `git push --no-verify`.
 
 Note: `tsconfig.json` excludes all test files and `tsconfig.tests.json` includes
 only a handful by name, so neither the hook nor CI type-checks most of

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,17 @@ npm run lighthouse       # Lighthouse CI only
 
 Hooks live in `.husky/` (installed via the `prepare` script):
 - `pre-commit` — gitleaks secret scan of the staged diff
-- `pre-push` — gitleaks secret scan of unpushed commits
+- `pre-push` — gitleaks secret scan of unpushed commits, then `tsc --noEmit`
+  against both `tsconfig.json` and `tsconfig.tests.json` (the same two projects
+  CI type-checks). Roughly 4s. Skipped entirely when the push only deletes refs.
+
+Both hooks hard-fail if `gitleaks` is not installed; pre-push also hard-fails if
+`node_modules/.bin/tsc` is missing (run `npm ci`). Bypass in an emergency with
+`git commit --no-verify` / `git push --no-verify`.
+
+Note: `tsconfig.json` excludes all test files and `tsconfig.tests.json` includes
+only a handful by name, so neither the hook nor CI type-checks most of
+`__tests__/`. Widening it is tracked separately.
 
 E2E (Playwright) and Lighthouse CI run in GitHub Actions
 (`.github/workflows/`), not in local hooks. Lighthouse config: `lighthouserc.js`.

--- a/CODING.md
+++ b/CODING.md
@@ -166,7 +166,14 @@ Use this order:
 Hooks live in `.husky/` (installed via the `prepare` script):
 
 - `pre-commit` — gitleaks secret scan of the staged diff
-- `pre-push` — gitleaks secret scan of unpushed commits
+- `pre-push` — gitleaks secret scan of unpushed commits, then `tsc --noEmit`
+  against both `tsconfig.json` and `tsconfig.tests.json` (the same two projects
+  CI type-checks)
+
+The pre-push type check is local-only: it is skipped when `CI` is set, because
+`ci.yml` already type-checks both projects, and the newsletter workflows push
+from CI without being allowed to bypass hooks. The secret scan always runs.
+Pushes that only delete refs skip both gates — a deletion sends no objects.
 
 E2E (Playwright) and Lighthouse CI run in GitHub Actions (`.github/workflows/`), not in local hooks. Lighthouse config: `lighthouserc.js`.
 

--- a/__tests__/pre-push-hook.test.ts
+++ b/__tests__/pre-push-hook.test.ts
@@ -1,0 +1,102 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Static regression coverage for .husky/pre-push, in the same style as
+ * newsletter-workflows.test.ts.
+ *
+ * The hook cannot be exercised in-process — it shells out to gitleaks and tsc —
+ * so these assertions pin the properties that are easy to break by editing the
+ * script and hard to notice afterwards.
+ */
+
+const HOOK_PATH = '.husky/pre-push';
+
+function readHook(): string {
+  return readFileSync(join(process.cwd(), HOOK_PATH), 'utf8');
+}
+
+describe('.husky/pre-push', () => {
+  const hook = readHook();
+
+  describe('secret scan', () => {
+    it('refuses to push when gitleaks is absent', () => {
+      expect(hook).toContain('command -v gitleaks');
+      expect(hook).toContain('refusing to push without a secret scan');
+    });
+
+    it('propagates a gitleaks failure instead of falling through', () => {
+      // gitleaks is no longer the last command in the script, so its exit status
+      // is not the script's. Without `|| exit 1` a detected leak would be pushed.
+      const gitleaksCalls = hook.match(/^\s*gitleaks git .*$/gm) ?? [];
+      expect(gitleaksCalls.length).toBeGreaterThan(0);
+      for (const call of gitleaksCalls) {
+        expect(call).toContain('|| exit 1');
+      }
+    });
+
+    it('scans full history when the branch has no upstream', () => {
+      expect(hook).toContain('@{u}');
+      expect(hook).toMatch(/gitleaks git --redact/);
+    });
+  });
+
+  describe('type check', () => {
+    it('runs the same two projects CI type-checks', () => {
+      expect(hook).toContain('node_modules/.bin/tsc --noEmit');
+      expect(hook).toContain('tsc --noEmit -p tsconfig.tests.json');
+    });
+
+    it('refuses to push when tsc is absent rather than skipping silently', () => {
+      expect(hook).toContain('node_modules/.bin/tsc');
+      expect(hook).toContain('refusing to push without a type check');
+    });
+
+    it('is skipped under CI', () => {
+      // The newsletter workflows run `npm ci` (installing husky) and then
+      // `git push`, and newsletter-workflows.test.ts forbids them from passing
+      // --no-verify or setting HUSKY=0. Without this guard every newsletter run
+      // would compile the repo twice, and a type error on main would fail the
+      // newsletter instead of the change that introduced it.
+      expect(hook).toMatch(/\[ -n "\$\{CI:-\}" \]/);
+      expect(hook).toContain('skipping type check');
+    });
+
+    it('still runs the secret scan under CI', () => {
+      // The CI early-exit must sit AFTER the gitleaks gate: that one is a
+      // security control the newsletter design doc requires those runs to keep.
+      const gitleaksIdx = hook.indexOf('command -v gitleaks');
+      const ciGuardIdx = hook.search(/\[ -n "\$\{CI:-\}" \]/);
+      expect(gitleaksIdx).toBeGreaterThan(-1);
+      expect(ciGuardIdx).toBeGreaterThan(-1);
+      expect(gitleaksIdx).toBeLessThan(ciGuardIdx);
+    });
+  });
+
+  describe('delete-only pushes', () => {
+    it('exits early when every pushed ref has an all-zero local sha', () => {
+      expect(hook).toContain('deleting_only');
+      // The all-zero test must use POSIX `!` negation, not bash's `^`.
+      expect(hook).toContain('*[!0]*');
+    });
+
+    it('reads the ref list without a pipeline', () => {
+      // A `while read ... | ` pipeline would run the loop in a subshell and
+      // discard deleting_only, silently defeating the early exit.
+      expect(hook).toContain('<<EOF');
+      expect(hook).not.toMatch(/\|\s*while read/);
+    });
+  });
+
+  describe('portability', () => {
+    it('targets POSIX sh, not bash', () => {
+      expect(hook.startsWith('#!/usr/bin/env sh')).toBe(true);
+    });
+
+    it('avoids bash-only constructs', () => {
+      expect(hook).not.toContain('[[');
+      expect(hook).not.toContain('<<<');
+      expect(hook).not.toMatch(/\bdeclare -/);
+    });
+  });
+});

--- a/planning/prds/PRD-news-overhaul.md
+++ b/planning/prds/PRD-news-overhaul.md
@@ -6,7 +6,7 @@
 **Project:** 16-Bit Weather (16bitweather.co)
 **Branch:** `feat/news-overhaul`
 **Priority:** High (3 of 17 live feeds are broken in production; ~1,500 LOC of dead code)
-**Lighthouse Gate:** Performance score must remain >= 85 on mobile and desktop after all changes (per `lighthouserc.js` / pre-push hook).
+**Lighthouse Gate:** Performance score must remain >= 85 on mobile and desktop after all changes (per `lighthouserc.js`, enforced by the Lighthouse CI workflow).
 
 ---
 
@@ -321,8 +321,8 @@ A reusable `scripts/check-news-feeds.ts` (run via `tsx`) that imports `FEED_SOUR
 - `npm run lint` passes.
 - `npm test` passes (new parser/dedup/cache tests green).
 - `npm run knip` reports no new unused files/exports; orphaned subsystem gone.
-- Playwright `/news` smoke passes (pre-push hook).
-- Lighthouse performance >= 85 mobile and desktop (pre-push hook).
+- Playwright `/news` smoke passes (E2E workflow).
+- Lighthouse performance >= 85 mobile and desktop (Lighthouse CI workflow).
 - All enabled feeds 2xx via `scripts/check-news-feeds.ts`.
 - No `NEWS_API_KEY` reference remains in code or required-env docs.
 


### PR DESCRIPTION
The git hooks only scanned for secrets, so nothing stopped a type-broken commit locally — you found out when CI went red. `pre-push` now type-checks after the gitleaks scan.

## What it does

Runs `tsc --noEmit` against the same two projects CI type-checks (`tsconfig.json` and `tsconfig.tests.json`), after the existing secret scan.

Push time rather than commit time, deliberately: the check costs about 4 seconds, which is fine once per push but would be intrusive on every commit. The pre-commit secret scan stays under 100ms and is untouched.

Behaviour details:

- Skipped entirely when the push only deletes refs (`git push --delete`), so a branch cleanup doesn't pay for a compile.
- Hard-fails if `node_modules/.bin/tsc` is missing, with an instruction to run `npm ci`. Pushing code whose types were never checked is the thing this is meant to prevent, so it does not silently pass.
- `git push --no-verify` remains the escape hatch, same as before.
- Added `sudo pacman -S gitleaks` to the install hints, since that was the missing piece on this machine.

Also gitignores `tsconfig.tests.tsbuildinfo`, which the tests-project check now generates on every push.

## Verification

Ran the hook directly rather than trusting it by inspection:

- Clean tree: passes, exits 0.
- Deliberate type error in `lib/utils.ts`: blocked, exit 1, compiler error shown.
- Delete-only push: exits 0 without running either gate.
- This PR's own push exercised it end to end.

## A gap this surfaced, left for a follow-up

The hook covers app code fully, but it turns out **most test files are type-checked by nothing** — not by this hook, and not by CI:

- `tsconfig.json` excludes `__tests__/**` and every `*.test.ts` / `*.spec.ts`.
- `tsconfig.tests.json` includes only 4 test files by name.

So roughly 146 of 150 test files have never been type-checked. I confirmed this by adding a deliberate type error to a test file and watching `typecheck:tests` pass.

Measured cost of closing it, so the decision is informed rather than a guess: add `"@testing-library/jest-dom"` to the tests project's `types` and widen its `include` to all of `__tests__/**`. That surfaces 10 pre-existing type errors across 4 files — `aviation-alerts-route` (reading `res.headers['Cache-Control']` as an index rather than `.get()`), `flight-lookup-service` (a mock whose `status` widens to `string`), `generate-blog-post-spotlight` (an unintentional comparison), `news-rss-route` (an over-narrow cast), and `open-meteo-adapter` (six possibly-undefined accesses).

All type-level and mechanical, but it is a distinct piece of work from adding the hook, so it is not in this PR. Happy to do it next if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)