### PR TITLE
docs(news): Hard C PRD amendment + weekly feed health

### DIFF
--- a/.github/workflows/news-feed-health.yml
+++ b/.github/workflows/news-feed-health.yml
@@ -1,0 +1,30 @@
+name: News Feed Health
+
+# Weekly probe of enabled RSS/Atom/JSON sources used by /news.
+# Fails the job when any enabled feed is non-2xx or returns a mismatched body
+# so silent outages (like the old NWS CAP decommission) surface without a human
+# remembering to run scripts/check-news-feeds.ts.
+
+on:
+  schedule:
+    - cron: '0 15 * * 1' # Mondays 15:00 UTC
+  workflow_dispatch:
+
+jobs:
+  check-feeds:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - name: Check enabled news feeds
+        run: npx tsx scripts/check-news-feeds.ts

--- a/planning/prds/PRD-news-overhaul.md
+++ b/planning/prds/PRD-news-overhaul.md
@@ -1,12 +1,63 @@
 # PRD: News Section Overhaul — Earth & Space Hazard Feed
 
-**Version:** 1.0
-**Date:** 2026-05-29
+**Version:** 1.1 (amendment)
+**Date:** 2026-05-29 (v1.0); amended 2026-08-04
 **Author:** Justin Elrod / Claude Analysis
 **Project:** 16-Bit Weather (16bitweather.co)
-**Branch:** `feat/news-overhaul`
-**Priority:** High (3 of 17 live feeds are broken in production; ~1,500 LOC of dead code)
+**Priority:** High (v1.0); follow-through after Phases 1–3 shipped
 **Lighthouse Gate:** Performance score must remain >= 85 on mobile and desktop after all changes (per `lighthouserc.js`, enforced by the Lighthouse CI workflow).
+
+---
+
+## Amendment (2026-08-04) — product identity + image honesty
+
+### Status of v1.0 phases
+
+Phases **1–3 are shipped** in production code. Do **not** re-implement them from the body below without verifying against `main`:
+
+| Phase | Intent | Status |
+|---|---|---|
+| 1 | Feed remediation + Sentry feed health + `scripts/check-news-feeds.ts` | Done |
+| 2 | Delete orphaned NewsAPI / NewsTicker / `NEWS_API_KEY` | Done in app (docs/fixtures may still mention orphans) |
+| 3 | `fast-xml-parser`, fuzzy dedup, tiered cache, Happening Now, freshness | Done |
+
+Treat §§7–13 of this document as **historical implementation notes**, not an open backlog.
+
+### Product decision (Hard C)
+
+`/news` is a **hybrid**:
+
+1. **Hazard console as the spine** — USGS / NWS / NHC / SPC primary-source hazards, optimized for “is this real and current.”
+2. **Earth & Space magazine as the reading layer** — NASA, Carbon Brief, Yale, ScienceDaily, etc., so quiet days still have a reason to visit.
+
+Nobody needs another generic science-magazine aggregator. The differentiator is fast primary-source hazards with honest presentation.
+
+### Image honesty (governs the whole page)
+
+| Item type | Imagery rule |
+|---|---|
+| Earthquakes | ShakeMap / event product, or **imageless data-forward card** (magnitude, location, depth). Never place-specific historical stock (e.g. 1906 San Francisco). |
+| Volcanoes | Photo only when it is **of that named peak**. No hash pool of unrelated eruptions. |
+| Severe / tropical | Live GOES / SPC / NHC products (provenance-bound). |
+| Science / climate / space (editorial) | Illustrative stock / OG allowed; **must show visible credit** when stock is used. |
+
+**Never** an unlabeled historical catastrophe photo on a live hazard card.
+
+Implementation track: PR `fix/news-hazard-image-honesty` (quake/volcano honesty + data cards). Editorial credit UI ships after that lands.
+
+### Feed-health detection (closes G3 for real)
+
+v1.0 left `scripts/check-news-feeds.ts` as a **manual** gate (§14). That repeated the original failure mode: NWS can go dark and nobody notices until a human runs the script.
+
+**Required follow-through:** a scheduled GitHub Actions workflow runs `npx tsx scripts/check-news-feeds.ts` weekly (and on `workflow_dispatch`). Failure is allowed to fail the job so maintainers get notified; flaky upstream should be investigated, not silenced forever.
+
+### Open follow-ups (post-amendment)
+
+1. Ship hazard image honesty (no SF-1906 / wrong-peak stand-ins).
+2. Weekly feed-health workflow (this amendment).
+3. Visible stock image credits on editorial cards.
+4. Soften `stats.errors` / `NewsFeedBanner` so swallowed per-feed `[]` failures still surface.
+5. Archive or trim stale body sections of this PRD once honesty + credits land; keep this amendment as the living north star.
 
 ---
 

