### PR TITLE
fix(news): hazard image honesty (no SF-1906 stand-ins)

### DIFF
--- a/__tests__/news-card.test.tsx
+++ b/__tests__/news-card.test.tsx
@@ -98,4 +98,24 @@ describe('NewsCard default variant', () => {
     fireEvent.click(link);
     expect(openSpy).toHaveBeenCalledTimes(1);
   });
+
+  it('shows a data-forward magnitude banner for imageless earthquakes', () => {
+    render(
+      <NewsCard
+        item={makeItem({
+          imageUrl: undefined,
+          category: 'earthquakes',
+          title: 'M 5.1 - south of Tonga',
+          magnitude: 5.1,
+          depth: 10,
+          location: 'south of Tonga',
+        })}
+      />,
+    );
+
+    expect(screen.getByTestId('news-card-data-banner')).toHaveTextContent('M5.1');
+    expect(screen.getByTestId('news-card-data-banner')).toHaveTextContent('south of Tonga');
+    expect(screen.getByTestId('news-card-data-banner')).toHaveTextContent('10.0 km depth');
+    expect(screen.queryByRole('img')).toBeNull();
+  });
 });

--- a/__tests__/news-card.test.tsx
+++ b/__tests__/news-card.test.tsx
@@ -113,9 +113,17 @@ describe('NewsCard default variant', () => {
       />,
     );
 
-    expect(screen.getByTestId('news-card-data-banner')).toHaveTextContent('M5.1');
-    expect(screen.getByTestId('news-card-data-banner')).toHaveTextContent('south of Tonga');
-    expect(screen.getByTestId('news-card-data-banner')).toHaveTextContent('10.0 km depth');
+    const banner = screen.getByTestId('news-card-data-banner');
+    expect(banner).toHaveTextContent('M5.1');
+    expect(banner).toHaveTextContent('south of Tonga');
+    expect(banner).toHaveTextContent('10.0 km depth');
+    expect(banner).not.toHaveAttribute('aria-hidden', 'true');
     expect(screen.queryByRole('img')).toBeNull();
+  });
+
+  it('keeps decorative category banners hidden from assistive tech', () => {
+    render(<NewsCard item={makeItem({ imageUrl: undefined, category: 'severe' })} />);
+
+    expect(screen.getByTestId('news-card-data-banner')).toHaveAttribute('aria-hidden', 'true');
   });
 });

