### PR TITLE
fix(e2e): stabilize aviation Demo data badge on Vercel preview

### DIFF
--- a/tests/e2e/aviation.spec.ts
+++ b/tests/e2e/aviation.spec.ts
@@ -245,6 +245,15 @@ test.describe('/aviation', () => {
 
     const flightInput = page.getByTestId('flight-number-input');
     await expect(flightInput).toBeVisible({ timeout: 30000 });
+
+    // Force mock routes so the Demo badge appears even when AeroAPI is configured
+    // (e.g. Vercel preview). Without this, live AA123 responses omit `mock: true`.
+    const demoToggle = page.getByTestId('aviation-demo-mode-toggle');
+    await expect(demoToggle).toBeVisible();
+    if (!(await demoToggle.isChecked())) {
+      await demoToggle.check();
+    }
+
     await flightInput.fill('AA123');
     await page.getByTestId('flight-search-button').click();
     await expect(page.getByText(/Demo data/i)).toBeVisible({ timeout: 15000 });


### PR DESCRIPTION
## Summary
- Fixes the flaky `e2e-preview` failure from #505: `detail console reveals flight lookup demo badge`.
- Enables the aviation demo-mode toggle before searching so `/api/aviation/flight-lookup` always gets `mock=1` and the UI shows the Demo data badge, even when AeroAPI is configured on Vercel preview.

## Test plan
- [x] `npx playwright test tests/e2e/aviation.spec.ts --project=chromium -g "demo badge"`
- [ ] Confirm `e2e-preview` passes on this PR


Made with [Cursor](https://cursor.com)