--- a/planning/prds/README.md
+++ b/planning/prds/README.md
@@ -8,7 +8,7 @@ Canonical location for **long-form product specs** used by humans and AI agents.
 |----------|---------|
 | [PRD-radar-v2.md](./PRD-radar-v2.md) | Radar v2 — RainViewer-only tiles + RainViewer-style UX, bottom player dock, Severe preset, new `components/radar-v2/` (v2.0 drops Iowa/MRMS/GeoMet) |
 | [PRD-condition-alerts.md](./PRD-condition-alerts.md) | Location-scoped condition alerts — in-app alert center for stargazing windows at saved locations, daily Vercel cron evaluation, schema + RLS design |
-| [PRD-news-overhaul.md](./PRD-news-overhaul.md) | News section overhaul — fix dead feeds, remove orphaned subsystem, tiered caching + feed-health monitoring |
+| [PRD-news-overhaul.md](./PRD-news-overhaul.md) | News — Phases 1–3 shipped; living amendment is Hard C hybrid + image honesty + weekly feed-health. Body below the amendment is historical. |
 
 Shipped PRDs are removed once the work lands; recover any from **git history** if needed. Recently completed and removed: open-meteo migration, Stargazer, newsletter redesign.
 

--- a/scripts/check-news-feeds.ts
+++ b/scripts/check-news-feeds.ts
@@ -1,12 +1,16 @@
 /**
- * News feed health-check (PRD §14 manual gate for the news-overhaul work).
+ * News feed health-check for the /news aggregator.
  *
  * Imports the live FEED_SOURCES list, fetches every ENABLED feed with the same
  * User-Agent the aggregator uses, follows redirects, and prints `status id url`.
- * Exits non-zero if any enabled feed returns a non-2xx status so it can gate a
- * commit. NOT wired into CI (external network); run manually:
+ * Exits non-zero if any enabled feed returns a non-2xx status (or a body that
+ * does not match the declared format).
  *
+ * Run manually:
  *   npx tsx scripts/check-news-feeds.ts
+ *
+ * Also runs on a weekly schedule via `.github/workflows/news-feed-health.yml`
+ * (and workflow_dispatch) so feed outages do not depend on a human remembering.
  */
 
 import { FEED_SOURCES, type FeedSource } from '../lib/services/rss/feedSources'


### PR DESCRIPTION
## Summary

- **PRD amendment:** Documents product identity **Hard C** (hazard-spine + magazine hybrid), adds the image-honesty table, and records that Phases 1–3 have shipped in `planning/prds/PRD-news-overhaul.md` (index updated in `planning/prds/README.md`).
- **Weekly feed health:** Adds `.github/workflows/news-feed-health.yml` to run `scripts/check-news-feeds.ts` on a schedule so silent RSS/feed outages surface without a manual run (script tweaks included for CI use).
- **Credits UI:** Deferred until after #507 merges to avoid conflicting with stock-images work.

## Test plan

- [ ] After merge, run the new workflow via **workflow_dispatch** on `news-feed-health.yml` and confirm it completes (or fails loudly on broken feeds).
- [ ] Skim the PRD amendment for Hard C identity, image-honesty rules, and shipped-phase notes.


Made with [Cursor](https://cursor.com)