--- a/__tests__/rss-image-enrichment.test.ts
+++ b/__tests__/rss-image-enrichment.test.ts
@@ -1,11 +1,13 @@
 import { parseOgImageFromHtml, shouldAttemptOgImage } from '@/lib/services/rss/resolve-og-image';
 import {
   getCategoryStockImage,
+  pickCategoryStockImage,
   pickSevereStockImage,
   pickTropicalStockImage,
   pickVolcanoStockImage,
   resolveNhcOutlookImage,
   resolveNwsAlertImage,
+  CATEGORY_STOCK_IMAGES,
   SEVERE_STOCK_POOL,
   TROPICAL_STOCK_POOL,
   VOLCANO_STOCK_POOL,
@@ -73,27 +75,29 @@ describe('parseRSSFeed image extraction', () => {
 });
 
 describe('category stock images', () => {
-  it('provides a fallback image for every category', () => {
-    for (const category of [
-      'severe',
-      'hurricanes',
-      'earthquakes',
-      'volcanoes',
-      'space',
-      'climate',
-      'science',
-    ] as const) {
-      expect(getCategoryStockImage(category).url).toMatch(/^https:\/\//);
+  it('provides editorial stock for non-hazard categories only', () => {
+    for (const category of ['space', 'climate', 'science'] as const) {
+      expect(getCategoryStockImage(category)?.url).toMatch(/^https:\/\//);
     }
+    expect(getCategoryStockImage('earthquakes')).toBeUndefined();
+    expect(getCategoryStockImage('volcanoes')).toBeUndefined();
   });
 
-  it('assigns different volcano stock art per peak name', () => {
-    const greatSitkin = pickVolcanoStockImage('Great Sitkin');
-    const kupreanof = pickVolcanoStockImage('Kupreanof');
-    const kilauea = pickVolcanoStockImage('Kilauea');
+  it('never falls back to the 1906 San Francisco earthquake photo', () => {
+    expect(pickCategoryStockImage('earthquakes', 'M 5.1 - south of Tonga')).toBeUndefined();
+    expect(pickCategoryStockImage('earthquakes', 'M 4.6 - 79 km E of Onagawa Chō, Japan')).toBeUndefined();
+    const urls = JSON.stringify(CATEGORY_STOCK_IMAGES);
+    expect(urls).not.toMatch(/1906_San_Francisco/);
+  });
 
-    expect(greatSitkin.url).not.toBe(kupreanof.url);
-    expect(kilauea.url).toContain('Puu_Oo');
+  it('only returns volcano stock for accurately named peaks', () => {
+    const kilauea = pickVolcanoStockImage('Kilauea');
+    expect(kilauea?.url).toContain('Puu_Oo');
+
+    // Unknown / previously mis-mapped peaks stay imageless
+    expect(pickVolcanoStockImage('Great Sitkin')).toBeUndefined();
+    expect(pickVolcanoStockImage('Kupreanof')).toBeUndefined();
+    expect(pickCategoryStockImage('volcanoes', 'Great Sitkin')).toBeUndefined();
     expect(VOLCANO_STOCK_POOL.length).toBeGreaterThanOrEqual(6);
   });
 

--- a/components/news/NewsCard.tsx
+++ b/components/news/NewsCard.tsx
@@ -166,6 +166,9 @@ export default function NewsCard({ item, variant = 'default', className }: NewsC
   const showImage = Boolean(item.imageUrl) && !imageError;
   const categoryConfig = getCategoryConfig(item.category);
   const CategoryIcon = categoryConfig.icon;
+  const earthquakeMagnitude =
+    item.category === 'earthquakes' ? item.magnitude : undefined;
+  const showEarthquakeData = earthquakeMagnitude != null;
 
   return (
     <Card
@@ -206,16 +209,18 @@ export default function NewsCard({ item, variant = 'default', className }: NewsC
         <div
           className={cn(
             'relative w-full border-b-2 flex items-center justify-center',
-            item.category === 'earthquakes' && item.magnitude != null ? 'h-28' : 'h-24',
+            showEarthquakeData ? 'h-28' : 'h-24',
             categoryConfig.colorClass
           )}
           data-testid="news-card-data-banner"
-          aria-hidden="true"
+          // Magnitude/location/depth are real content for SR users; only the
+          // decorative category-icon banner stays hidden.
+          aria-hidden={!showEarthquakeData}
         >
-          {item.category === 'earthquakes' && item.magnitude != null ? (
+          {showEarthquakeData ? (
             <div className="flex flex-col items-center gap-0.5 px-3 text-center font-mono">
               <span className="text-3xl sm:text-4xl font-bold leading-none tracking-tight">
-                M{item.magnitude.toFixed(1)}
+                M{earthquakeMagnitude.toFixed(1)}
               </span>
               {item.location ? (
                 <span className="text-xs opacity-90 line-clamp-1 max-w-full">{item.location}</span>
@@ -225,7 +230,7 @@ export default function NewsCard({ item, variant = 'default', className }: NewsC
               ) : null}
             </div>
           ) : (
-            <CategoryIcon className="w-10 h-10 opacity-90" />
+            <CategoryIcon className="w-10 h-10 opacity-90" aria-hidden="true" />
           )}
           <div className="absolute top-2 right-2 flex gap-2">
             <PriorityIndicator priority={item.priority} size="md" />

--- a/components/news/NewsCard.tsx
+++ b/components/news/NewsCard.tsx
@@ -109,10 +109,16 @@ export default function NewsCard({ item, variant = 'default', className }: NewsC
               <div
                 className={cn(
                   'w-16 h-16 flex-shrink-0 border-2 rounded flex items-center justify-center',
-                  'border-border'
+                  'border-border',
+                  item.category === 'earthquakes' && item.magnitude != null && 'bg-orange-600/20'
                 )}
+                data-testid="news-card-compact-data"
               >
-                <CategoryBadge category={item.category} />
+                {item.category === 'earthquakes' && item.magnitude != null ? (
+                  <span className="font-mono font-bold text-sm">M{item.magnitude.toFixed(1)}</span>
+                ) : (
+                  <CategoryBadge category={item.category} />
+                )}
               </div>
             )}
 
@@ -194,17 +200,33 @@ export default function NewsCard({ item, variant = 'default', className }: NewsC
           </div>
         </div>
       ) : (
-        // Most feed items (USGS/NWS/NHC data feeds) have no image. Rather than
-        // a blank card, show a category-colored banner with the category icon so
-        // imageless cards read as deliberate and stay scannable by category.
+        // Hazard items without provenance-bound imagery stay imageless on
+        // purpose. Earthquakes get a data-forward magnitude panel; other
+        // categories keep the category icon banner.
         <div
           className={cn(
-            'relative w-full h-24 flex items-center justify-center border-b-2',
+            'relative w-full border-b-2 flex items-center justify-center',
+            item.category === 'earthquakes' && item.magnitude != null ? 'h-28' : 'h-24',
             categoryConfig.colorClass
           )}
+          data-testid="news-card-data-banner"
           aria-hidden="true"
         >
-          <CategoryIcon className="w-10 h-10 opacity-90" />
+          {item.category === 'earthquakes' && item.magnitude != null ? (
+            <div className="flex flex-col items-center gap-0.5 px-3 text-center font-mono">
+              <span className="text-3xl sm:text-4xl font-bold leading-none tracking-tight">
+                M{item.magnitude.toFixed(1)}
+              </span>
+              {item.location ? (
+                <span className="text-xs opacity-90 line-clamp-1 max-w-full">{item.location}</span>
+              ) : null}
+              {typeof item.depth === 'number' ? (
+                <span className="text-[10px] opacity-75">{item.depth.toFixed(1)} km depth</span>
+              ) : null}
+            </div>
+          ) : (
+            <CategoryIcon className="w-10 h-10 opacity-90" />
+          )}
           <div className="absolute top-2 right-2 flex gap-2">
             <PriorityIndicator priority={item.priority} size="md" />
           </div>

--- a/lib/news/stock-images.ts
+++ b/lib/news/stock-images.ts
@@ -1,7 +1,13 @@
 /**
- * Photorealistic fallback imagery per hazard category when a story has no
- * feed or OG image. Volcano items rotate through a pool keyed by volcano name
- * so concurrent alerts do not all show the same St. Helens photo.
+ * Fallback imagery when a story has no feed / OG / provenance-bound product.
+ *
+ * Image honesty (hazard spine):
+ * - Earthquakes: never use place-specific historical stock. Prefer USGS
+ *   ShakeMap; otherwise leave imageless for a data-forward card.
+ * - Volcanoes: only named peaks with a photo of that peak; no hash pool of
+ *   unrelated eruptions standing in for Aleutian alerts.
+ * - Severe / tropical: live GOES / SPC / NHC products (provenance-bound).
+ * - Science / climate / space: illustrative stock is allowed (credit later).
  */
 import type { FeedCategory } from '@/lib/services/rss/feedSources';
 
@@ -10,7 +16,8 @@ export interface StockImage {
   credit: string;
 }
 
-export const CATEGORY_STOCK_IMAGES: Record<FeedCategory, StockImage> = {
+/** Editorial / live-product stock only. Hazards omitted on purpose. */
+export const CATEGORY_STOCK_IMAGES: Partial<Record<FeedCategory, StockImage>> = {
   severe: {
     url: 'https://cdn.star.nesdis.noaa.gov/GOES16/ABI/CONUS/GEOCOLOR/1250x750.jpg',
     credit: 'NOAA GOES-16 GeoColor',
@@ -18,14 +25,6 @@ export const CATEGORY_STOCK_IMAGES: Record<FeedCategory, StockImage> = {
   hurricanes: {
     url: 'https://www.nhc.noaa.gov/xgtwo/resize/xgtwo_atl_2d0_w1024.png',
     credit: 'NHC / NOAA',
-  },
-  earthquakes: {
-    url: 'https://commons.wikimedia.org/wiki/Special:FilePath/1906_San_Francisco_earthquake.jpg?width=1280',
-    credit: 'USGS / Wikimedia Commons',
-  },
-  volcanoes: {
-    url: 'https://commons.wikimedia.org/wiki/Special:FilePath/MSH80_eruption_mount_st_helens_05-18-80.jpg?width=1280',
-    credit: 'USGS / Wikimedia Commons',
   },
   space: {
     url: 'https://sdo.gsfc.nasa.gov/assets/img/latest/latest_1024_0193.jpg',
@@ -41,7 +40,10 @@ export const CATEGORY_STOCK_IMAGES: Record<FeedCategory, StockImage> = {
   },
 };
 
-/** Diverse PD volcano photography — index chosen by volcano name hash. */
+/**
+ * Retained for tests / future curated use. Not used as a blind hash fallback —
+ * that caused St. Helens / Pinatubo / Tambora to stand in for unrelated peaks.
+ */
 export const VOLCANO_STOCK_POOL: StockImage[] = [
   {
     url: 'https://commons.wikimedia.org/wiki/Special:FilePath/MSH80_eruption_mount_st_helens_05-18-80.jpg?width=1280',
@@ -77,7 +79,7 @@ export const VOLCANO_STOCK_POOL: StockImage[] = [
   },
 ];
 
-/** Well-known volcanoes get a distinctive photo instead of a hash collision. */
+/** Only peaks whose photo is actually of that volcano. */
 export const NAMED_VOLCANO_IMAGES: Record<string, StockImage> = {
   kilauea: {
     url: 'https://commons.wikimedia.org/wiki/Special:FilePath/Puu_Oo_crater_bench_lava_lake.jpg?width=1280',
@@ -90,14 +92,6 @@ export const NAMED_VOLCANO_IMAGES: Record<string, StockImage> = {
   shishaldin: {
     url: 'https://commons.wikimedia.org/wiki/Special:FilePath/Shishaldin_Volcano_from_the_ISS.jpg?width=1280',
     credit: 'NASA ISS',
-  },
-  'great sitkin': {
-    url: 'https://commons.wikimedia.org/wiki/Special:FilePath/Pinatubo91eruption_clark_air_base.jpg?width=1280',
-    credit: 'USGS',
-  },
-  kupreanof: {
-    url: 'https://commons.wikimedia.org/wiki/Special:FilePath/Mount_Tambora_Volcano,_Sumbawa_Island,_Indonesia.jpg?width=1280',
-    credit: 'NASA Earth Observatory',
   },
   'mount st. helens': {
     url: 'https://commons.wikimedia.org/wiki/Special:FilePath/MSH80_eruption_mount_st_helens_05-18-80.jpg?width=1280',
@@ -130,25 +124,26 @@ function hashSeed(seed: string): number {
   return Math.abs(hash);
 }
 
-export function pickVolcanoStockImage(locationOrId: string): StockImage {
+/** Named-peak photo only; unknown peaks stay imageless (data-forward card). */
+export function pickVolcanoStockImage(locationOrId: string): StockImage | undefined {
   const key = normalizeVolcanoKey(locationOrId);
-  const named = NAMED_VOLCANO_IMAGES[key];
-  if (named) return named;
-
-  const idx = hashSeed(key) % VOLCANO_STOCK_POOL.length;
-  return VOLCANO_STOCK_POOL[idx];
+  return NAMED_VOLCANO_IMAGES[key];
 }
 
-export function getCategoryStockImage(category: FeedCategory): StockImage {
+export function getCategoryStockImage(category: FeedCategory): StockImage | undefined {
   return CATEGORY_STOCK_IMAGES[category];
 }
 
-/** Pick stock art; volcano, tropical, and severe categories use richer pools. */
+/**
+ * Optional stock art. Returns undefined for earthquakes and unnamed volcanoes
+ * so cards never show a wrong-place historical catastrophe photo.
+ */
 export function pickCategoryStockImage(
   category: FeedCategory,
   seed: string,
   sourceId?: string,
-): StockImage {
+): StockImage | undefined {
+  if (category === 'earthquakes') return undefined;
   if (category === 'volcanoes') return pickVolcanoStockImage(seed);
   if (category === 'hurricanes') return pickTropicalStockImage(seed, sourceId);
   if (category === 'severe') return pickSevereStockImage(seed, sourceId);

--- a/lib/services/rss/enrich-images.ts
+++ b/lib/services/rss/enrich-images.ts
@@ -45,7 +45,7 @@ export async function enrichItemImages(
     if (item.imageUrl) continue;
     const stockSeed = item.category === 'volcanoes' ? (item.location ?? item.id) : item.title;
     item.imageUrl = resolved.get(item.id)
-      ?? pickCategoryStockImage(item.category, stockSeed, item.sourceId).url;
+      ?? pickCategoryStockImage(item.category, stockSeed, item.sourceId)?.url;
   }
 
   return result;


### PR DESCRIPTION
## Summary

- **Hard C hybrid rule:** hazard cards use provenance-bound imagery (e.g. USGS ShakeMap, named-peak photos) or stay imageless with data-forward panels for earthquakes and unnamed volcanoes—no generic historical catastrophe stock.
- **Stock mapping:** removed `CATEGORY_STOCK` defaults for earthquakes and volcanoes; volcano art only when a curated photo matches the named peak (dropped mis-mapped Great Sitkin / Kupreanof stand-ins).
- **NewsCard:** imageless earthquakes show a magnitude / location / depth banner instead of a category icon placeholder.
- **Tests:** rss image enrichment and NewsCard coverage updated for the new honesty rules.

## Follow-up

Separate branch `fix/news-prd-feed-health` for PRD amend, weekly feed check, and image credits.

## Test plan

- [ ] `npm test -- rss-image-enrichment.test.ts news-card.test.tsx`
- [ ] Spot-check news feed for recent USGS quakes (imageless data banner or ShakeMap when present)
- [ ] Spot-check volcano items without named peak match (no St. Helens / SF-1906 stand-ins)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Earthquake cards now display magnitude, location, and depth when no image is available.
  * Earthquake and volcano stories remain imageless unless a specifically mapped image exists.
  * Imageless earthquake details are now accessible to assistive technologies.

* **Bug Fixes**
  * Prevented image enrichment errors when no suitable stock image is available.
  * Removed incorrect fallback images for unknown volcanoes and hazard-related categories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->